### PR TITLE
Adding an empty grift for doing pull synchronization for event logs

### DIFF
--- a/cmd/olympus/grifts/eventlog_sync.go
+++ b/cmd/olympus/grifts/eventlog_sync.go
@@ -7,7 +7,7 @@ import (
 var _ = grift.Namespace("eventlog-sync", func() {
 
 	grift.Desc("eventlog-sync", "Runs continuously to sync event logs from 1 or more other Olympus server")
-	grift.Add("eventlog-sunc", func(c *grift.Context) error {
+	grift.Add("eventlog-sync", func(c *grift.Context) error {
 		// TODO: add event log syncing here
 		return nil
 	})

--- a/cmd/olympus/grifts/eventlog_sync.go
+++ b/cmd/olympus/grifts/eventlog_sync.go
@@ -1,0 +1,15 @@
+package grifts
+
+import (
+	"github.com/markbates/grift/grift"
+)
+
+var _ = grift.Namespace("eventlog-sync", func() {
+
+	grift.Desc("eventlog-sync", "Runs continuously to sync event logs from 1 or more other Olympus server")
+	grift.Add("eventlog-sunc", func(c *grift.Context) error {
+		// TODO: add event log syncing here
+		return nil
+	})
+
+})


### PR DESCRIPTION
This is the first patch in a series that implements https://github.com/gomods/athens/issues/107. I am keeping PRs as small as possible