### PR TITLE
Olympus: remove potential PROXY_URL when running vgo get

### DIFF
--- a/pkg/repo/goget.go
+++ b/pkg/repo/goget.go
@@ -123,8 +123,7 @@ func getSources(fs afero.Fs, gopath, repoRoot, repoURI, version string) (string,
 	disableCgo := "CGO_ENABLED=0"
 
 	cmd := exec.Command("vgo", "get", fullURI)
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, gopathEnv, disableCgo)
+	cmd.Env = []string{gopathEnv, disableCgo}
 	cmd.Dir = repoRoot
 
 	packagePath := filepath.Join(gopath, "src", "mod", "cache", "download", repoURI, "@v")


### PR DESCRIPTION
If we set the PROXY_URL to point to Zeus, and zues misses a cache, it will delegate the module fetch to olympus which in turn uses `vgo get`. We have to make sure that vgo get doesn't hit the proxy again causing an infinite loop.