### PR TITLE
Zeus: remove duplicate '/' handler assignment

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -109,8 +109,6 @@ func App() (*buffalo.App, error) {
 		}
 		app.Use(T.Middleware())
 
-		app.GET("/", homeHandler)
-
 		if err := addProxyRoutes(app, store, mf); err != nil {
 			err = fmt.Errorf("error adding proxy routes (%s)", err)
 			return nil, err

--- a/cmd/proxy/actions/home.go
+++ b/cmd/proxy/actions/home.go
@@ -1,24 +1,9 @@
 package actions
 
 import (
-	"time"
-
-	"github.com/bketelsen/buffet"
 	"github.com/gobuffalo/buffalo"
 )
 
 func proxyHomeHandler(c buffalo.Context) error {
 	return c.Render(200, proxy.HTML("index.html"))
-}
-
-func homeHandler(c buffalo.Context) error {
-	slow(c)
-	return c.Render(200, proxy.HTML("index.html"))
-}
-
-func slow(c buffalo.Context) {
-	sp := buffet.ChildSpan("slow", c)
-	defer sp.Finish()
-	time.Sleep(1 * time.Millisecond)
-
 }


### PR DESCRIPTION
The home '/' route handler for the proxy app is assigned to `proxyHomeHandler` in (./cmd/proxy/app_proxy.go) line 11.
However on line 112 of (./cmd/proxy/app.go) it is reassigned to the `homeHandler`. Since we can't have two handlers I removed the one from `app.go` for using `homeHandler`.

I am wondering which handler is preferred however, as the 'homeHandler' also includes a new tracing child span and a sleep for one millisecond. If whichever of the two is not needed I will remove that as well.