### PR TITLE
Separate in-mem storage and test

### DIFF
--- a/cmd/proxy/actions/storage.go
+++ b/cmd/proxy/actions/storage.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/envy"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/gomods/athens/pkg/storage/fs"
+	"github.com/gomods/athens/pkg/storage/mem"
 	"github.com/gomods/athens/pkg/storage/minio"
 	"github.com/gomods/athens/pkg/storage/mongo"
 	"github.com/gomods/athens/pkg/storage/rdbms"
@@ -20,12 +21,7 @@ func getStorage() (storage.Backend, error) {
 
 	switch storageType {
 	case "memory":
-		memFs := afero.NewMemMapFs()
-		tmpDir, err := afero.TempDir(memFs, "inmem", "")
-		if err != nil {
-			return nil, fmt.Errorf("could not create temp dir for 'In Memory' storage (%s)", err)
-		}
-		return fs.NewStorage(tmpDir, memFs), nil
+		return mem.NewStorage()
 	case "mongo":
 		storageRoot, err = envy.MustGet("ATHENS_MONGO_STORAGE_URL")
 		if err != nil {

--- a/pkg/storage/fs/all_test.go
+++ b/pkg/storage/fs/all_test.go
@@ -34,7 +34,7 @@ type FsTests struct {
 }
 
 func (d *FsTests) SetupTest() {
-	memFs := afero.NewMemMapFs()
+	memFs := afero.NewOsFs()
 	r, err := afero.TempDir(memFs, "", "athens-fs-tests")
 	d.Require().NoError(err)
 	d.storage = NewStorage(r, memFs)

--- a/pkg/storage/mem/mem.go
+++ b/pkg/storage/mem/mem.go
@@ -1,0 +1,35 @@
+package mem
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/gomods/athens/pkg/storage"
+	"github.com/gomods/athens/pkg/storage/fs"
+	"github.com/spf13/afero"
+)
+
+var (
+	l          sync.Mutex
+	memStorage storage.BackendConnector
+)
+
+// NewStorage creates new in-memory storage using the afero.NewMemMapFs() in memory file system
+func NewStorage() (storage.BackendConnector, error) {
+	l.Lock()
+	defer l.Unlock()
+
+	if memStorage != nil {
+		return memStorage, nil
+	}
+
+	memFs := afero.NewMemMapFs()
+	tmpDir, err := afero.TempDir(memFs, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("could not create temp dir for 'In Memory' storage (%s)", err)
+	}
+
+	s := fs.NewStorage(tmpDir, memFs)
+	memStorage = storage.NoOpBackendConnector(s)
+	return memStorage, nil
+}

--- a/pkg/storage/mem/mem_test.go
+++ b/pkg/storage/mem/mem_test.go
@@ -1,0 +1,63 @@
+package mem
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	module  = "testmodule"
+	version = "v1.0.0"
+)
+
+var (
+	// TODO: put these values inside of the suite, and generate longer values.
+	// This should help catch edge cases, like https://github.com/gomods/athens/issues/38
+	//
+	// Also, consider doing something similar to what testing/quick does
+	// with the Generator interface (https://godoc.org/testing/quick#Generator).
+	// The rough, simplified idea would be to run a single test case multiple
+	// times over different (increasing) values.
+	mod  = []byte("123")
+	zip  = []byte("456")
+	info = []byte("789")
+)
+
+type MemTests struct {
+	suite.Suite
+}
+
+func TestMemStorage(t *testing.T) {
+	suite.Run(t, new(MemTests))
+}
+
+func (d *MemTests) TestGetSaveListRoundTrip() {
+	r := d.Require()
+	// create new in mem storage
+	storage, err := NewStorage()
+	d.Require().NoError(err)
+
+	// save and list modules
+	r.NoError(storage.Save(module, version, mod, zip, info))
+	listedVersions, err := storage.List(module)
+	r.NoError(err)
+	r.Equal(1, len(listedVersions))
+	retVersion := listedVersions[0]
+	r.Equal(version, retVersion)
+
+	// create new in-mem storage - we should be able to get the saved module
+	storage, err = NewStorage()
+	d.Require().NoError(err)
+
+	gotten, err := storage.Get(module, version)
+	r.NoError(err)
+	defer gotten.Zip.Close()
+	// TODO: test the time
+	r.Equal(gotten.Mod, mod)
+	zipContent, err := ioutil.ReadAll(gotten.Zip)
+	r.NoError(err)
+	r.Equal(zipContent, zip)
+	r.Equal(gotten.Info, info)
+}


### PR DESCRIPTION
Fixes #165 
* adds separate mem pkg which uses the fs implementation under the hood
It's possible to call NewStorage() multiple time and get the same storage instance which makes the behavior consistent with other storage drivers