### PR TITLE
Using the CDN getter in the GoGet middleware

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -53,6 +53,8 @@ func App() *buffalo.App {
 		panic(err)
 	}
 
+	cdnGetter := newCDNGetter()
+
 	if app == nil {
 		app = buffalo.New(buffalo.Options{
 			Env: ENV,
@@ -89,7 +91,7 @@ func App() *buffalo.App {
 		app.Use(T.Middleware())
 
 		// serve go-get requests
-		app.Use(GoGet())
+		app.Use(GoGet(cdnGetter))
 		app.GET("/", homeHandler)
 
 		app.GET("/{base_url:.+}/{module}/@v/list", listHandler(storageReader))

--- a/actions/cdn.go
+++ b/actions/cdn.go
@@ -1,0 +1,10 @@
+package actions
+
+import (
+	"github.com/gomods/athens/pkg/cdn"
+	"github.com/gomods/athens/pkg/cdn/fake"
+)
+
+func newCDNGetter() cdn.Getter {
+	return &fake.Getter{URL: "https://mycdn.com"}
+}

--- a/actions/goget.go
+++ b/actions/goget.go
@@ -2,16 +2,20 @@ package actions
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/gobuffalo/buffalo"
+	"github.com/gomods/athens/pkg/cdn"
 )
 
-func GoGet() buffalo.MiddlewareFunc {
+// GoGet is middleware that checks for the 'go-get=1' query string. If it exists,
+// uses getter to determine the redirect location
+func GoGet(getter cdn.Getter) buffalo.MiddlewareFunc {
 	return func(next buffalo.Handler) buffalo.Handler {
 		return func(c buffalo.Context) error {
 			if strings.Contains(c.Request().URL.Query().Get("go-get"), "1") {
-				return goGetMeta(c)
+				return goGetMeta(c, getter)
 			}
 			return next(c)
 		}
@@ -19,12 +23,20 @@ func GoGet() buffalo.MiddlewareFunc {
 }
 
 // stubbed for now, look up package stuff
-func goGetMeta(c buffalo.Context) error {
+func goGetMeta(c buffalo.Context, getter cdn.Getter) error {
 	sp, err := getStandardParams(c)
 	if err != nil {
 		return err
 	}
-	meta := fmt.Sprintf("<!DOCTYPE html><meta name='go-import' content='%s/%s mod https://gomods.io/%s/%s", sp.baseURL, sp.module, sp.baseURL, sp.module)
-	_, err = c.Response().Write([]byte(meta))
-	return err
+	loc, err := getter.Get(sp.baseURL, sp.module)
+	if err != nil {
+		return c.Error(
+			http.StatusNotFound,
+			fmt.Errorf("%s/%s does not exist", sp.baseURL, sp.module),
+		)
+	}
+	c.Set("redirectLoc", loc)
+	c.Set("baseURL", sp.baseURL)
+	c.Set("module", sp.module)
+	return c.Render(http.StatusOK, r.HTML(goget.html))
 }

--- a/actions/goget.go
+++ b/actions/goget.go
@@ -38,5 +38,5 @@ func goGetMeta(c buffalo.Context, getter cdn.Getter) error {
 	c.Set("redirectLoc", loc)
 	c.Set("baseURL", sp.baseURL)
 	c.Set("module", sp.module)
-	return c.Render(http.StatusOK, r.HTML(goget.html))
+	return c.Render(http.StatusOK, r.HTML("goget.html"))
 }

--- a/pkg/cdn/fake/getter.go
+++ b/pkg/cdn/fake/getter.go
@@ -1,0 +1,11 @@
+package fake
+
+// Getter is a (./pkg/cdn).Getter implementation that always returns URL
+type Getter struct {
+	URL string
+}
+
+// Get is the cdn.Getter implementation that always returns g.URL, nil
+func (g *Getter) Get(baseURL, module string) (string, error) {
+	return g.URL, nil
+}

--- a/pkg/cdn/getter.go
+++ b/pkg/cdn/getter.go
@@ -1,12 +1,16 @@
 package cdn
 
-// Getter gets the details about a given baseURL/module at vsn and returns
-// the base URL of the module metadata & content:
+// Getter gets the details about a given baseURL & module and returns the base
+// URL of the module metadata and content. For example, if
+// gomods.io/my/module is requested by the 'vgo get' command, this might return
+// 'https://mycdn.com/gomods.io/my/module'
 //
-// - {baseURL}/{module}/@v/list
-// - {baseURL}/{module}/@v/{version}.info
-// - {baseURL}/{module}/@v/{version}.mod
-// - {baseURL}/{module}/@v/{version}.zip
+// Then, the following URLs would be available:
+//
+// - https://mycdn.com/gomods.io/my/module/@v/list
+// - https://mycdn.com/gomods.io/my/module/@v/{version}.info
+// - https://mycdn.com/gomods.io/my/module/@v/{version}.mod
+// - https://mycdn.com/gomods.io/my/module/@v/{version}.zip
 type Getter interface {
-	Get(baseURL, module, vsn string) (string, error)
+	Get(baseURL, module string) (string, error)
 }

--- a/templates/goget.html
+++ b/templates/goget.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<meta name='go-import' content='<%= baseURL %>/<%= module %> mod <%= redirectLoc %>'>


### PR DESCRIPTION
This PR:

- Creates a fake CDN Getter implementation
    - For use in tests and stubs
- Passes the CDN getter along into the GoGet middleware
    - Using the fake CDN Getter implementation for now
- Uses the getter to determine whether a `baseURL/module` is available in the CDN
- Moves the `<meta ...>` tag into a template and renders the template

Fixes https://github.com/gomods/athens/issues/44

Also note that #44 prescribes that we make the middleware configurable, but the CDN getter effectively does that for us, since we can store any base URL in the registry DB. That will allow us to support as many domains as we like (gomods.io, gopackages.io, myradmoduledb.io, ...)