### PR TITLE
Update the buffalo version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a multi-stage Dockerfile and requires >= Docker 17.05
 # https://docs.docker.com/engine/userguide/eng-image/multistage-build/
-FROM gobuffalo/buffalo:development as builder
+FROM gobuffalo/buffalo:v0.11.0 as builder
 
 RUN mkdir -p $GOPATH/src/github.com/gomods/athens
 WORKDIR $GOPATH/src/github.com/gomods/athens


### PR DESCRIPTION
I don't recall if buffalo:development is the image to use for developing buffalo apps, or if it's a tracking tag for the dev branch in buffalo.

Anyway, if the `v0.11.0` tag can be used for developing buffalo, we should definitely use it because it's immutable