### PR TITLE
adding a "dev" target to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,12 @@ test:
 
 olympus-docker:
 	docker build -t gopackages/olympus -f cmd/olympus/Dockerfile .
+
+dev:
+	# TODO: spin up all the services :)
+	# need to create an umbrella service in
+	# the docker compose file that declares all the
+	# deps
+	docker-compose -p athensdev up -d mysql
+	echo "sleeping for a bit to wait for the DB to come up"
+	sleep 5


### PR DESCRIPTION
This makes it easier to get started. You can type `make dev` on the cmdline and it executes the right docker-compose command to get all dependency services up