### PR TITLE
make: drop cli reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ build:
 run: build
 	./athens
 
-.PHONY: cli	
-cli:
-	go build -o athens ./cmd/cli
-
 .PHONY: docs
 docs:
 	cd docs && hugo


### PR DESCRIPTION
CLI was removed and so should be the dangling reference within `Makefile`.