### PR TITLE
Remove the base URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+build:
+	go build .
+
+run: build
+	./athens
+	
 cli: 
 	go build -o athens ./cmd/cli
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 build:
-	go build .
+	buffalo build
 
 run: build
 	./athens
 	
-cli: 
+cli:
 	go build -o athens ./cmd/cli
 
 docs:

--- a/actions/app.go
+++ b/actions/app.go
@@ -79,6 +79,8 @@ func App() *buffalo.App {
 		}
 		app.Use(T.Middleware())
 
+		app.GET("/", homeHandler)
+
 		if MODE == "proxy" {
 			log.Printf("starting athens in proxy mode")
 			if err := addProxyRoutes(app); err != nil {

--- a/actions/app_proxy.go
+++ b/actions/app_proxy.go
@@ -11,11 +11,11 @@ func addProxyRoutes(app *buffalo.App) error {
 	}
 
 	app.GET("/", proxyHomeHandler)
-	app.GET("/{base_url:.+}/{module}/@v/list", listHandler(storage))
-	app.GET("/{base_url:.+}/{module}/@v/{version}.info", versionInfoHandler(storage))
-	app.GET("/{base_url:.+}/{module}/@v/{version}.mod", versionModuleHandler(storage))
-	app.GET("/{base_url:.+}/{module}/@v/{version}.zip", versionZipHandler(storage))
-	app.POST("/admin/upload/{base_url:[a-zA-Z./]+}/{module}/{version}", uploadHandler(storage))
-	app.POST("/admin/fetch/{base_url:[a-zA-Z./]+}/{owner}/{repo}/{ref}/{version}", fetchHandler(storage))
+	app.GET("/{module:.+}/@v/list", listHandler(storage))
+	app.GET("/{module:.+}/@v/{version}.info", versionInfoHandler(storage))
+	app.GET("/{module:.+}/@v/{version}.mod", versionModuleHandler(storage))
+	app.GET("/{module:.+}/@v/{version}.zip", versionZipHandler(storage))
+	app.POST("/admin/upload/{module:[a-zA-Z./]+}/{version}", uploadHandler(storage))
+	app.POST("/admin/fetch/{module:[a-zA-Z./]+}/{owner}/{repo}/{ref}/{version}", fetchHandler(storage))
 	return nil
 }

--- a/actions/app_registry.go
+++ b/actions/app_registry.go
@@ -12,13 +12,13 @@ func addRegistryRoutes(app *buffalo.App) error {
 	if err := mgoStore.Connect(); err != nil {
 		return err
 	}
-
 	// serve go-get requests
 	app.Use(GoGet(cdnGetter))
 	auth := app.Group("/auth")
 	auth.GET("/{provider}", buffalo.WrapHandlerFunc(gothic.BeginAuthHandler))
 	auth.GET("/{provider}/callback", authCallback(mgoStore))
-	//	app.GET("/{base_url:.+}/{module}", homeHandler)
+
 	app.GET("/", homeHandler)
+	//	app.GET("/{module:.+}", homeHandler)
 	return nil
 }

--- a/actions/fetch.go
+++ b/actions/fetch.go
@@ -15,10 +15,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// /admin/fetch/{base_url:[a-zA-Z./]+}/{owner}/{repo}/{ref}/{version}
+// /admin/fetch/{module:[a-zA-Z./]+}/{owner}/{repo}/{ref}/{version}
 func fetchHandler(store storage.Saver) func(c buffalo.Context) error {
 	return func(c buffalo.Context) error {
-		baseURL := c.Param("base_url")
 		owner := c.Param("owner")
 		repo := c.Param("repo")
 		ref := c.Param("ref")
@@ -47,12 +46,12 @@ func fetchHandler(store storage.Saver) func(c buffalo.Context) error {
 			return fmt.Errorf("couldn't parse go.mod file (%s)", err)
 		}
 
-		zipBytes, err := module.MakeZip(path, baseURL, moduleName, version)
+		zipBytes, err := module.MakeZip(path, moduleName, version)
 		if err != nil {
 			return fmt.Errorf("couldn't make zip (%s)", err)
 		}
 
-		saveErr := store.Save(baseURL, moduleName, version, modBytes, zipBytes)
+		saveErr := store.Save(moduleName, version, modBytes, zipBytes)
 		if storage.IsVersionAlreadyExistsErr(saveErr) {
 			return c.Error(http.StatusConflict, saveErr)
 		} else if err != nil {

--- a/actions/goget.go
+++ b/actions/goget.go
@@ -23,19 +23,15 @@ func GoGet(getter cdn.Getter) buffalo.MiddlewareFunc {
 }
 
 func goGetMeta(c buffalo.Context, getter cdn.Getter) error {
-	sp, err := getStandardParams(c)
+	params, err := getAllPathParams(c)
 	if err != nil {
 		return err
 	}
-	loc, err := getter.Get(sp.baseURL, sp.module)
+	loc, err := getter.Get(params.module, params.version)
 	if err != nil {
-		return c.Error(
-			http.StatusNotFound,
-			fmt.Errorf("%s/%s does not exist", sp.baseURL, sp.module),
-		)
+		return c.Error(http.StatusNotFound, fmt.Errorf("module %s does not exist", params.module))
 	}
 	c.Set("redirectLoc", loc)
-	c.Set("baseURL", sp.baseURL)
-	c.Set("module", sp.module)
+	c.Set("module", params.module)
 	return c.Render(http.StatusOK, proxy.HTML("goget.html"))
 }

--- a/actions/list.go
+++ b/actions/list.go
@@ -11,11 +11,11 @@ import (
 
 func listHandler(lister storage.Lister) func(c buffalo.Context) error {
 	return func(c buffalo.Context) error {
-		params, err := getStandardParams(c)
+		mod, err := getModule(c)
 		if err != nil {
 			return err
 		}
-		versions, err := lister.List(params.baseURL, params.module)
+		versions, err := lister.List(mod)
 		if storage.IsNotFoundError(err) {
 			return c.Error(http.StatusNotFound, err)
 		} else if err != nil {

--- a/actions/path_params.go
+++ b/actions/path_params.go
@@ -6,30 +6,21 @@ import (
 	"github.com/gobuffalo/buffalo"
 )
 
-type standardPathParams struct {
-	baseURL string
-	module  string
-}
-
-func getStandardParams(c buffalo.Context) (*standardPathParams, error) {
-	baseURL := c.Param("base_url")
+func getModule(c buffalo.Context) (string, error) {
 	module := c.Param("module")
-	if baseURL == "" {
-		return nil, fmt.Errorf("baseURL missing")
-	}
 	if module == "" {
-		return nil, fmt.Errorf("module missing")
+		return "", fmt.Errorf("module missing")
 	}
-	return &standardPathParams{baseURL: baseURL, module: module}, nil
+	return module, nil
 }
 
 type allPathParams struct {
-	*standardPathParams
+	module  string
 	version string
 }
 
 func getAllPathParams(c buffalo.Context) (*allPathParams, error) {
-	stdParams, err := getStandardParams(c)
+	mod, err := getModule(c)
 	if err != nil {
 		return nil, err
 	}
@@ -37,5 +28,5 @@ func getAllPathParams(c buffalo.Context) (*allPathParams, error) {
 	if version == "" {
 		return nil, fmt.Errorf("version not found")
 	}
-	return &allPathParams{standardPathParams: stdParams, version: version}, nil
+	return &allPathParams{module: mod, version: version}, nil
 }

--- a/actions/upload.go
+++ b/actions/upload.go
@@ -11,7 +11,7 @@ import (
 
 func uploadHandler(store storage.Saver) func(c buffalo.Context) error {
 	return func(c buffalo.Context) error {
-		stdParams, err := getStandardParams(c)
+		mod, err := getModule(c)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -20,7 +20,7 @@ func uploadHandler(store storage.Saver) func(c buffalo.Context) error {
 		if c.Bind(payload); err != nil {
 			return errors.WithStack(err)
 		}
-		saveErr := store.Save(stdParams.baseURL, stdParams.module, version, payload.Module, payload.Zip)
+		saveErr := store.Save(mod, version, payload.Module, payload.Zip)
 		if storage.IsVersionAlreadyExistsErr(saveErr) {
 			return c.Error(http.StatusConflict, saveErr)
 		} else if err != nil {

--- a/actions/version_info.go
+++ b/actions/version_info.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gobuffalo/buffalo"
@@ -13,8 +14,10 @@ func versionInfoHandler(getter storage.Getter) func(c buffalo.Context) error {
 		if err != nil {
 			return err
 		}
-		version, err := getter.Get(params.baseURL, params.module, params.version)
-		if err != nil {
+		version, err := getter.Get(params.module, params.version)
+		if storage.IsNotFoundError(err) {
+			return c.Error(http.StatusNotFound, fmt.Errorf("%s@%s not found", params.module, params.version))
+		} else if err != nil {
 			return err
 		}
 		return c.Render(http.StatusOK, proxy.JSON(version.RevInfo))

--- a/actions/version_module.go
+++ b/actions/version_module.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gobuffalo/buffalo"
@@ -13,10 +14,14 @@ func versionModuleHandler(getter storage.Getter) func(c buffalo.Context) error {
 		if err != nil {
 			return err
 		}
-		version, err := getter.Get(params.baseURL, params.module, params.version)
-		if err != nil {
+
+		version, err := getter.Get(params.module, params.version)
+		if storage.IsNotFoundError(err) {
+			return c.Error(http.StatusNotFound, fmt.Errorf("%s@%s not found", params.module, params.version))
+		} else if err != nil {
 			return err
 		}
+
 		c.Response().WriteHeader(http.StatusOK)
 		_, err = c.Response().Write(version.Mod)
 		return err

--- a/actions/version_zip.go
+++ b/actions/version_zip.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 
@@ -14,10 +15,13 @@ func versionZipHandler(getter storage.Getter) func(c buffalo.Context) error {
 		if err != nil {
 			return err
 		}
-		version, err := getter.Get(params.baseURL, params.module, params.version)
-		if err != nil {
+		version, err := getter.Get(params.module, params.version)
+		if storage.IsNotFoundError(err) {
+			return c.Error(http.StatusNotFound, fmt.Errorf("%s@%s not found", params.module, params.version))
+		} else if err != nil {
 			return err
 		}
+
 		defer version.Zip.Close()
 
 		c.Response().WriteHeader(http.StatusOK)

--- a/cmd/cli/upload.go
+++ b/cmd/cli/upload.go
@@ -16,7 +16,6 @@ import (
 )
 
 type uploadCmd struct {
-	baseURL    string
 	moduleName string
 	version    string
 }
@@ -29,8 +28,6 @@ func newUploadCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  upload(uploadCmd),
 	}
-	cmd.Flags().StringVarP(&uploadCmd.baseURL, "base-url", "b", "", "The base URL of the module (required)")
-	cmd.MarkFlagRequired("base-url")
 	cmd.Flags().StringVarP(&uploadCmd.version, "version", "v", "v0.0.1", "The version of this module")
 	return cmd
 }
@@ -56,14 +53,13 @@ func upload(c *uploadCmd) func(*cobra.Command, []string) error {
 			return fmt.Errorf("couldn't parse go.mod file (%s)", err)
 		}
 
-		zipBytes, err := module.MakeZip(fullDirectory, c.baseURL, c.moduleName, c.version)
+		zipBytes, err := module.MakeZip(fullDirectory, c.moduleName, c.version)
 		if err != nil {
 			return fmt.Errorf("couldn't make zip (%s)", err)
 		}
 
 		url := fmt.Sprintf(
-			"http://localhost:3000/admin/upload/%s/%s/%s",
-			c.baseURL,
+			"http://localhost:3000/admin/upload/%s/%s",
 			c.moduleName,
 			c.version,
 		)

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -23,7 +23,7 @@ type file struct {
 
 // MakeZip takes dir and module info and generates vgo valid zip
 // the dir must end with a "/"
-func MakeZip(dir, basePath, module, version string) ([]byte, error) {
+func MakeZip(dir, module, version string) ([]byte, error) {
 	ignoreParser := getIgnoreParser(dir)
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
@@ -33,7 +33,7 @@ func MakeZip(dir, basePath, module, version string) ([]byte, error) {
 			return err
 		}
 
-		fileName := getFileName(path, dir, basePath, module, version)
+		fileName := getFileName(path, dir, module, version)
 
 		if ignoreParser.MatchesPath(fileName) {
 			return nil
@@ -68,13 +68,12 @@ func getIgnoreParser(dir string) ignore.IgnoreParser {
 }
 
 // getFileName composes filename for zip to match standard specified as
-// mod.path@mod.version/{filename}
-// where mod.path equals {basePath}/{moduleName}
-func getFileName(path, dir, basePath, module, version string) string {
+// module@version/{filename}
+func getFileName(path, dir, module, version string) string {
 	filename := strings.TrimPrefix(path, dir)
 	filename = strings.TrimLeftFunc(filename, func(r rune) bool { return r == os.PathSeparator })
 
 	moduleID := fmt.Sprintf("%s@%s", module, version)
 
-	return filepath.Join(basePath, moduleID, filename)
+	return filepath.Join(moduleID, filename)
 }

--- a/pkg/storage/fs/all_test.go
+++ b/pkg/storage/fs/all_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	baseURL = "testbaseurl"
 	module  = "testmodule"
 	version = "v1.0.0"
 )

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -12,12 +12,12 @@ type storageImpl struct {
 	filesystem afero.Fs
 }
 
-func (s *storageImpl) moduleLocation(baseURL, module string) string {
-	return filepath.Join(s.rootDir, baseURL, module)
+func (s *storageImpl) moduleLocation(module string) string {
+	return filepath.Join(s.rootDir, module)
 }
 
-func (s *storageImpl) versionLocation(baseURL, module, version string) string {
-	return filepath.Join(s.moduleLocation(baseURL, module), version)
+func (s *storageImpl) versionLocation(module, version string) string {
+	return filepath.Join(s.moduleLocation(module), version)
 
 }
 

--- a/pkg/storage/fs/fs_test.go
+++ b/pkg/storage/fs/fs_test.go
@@ -8,21 +8,21 @@ import (
 func (d *FsTests) TestLocationFuncs() {
 	r := d.Require()
 	storage := d.storage.(*storageImpl)
-	moduleLoc := storage.moduleLocation(baseURL, module)
-	r.Equal(filepath.Join(d.rootDir, baseURL, module), moduleLoc)
-	versionedLoc := storage.versionLocation(baseURL, module, version)
-	r.Equal(filepath.Join(d.rootDir, baseURL, module, version), versionedLoc)
+	moduleLoc := storage.moduleLocation(module)
+	r.Equal(filepath.Join(d.rootDir, module), moduleLoc)
+	versionedLoc := storage.versionLocation(module, version)
+	r.Equal(filepath.Join(d.rootDir, module, version), versionedLoc)
 }
 
 func (d *FsTests) TestGetSaveListRoundTrip() {
 	r := d.Require()
-	r.NoError(d.storage.Save(baseURL, module, version, mod, zip))
-	listedVersions, err := d.storage.List(baseURL, module)
+	r.NoError(d.storage.Save(module, version, mod, zip))
+	listedVersions, err := d.storage.List(module)
 	r.NoError(err)
 	r.Equal(1, len(listedVersions))
 	retVersion := listedVersions[0]
 	r.Equal(version, retVersion)
-	gotten, err := d.storage.Get(baseURL, module, version)
+	gotten, err := d.storage.Get(module, version)
 	r.NoError(err)
 	defer gotten.Zip.Close()
 	r.Equal(version, gotten.RevInfo.Version)

--- a/pkg/storage/fs/getter.go
+++ b/pkg/storage/fs/getter.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gomods/athens/pkg/storage"
 )
 
-func (v *storageImpl) Get(baseURL, module, version string) (*storage.Version, error) {
-	versionedPath := v.versionLocation(baseURL, module, version)
+func (v *storageImpl) Get(module, version string) (*storage.Version, error) {
+	versionedPath := v.versionLocation(module, version)
 	mod, err := afero.ReadFile(v.filesystem, filepath.Join(versionedPath, "go.mod"))
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/lister.go
+++ b/pkg/storage/fs/lister.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (l *storageImpl) List(basePath, module string) ([]string, error) {
-	loc := l.moduleLocation(basePath, module)
+func (l *storageImpl) List(module string) ([]string, error) {
+	loc := l.moduleLocation(module)
 	fileInfos, err := afero.ReadDir(l.filesystem, loc)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/lister_test.go
+++ b/pkg/storage/fs/lister_test.go
@@ -4,9 +4,9 @@ func (d *FsTests) TestList() {
 	r := d.Require()
 	versions := []string{"v1.0.0", "v1.1.0", "v1.2.0"}
 	for _, version := range versions {
-		r.NoError(d.storage.Save(baseURL, module, version, mod, zip))
+		r.NoError(d.storage.Save(module, version, mod, zip))
 	}
-	retVersions, err := d.storage.List(baseURL, module)
+	retVersions, err := d.storage.List(module)
 	r.NoError(err)
 	r.Equal(versions, retVersions)
 }

--- a/pkg/storage/fs/saver.go
+++ b/pkg/storage/fs/saver.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (s *storageImpl) Save(baseURL, module, vsn string, mod, zip []byte) error {
-	dir := s.versionLocation(baseURL, module, vsn)
+func (s *storageImpl) Save(module, vsn string, mod, zip []byte) error {
+	dir := s.versionLocation(module, vsn)
 	// TODO: 777 is not the best filemode, use something better
 
 	// make the versioned directory to hold the go.mod and the zipfile

--- a/pkg/storage/getter.go
+++ b/pkg/storage/getter.go
@@ -1,6 +1,7 @@
 package storage
 
+// Getter gets module metadata and its source from underlying storage
 type Getter interface {
-	// must return ErrNotFound if the coordinates are not found
-	Get(baseURL, module, vsn string) (*Version, error)
+	// Get must return ErrNotFound if the coordinates are not found
+	Get(module, vsn string) (*Version, error)
 }

--- a/pkg/storage/lister.go
+++ b/pkg/storage/lister.go
@@ -3,6 +3,6 @@ package storage
 // Lister is the interface that lists versions of a specific baseURL & module
 type Lister interface {
 	// List gets all the versions for the given baseURL & module.
-	// It returns ErrNotFound if baseURL/module isn't found
-	List(baseURL, module string) ([]string, error)
+	// It returns ErrNotFound if the module isn't found
+	List(module string) ([]string, error)
 }

--- a/pkg/storage/module.go
+++ b/pkg/storage/module.go
@@ -1,7 +1,6 @@
 package storage
 
 type Module struct {
-	BaseURL string `bson:"base_url"`
 	Module  string `bson:"module"`
 	Version string `bson:"version"`
 	Mod     []byte `bson:"mod"`

--- a/pkg/storage/mongo/all_test.go
+++ b/pkg/storage/mongo/all_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	baseURL = "testbaseurl"
 	module  = "testmodule"
 	version = "v1.0.0"
 )

--- a/pkg/storage/mongo/getter.go
+++ b/pkg/storage/mongo/getter.go
@@ -10,13 +10,13 @@ import (
 	"github.com/gomods/athens/pkg/storage"
 )
 
-func (s *MongoModuleStore) Get(baseURL, module, vsn string) (*storage.Version, error) {
+func (s *MongoModuleStore) Get(module, vsn string) (*storage.Version, error) {
 	c := s.s.DB(s.d).C(s.c)
 	result := &storage.Module{}
-	err := c.Find(bson.M{"base_url": baseURL, "module": module, "version": vsn}).One(result)
+	err := c.Find(bson.M{"module": module, "version": vsn}).One(result)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			err = storage.ErrVersionNotFound{BasePath: baseURL, Module: module, Version: vsn}
+			err = storage.ErrVersionNotFound{Module: module, Version: vsn}
 		}
 		return nil, err
 	}

--- a/pkg/storage/mongo/lister.go
+++ b/pkg/storage/mongo/lister.go
@@ -7,13 +7,13 @@ import (
 	"github.com/gomods/athens/pkg/storage"
 )
 
-func (s *MongoModuleStore) List(baseURL, module string) ([]string, error) {
+func (s *MongoModuleStore) List(module string) ([]string, error) {
 	c := s.s.DB(s.d).C(s.c)
 	result := make([]storage.Module, 0)
-	err := c.Find(bson.M{"base_url": baseURL, "module": module}).All(&result)
+	err := c.Find(bson.M{"module": module}).All(&result)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			err = storage.ErrNotFound{Module: module, BasePath: baseURL}
+			err = storage.ErrNotFound{Module: module}
 		}
 		return nil, err
 	}

--- a/pkg/storage/mongo/lister_test.go
+++ b/pkg/storage/mongo/lister_test.go
@@ -4,9 +4,9 @@ func (m *MongoTests) TestList() {
 	r := m.Require()
 	versions := []string{"v1.0.0", "v1.1.0", "v1.2.0"}
 	for _, version := range versions {
-		m.storage.Save(baseURL, module, version, mod, zip)
+		m.storage.Save(module, version, mod, zip)
 	}
-	retVersions, err := m.storage.List(baseURL, module)
+	retVersions, err := m.storage.List(module)
 	r.NoError(err)
 	r.Equal(versions, retVersions)
 }

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -6,13 +6,13 @@ import (
 
 func (m *MongoTests) TestGetSaveListRoundTrip() {
 	r := m.Require()
-	m.storage.Save(baseURL, module, version, mod, zip)
-	listedVersions, err := m.storage.List(baseURL, module)
+	m.storage.Save(module, version, mod, zip)
+	listedVersions, err := m.storage.List(module)
 	r.NoError(err)
 	r.Equal(1, len(listedVersions))
 	retVersion := listedVersions[0]
 	r.Equal(version, retVersion)
-	gotten, err := m.storage.Get(baseURL, module, version)
+	gotten, err := m.storage.Get(module, version)
 	r.NoError(err)
 	defer gotten.Zip.Close()
 	r.Equal(version, gotten.RevInfo.Version)

--- a/pkg/storage/mongo/saver.go
+++ b/pkg/storage/mongo/saver.go
@@ -2,9 +2,8 @@ package mongo
 
 import "github.com/gomods/athens/pkg/storage"
 
-func (s *MongoModuleStore) Save(baseURL, module, version string, mod, zip []byte) error {
+func (s *MongoModuleStore) Save(module, version string, mod, zip []byte) error {
 	m := &storage.Module{
-		BaseURL: baseURL,
 		Module:  module,
 		Version: version,
 		Mod:     mod,

--- a/pkg/storage/not_found_err.go
+++ b/pkg/storage/not_found_err.go
@@ -4,40 +4,45 @@ import (
 	"fmt"
 )
 
+// ErrNotFound is an error implementation that indicates a module
+// doesn't exist
 type ErrNotFound struct {
-	BasePath string
-	Module   string
+	Module string
 }
 
 func (n ErrNotFound) Error() string {
-	return fmt.Sprintf("%s/%s not found", n.BasePath, n.Module)
+	return fmt.Sprintf("module %s not found", n.Module)
 }
 
+// ErrVersionNotFound is an error implementation that indicates a module
+// at a specific version doesn't exist
 type ErrVersionNotFound struct {
-	BasePath string
-	Module   string
-	Version  string
+	Module  string
+	Version string
 }
 
 func (e ErrVersionNotFound) Error() string {
-	return fmt.Sprintf("%s/%s@%s not found", e.BasePath, e.Module, e.Version)
+	return fmt.Sprintf("module %s@%s not found", e.Module, e.Version)
 }
 
+// IsNotFoundError returns true if err is an ErrNotFound
 func IsNotFoundError(err error) bool {
 	_, ok := err.(ErrNotFound)
 	return ok
 }
 
+// ErrVersionAlreadyExists is an error implementation that indicates that a
+// module@version already exists
 type ErrVersionAlreadyExists struct {
-	BasePath string
-	Module   string
-	Version  string
+	Module  string
+	Version string
 }
 
 func (e ErrVersionAlreadyExists) Error() string {
-	return fmt.Sprintf("%s/%s@%s", e.BasePath, e.Module, e.Version)
+	return fmt.Sprintf("%s@%s already exists", e.Module, e.Version)
 }
 
+// IsVersionAlreadyExistsErr returns true if err is an ErrVersionAlreadyExists
 func IsVersionAlreadyExistsErr(err error) bool {
 	_, ok := err.(ErrVersionAlreadyExists)
 	return ok

--- a/pkg/storage/saver.go
+++ b/pkg/storage/saver.go
@@ -1,5 +1,6 @@
 package storage
 
+// Saver saves module metadata and its source to underlying storage
 type Saver interface {
-	Save(baseURL, module, version string, mod, zip []byte) error
+	Save(module, version string, mod, zip []byte) error
 }

--- a/pkg/storage/storageconnector.go
+++ b/pkg/storage/storageconnector.go
@@ -19,12 +19,12 @@ func (n noOpConnectedStorage) Connect() error {
 	return nil
 }
 
-func (n noOpConnectedStorage) Get(baseURL, module, vsn string) (*Version, error) {
-	return n.s.Get(baseURL, module, vsn)
+func (n noOpConnectedStorage) Get(module, vsn string) (*Version, error) {
+	return n.s.Get(module, vsn)
 }
-func (n noOpConnectedStorage) List(baseURL, module string) ([]string, error) {
-	return n.s.List(baseURL, module)
+func (n noOpConnectedStorage) List(module string) ([]string, error) {
+	return n.s.List(module)
 }
-func (n noOpConnectedStorage) Save(baseURL, module, version string, mod, zip []byte) error {
-	return n.s.Save(baseURL, module, version, mod, zip)
+func (n noOpConnectedStorage) Save(module, version string, mod, zip []byte) error {
+	return n.s.Save(module, version, mod, zip)
 }

--- a/templates/goget.html
+++ b/templates/goget.html
@@ -1,2 +1,2 @@
 <!DOCTYPE html>
-<meta name='go-import' content='<%= baseURL %>/<%= module %> mod <%= redirectLoc %>'>
+<meta name='go-import' content='<%= module %> mod <%= redirectLoc %>'>


### PR DESCRIPTION
~**Note: wait for #64 to go in before merging this. It'll need a rebase before the merge**~ (#64 is in and this has been rebased)

I originally added a `baseURL` to our paths to follow exactly the download protocol in https://research.swtch.com/vgo-module. In reality, there's no need for it because modules are always referred to by their fully qualified names - like `swtch.com/testmod` - and their version.

- Code before this patch would parse `swtch.com` into baseURL and `testmod` into module, and then immediately concatenate them.
- This patch captures the entire `swtch.com/testmod` in one path parameter and then works with that as the module name in all further processing.

TODO:

- [x] Change the `build` target of the `Makefile` to run `buffalo build` instead of just `go build`