### PR TITLE
tidy up pointer registry mongo driver

### DIFF
--- a/pkg/eventlog/mongo/pointer_registry.go
+++ b/pkg/eventlog/mongo/pointer_registry.go
@@ -50,8 +50,7 @@ func (r *Registry) LookupPointer(deploymentID string) (string, error) {
 	var result eventlog.RegisteredEventlog
 
 	c := r.s.DB(r.d).C(r.c)
-	err := c.FindId(deploymentID).One(&result)
-	if err == mgo.ErrNotFound {
+	if err := c.FindId(deploymentID).One(&result); err == mgo.ErrNotFound {
 		return result.Pointer, eventlog.ErrDeploymentNotFound
 	}
 

--- a/pkg/eventlog/mongo/pointer_registry_test.go
+++ b/pkg/eventlog/mongo/pointer_registry_test.go
@@ -34,16 +34,16 @@ func (m *MongoRegistryTests) TestSetReadRoundTrip() {
 	r.NoError(err)
 	gotten, err := m.registry.LookupPointer("deployment1")
 	r.NoError(err)
-	r.Equal(gotten, "location1")
+	r.Equal("location1", gotten)
 
 	err = m.registry.SetPointer("deployment1", "location2")
 	r.NoError(err)
 	gotten, err = m.registry.LookupPointer("deployment1")
 	r.NoError(err)
-	r.Equal(gotten, "location2")
+	r.Equal("location2", gotten)
 
 	gotten, err = m.registry.LookupPointer("doesnt-exist")
-	r.Equal(err, eventlog.ErrDeploymentNotFound)
+	r.Equal(eventlog.ErrDeploymentNotFound, err)
 }
 
 func (m *MongoRegistryTests) TestNewRegistry() {
@@ -57,5 +57,5 @@ func (m *MongoRegistryTests) TestNewRegistry() {
 	r.NotNil(registry.c)
 	r.NotNil(registry.d)
 	r.NotNil(registry.s)
-	r.Equal(registry.url, url)
+	r.Equal(url, registry.url)
 }


### PR DESCRIPTION
use correct order for testify require.Equal
also make an error check more compact like the rest of the code base