### PR TITLE
Zeus: check for status code in ModuleStore.Get

### DIFF
--- a/pkg/storage/olympus/getter.go
+++ b/pkg/storage/olympus/getter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/storage"
@@ -25,6 +26,9 @@ func (s *ModuleStore) Get(module, vsn string) (*storage.Version, error) {
 		return nil, err
 	}
 	defer modResp.Body.Close()
+	if modResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %v returned unexpected status: %v", modURI, modResp.StatusCode)
+	}
 
 	mod, err = ioutil.ReadAll(modResp.Body)
 	if err != nil {
@@ -38,6 +42,9 @@ func (s *ModuleStore) Get(module, vsn string) (*storage.Version, error) {
 		return nil, err
 	}
 	defer zipResp.Body.Close()
+	if zipResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %v returned unexpected status: %v", zipURI, zipResp.StatusCode)
+	}
 
 	zip, err = ioutil.ReadAll(zipResp.Body)
 	if err != nil {
@@ -51,6 +58,9 @@ func (s *ModuleStore) Get(module, vsn string) (*storage.Version, error) {
 		return nil, err
 	}
 	defer infoResp.Body.Close()
+	if infoResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %v returned unexpected status: %v", infoURI, infoResp.StatusCode)
+	}
 
 	info, err = ioutil.ReadAll(infoResp.Body)
 	if err != nil {


### PR DESCRIPTION
This makes sure we don't persist in the Zeus storage whatever Olympus gives us. 
