### PR TITLE
Removing the All() function from storage listers

### DIFF
--- a/pkg/storage/lister.go
+++ b/pkg/storage/lister.go
@@ -2,7 +2,7 @@ package storage
 
 // Lister is the interface that lists versions of a specific baseURL & module
 type Lister interface {
-	// must return NotFoundErr if baseURL / module isn't found
+	// List gets all the versions for the given baseURL & module.
+	// It returns NotFoundErr if baseURL/module isn't found
 	List(baseURL, module string) ([]string, error)
-	All() (map[string][]*RevInfo, error)
 }

--- a/pkg/storage/memory/lister.go
+++ b/pkg/storage/memory/lister.go
@@ -20,15 +20,3 @@ func (l *Lister) List(basePath, module string) ([]string, error) {
 	}
 	return ret, nil
 }
-
-func (l *Lister) All() (map[string][]*storage.RevInfo, error) {
-	ret := map[string][]*storage.RevInfo{}
-	entries.RLock()
-	defer entries.RUnlock()
-	for name, versions := range entries.versions {
-		for _, version := range versions {
-			ret[name] = append(ret[name], &version.RevInfo)
-		}
-	}
-	return ret, nil
-}


### PR DESCRIPTION
I used this function for early debugging of the memory storage driver. Now that I’m writing tests for it (see
https://github.com/gomods/athens/pull/21), it is no longer valuable to have it. Also, as the proxy is used in the real world, it’s no longer going to be scalable to use this function.