### PR TITLE
Olympus: default port to 3001

### DIFF
--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -46,9 +46,11 @@ var (
 func App() *buffalo.App {
 	if app == nil {
 		redisPort := env.OlympusRedisQueuePortWithDefault(":6379")
+		port := env.OlympusHTTPPort(":3001")
 
 		app = buffalo.New(buffalo.Options{
-			Env: ENV,
+			Addr: port,
+			Env:  ENV,
 			PreWares: []buffalo.PreWare{
 				cors.Default().Handler,
 			},

--- a/cmd/proxy/actions/cache_miss_reporter.go
+++ b/cmd/proxy/actions/cache_miss_reporter.go
@@ -43,6 +43,7 @@ func reportCacheMiss(module, version string) error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	client := http.Client{
 		Timeout: 30 * time.Second,

--- a/pkg/config/env/olympus.go
+++ b/pkg/config/env/olympus.go
@@ -6,3 +6,9 @@ import "github.com/gobuffalo/envy"
 func OlympusGlobalEndpointWithDefault(value string) string {
 	return envy.Get("OLYMPUS_GLOBAL_ENDPOINT", value)
 }
+
+// OlympusHTTPPort returns the port that the olympus server is running on;
+// should default to 3001.
+func OlympusHTTPPort(value string) string {
+	return envy.Get("OLYMPUS_HTTP_PORT", value)
+}


### PR DESCRIPTION
So that Zeus can happily run at 3000. 