### PR TITLE
Fix assets manifest path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
       debug: false
     }),
     new ManifestPlugin({
-      fileName: "manifest.json"
+      fileName: "../manifest.json"
     })
   ],
   module: {


### PR DESCRIPTION
Buffalo tries to find `manifest.json` in assetBox path:
```
// github.com/gobuffalo/buffalo/render/template.assetPath
manifest, err := s.AssetsBox.MustString("manifest.json")

// actions/render.go
var assetsBox = packr.NewBox("../public")
```
