### PR TITLE
Athens: delegate worker retries to gocraft/work

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -28,7 +28,6 @@ const (
 	workerQueue        = "default"
 	workerModuleKey    = "module"
 	workerVersionKey   = "version"
-	workerTryCountKey  = "trycount"
 
 	maxTryCount = 5
 )

--- a/cmd/proxy/actions/cache_miss_reporter.go
+++ b/cmd/proxy/actions/cache_miss_reporter.go
@@ -75,9 +75,8 @@ func queueCacheMissFetch(module, version string, w worker.Worker) error {
 		Queue:   workerQueue,
 		Handler: FetcherWorkerName,
 		Args: worker.Args{
-			workerModuleKey:   module,
-			workerVersionKey:  version,
-			workerTryCountKey: maxTryCount,
+			workerModuleKey:  module,
+			workerVersionKey: version,
 		},
 	})
 }


### PR DESCRIPTION
The `gowork/work` package already handles retries, so having our own retries on top of those could be potentially conflicting or unnecessary at best