### PR TITLE
Athens: introduce log package

### DIFF
--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gomods/athens/pkg/config/env"
 	"github.com/gomods/athens/pkg/download"
 	"github.com/gomods/athens/pkg/eventlog"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/rs/cors"
 	"github.com/unrolled/secure"
@@ -69,6 +70,7 @@ func App(config *AppConfig) (*buffalo.App, error) {
 			},
 			SessionName: "_olympus_session",
 			Worker:      w,
+			Logger:      log.Buffalo(),
 		})
 		// Automatically redirect to SSL
 		app.Use(ssl.ForceSSL(secure.Options{

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -73,7 +73,7 @@ func App() (*buffalo.App, error) {
 			return nil, err
 		}
 
-		lggr := log.New(env.CloudRuntime())
+		lggr := log.New(env.CloudRuntime(), env.LogLevel())
 
 		app = buffalo.New(buffalo.Options{
 			Env: ENV,

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/garyburd/redigo/redis"
 	"github.com/gobuffalo/buffalo"
@@ -15,6 +14,7 @@ import (
 	"github.com/gobuffalo/packr"
 	"github.com/gocraft/work"
 	"github.com/gomods/athens/pkg/config/env"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/module"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/gomods/athens/pkg/user"
@@ -47,7 +47,7 @@ var userStore *user.Store
 func init() {
 	g, err := env.GoPath()
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	gopath = g
 }
@@ -73,6 +73,8 @@ func App() (*buffalo.App, error) {
 			return nil, err
 		}
 
+		lggr := log.New()
+
 		app = buffalo.New(buffalo.Options{
 			Env: ENV,
 			PreWares: []buffalo.PreWare{
@@ -80,7 +82,9 @@ func App() (*buffalo.App, error) {
 			},
 			SessionName: "_athens_session",
 			Worker:      worker,
+			Logger:      log.Buffalo(),
 		})
+
 		// Automatically redirect to SSL
 		app.Use(ssl.ForceSSL(secure.Options{
 			SSLRedirect:     ENV == "production",
@@ -111,7 +115,7 @@ func App() (*buffalo.App, error) {
 
 		app.GET("/", homeHandler)
 
-		if err := addProxyRoutes(app, store, mf); err != nil {
+		if err := addProxyRoutes(app, store, mf, lggr); err != nil {
 			err = fmt.Errorf("error adding proxy routes (%s)", err)
 			return nil, err
 		}

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -73,7 +73,7 @@ func App() (*buffalo.App, error) {
 			return nil, err
 		}
 
-		lggr := log.New()
+		lggr := log.New(env.CloudRuntime())
 
 		app = buffalo.New(buffalo.Options{
 			Env: ENV,

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -3,18 +3,24 @@ package actions
 import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/gomods/athens/pkg/download"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/module"
 	"github.com/gomods/athens/pkg/storage"
 )
 
-func addProxyRoutes(app *buffalo.App, storage storage.Backend, mf *module.Filter) error {
+func addProxyRoutes(
+	app *buffalo.App,
+	storage storage.Backend,
+	mf *module.Filter,
+	lggr *log.Logger,
+) error {
 	app.GET("/", proxyHomeHandler)
 
 	// Download Protocol
 	app.GET(download.PathList, download.ListHandler(storage, proxy))
-	app.GET(download.PathVersionInfo, cacheMissHandler(download.VersionInfoHandler(storage, proxy), app.Worker, mf))
-	app.GET(download.PathVersionModule, cacheMissHandler(download.VersionModuleHandler(storage), app.Worker, mf))
-	app.GET(download.PathVersionZip, cacheMissHandler(download.VersionZipHandler(storage), app.Worker, mf))
+	app.GET(download.PathVersionInfo, cacheMissHandler(download.VersionInfoHandler(storage, proxy), app.Worker, mf, lggr))
+	app.GET(download.PathVersionModule, cacheMissHandler(download.VersionModuleHandler(storage), app.Worker, mf, lggr))
+	app.GET(download.PathVersionZip, cacheMissHandler(download.VersionZipHandler(storage), app.Worker, mf, lggr))
 
 	app.POST("/admin/fetch/{module:[a-zA-Z./]+}/{owner}/{repo}/{ref}/{version}", fetchHandler(storage))
 	return nil

--- a/cmd/proxy/actions/cache_miss_handler.go
+++ b/cmd/proxy/actions/cache_miss_handler.go
@@ -1,20 +1,19 @@
 package actions
 
 import (
-	"log"
-
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/worker"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/module"
 	"github.com/gomods/athens/pkg/paths"
 	"github.com/gomods/athens/pkg/storage"
 )
 
-func cacheMissHandler(next buffalo.Handler, w worker.Worker, mf *module.Filter) buffalo.Handler {
+func cacheMissHandler(next buffalo.Handler, w worker.Worker, mf *module.Filter, lggr log.Entry) buffalo.Handler {
 	return func(c buffalo.Context) error {
 		params, err := paths.GetAllParams(c)
 		if err != nil {
-			log.Println(err)
+			lggr.SystemErr(err)
 			return err
 		}
 
@@ -26,7 +25,7 @@ func cacheMissHandler(next buffalo.Handler, w worker.Worker, mf *module.Filter) 
 		if storage.IsNotFoundError(nextErr) {
 			// TODO: add separate worker instead of inline reports
 			if err := queueCacheMissReportJob(params.Module, params.Version, app.Worker); err != nil {
-				log.Println(err)
+				lggr.SystemErr(err)
 				return nextErr
 			}
 

--- a/pkg/config/env/cloud_runtime.go
+++ b/pkg/config/env/cloud_runtime.go
@@ -7,5 +7,5 @@ import (
 // CloudRuntime returns the Cloud Provider
 // underneath which the Proxy/Registry is running.
 func CloudRuntime() string {
-	return envy.Get("ATHENS_CLOUD_RUNTIME", "development")
+	return envy.Get("ATHENS_CLOUD_RUNTIME", "none")
 }

--- a/pkg/config/env/cloud_runtime.go
+++ b/pkg/config/env/cloud_runtime.go
@@ -1,0 +1,11 @@
+package env
+
+import (
+	"github.com/gobuffalo/envy"
+)
+
+// CloudRuntime returns the Cloud Provider
+// underneath which the Proxy/Registry is running.
+func CloudRuntime() string {
+	return envy.Get("ATHENS_CLOUD_RUNTIME", "development")
+}

--- a/pkg/config/env/log.go
+++ b/pkg/config/env/log.go
@@ -1,0 +1,12 @@
+package env
+
+import (
+	"github.com/gobuffalo/envy"
+)
+
+// LogLevel returns the system's
+// exposure to internal logs. Defaults
+// to debug.
+func LogLevel() string {
+	return envy.Get("ATHENS_LOG_LEVEL", "debug")
+}

--- a/pkg/log/buffalo.go
+++ b/pkg/log/buffalo.go
@@ -28,7 +28,7 @@ func (buffaloFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	if entry.Level == logrus.ErrorLevel {
 		// buffalo does not pass request params when an error occurs: pass params
 		// when https://github.com/gobuffalo/buffalo/issues/1171 is resolved.
-		return fmtBuffaloErr(entry.Message)
+		return fmtBuffaloErr(entry.Message), nil
 	}
 
 	statusCode, _ := entry.Data["status"].(int)
@@ -65,7 +65,6 @@ func (bf *buffaloLogger) WithFields(fields map[string]interface{}) buffalo.Logge
 	return &buffaloLogger{e}
 }
 
-func fmtBuffaloErr(msg string) ([]byte, error) {
-	str := fmt.Sprintf("%s %s\n", color.HiRedString("buffalo:"), msg)
-	return []byte(str), nil
+func fmtBuffaloErr(msg string) []byte {
+	return []byte(fmt.Sprintf("%s %s\n", color.HiRedString("buffalo:"), msg))
 }

--- a/pkg/log/buffalo.go
+++ b/pkg/log/buffalo.go
@@ -33,11 +33,13 @@ func (buffaloFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	statusCode, _ := entry.Data["status"].(int)
 	status := fmt.Sprint(statusCode)
-	if statusCode < 400 {
+
+	switch {
+	case statusCode < 400:
 		status = color.GreenString("%v", status)
-	} else if statusCode >= 400 && statusCode < 500 {
+	case statusCode >= 400 && statusCode < 500:
 		status = color.HiYellowString("%v", status)
-	} else {
+	default:
 		status = color.HiRedString("%v", status)
 	}
 

--- a/pkg/log/buffalo.go
+++ b/pkg/log/buffalo.go
@@ -12,6 +12,9 @@ import (
 // than the default buffalo formatter.
 // For the most part, we only care about
 // the path, the method, and the status code.
+// It's also good to note that internal logs
+// from buffalo should only be allowed in development
+// as our logging-system should be handled from our codebase.
 func Buffalo() buffalo.Logger {
 	l := logrus.New()
 	l.Formatter = &buffaloFormatter{}

--- a/pkg/log/buffalo.go
+++ b/pkg/log/buffalo.go
@@ -1,0 +1,68 @@
+package log
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/gobuffalo/buffalo"
+	"github.com/sirupsen/logrus"
+)
+
+// Buffalo returns a more sane logging format
+// than the default buffalo formatter.
+// For the most part, we only care about
+// the path, the method, and the status code.
+func Buffalo() buffalo.Logger {
+	l := logrus.New()
+	l.Formatter = &buffaloFormatter{}
+
+	return &buffaloLogger{l}
+}
+
+type buffaloFormatter struct{}
+
+func (buffaloFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	if entry.Level == logrus.ErrorLevel {
+		// buffalo does not pass request params when an error occurs: pass params
+		// when https://github.com/gobuffalo/buffalo/issues/1171 is resolved.
+		return fmtBuffaloErr(entry.Message)
+	}
+
+	statusCode, _ := entry.Data["status"].(int)
+	status := fmt.Sprint(statusCode)
+	if statusCode < 400 {
+		status = color.GreenString("%v", status)
+	} else if statusCode >= 400 && statusCode < 500 {
+		status = color.HiYellowString("%v", status)
+	} else {
+		status = color.HiRedString("%v", status)
+	}
+
+	str := fmt.Sprintf(
+		"%v %v %v [%v]\n",
+		color.CyanString("handler:"),
+		entry.Data["method"],
+		entry.Data["path"],
+		status,
+	)
+
+	return []byte(str), nil
+}
+
+type buffaloLogger struct{ logrus.FieldLogger }
+
+func (bf *buffaloLogger) WithField(key string, val interface{}) buffalo.Logger {
+	e := bf.FieldLogger.WithField(key, val)
+
+	return &buffaloLogger{e}
+}
+
+func (bf *buffaloLogger) WithFields(fields map[string]interface{}) buffalo.Logger {
+	e := bf.FieldLogger.WithFields(fields)
+	return &buffaloLogger{e}
+}
+
+func fmtBuffaloErr(msg string) ([]byte, error) {
+	str := fmt.Sprintf("%s %s\n", color.HiRedString("buffalo:"), msg)
+	return []byte(str), nil
+}

--- a/pkg/log/buffalo_formatter.go
+++ b/pkg/log/buffalo_formatter.go
@@ -4,23 +4,8 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/gobuffalo/buffalo"
 	"github.com/sirupsen/logrus"
 )
-
-// Buffalo returns a more sane logging format
-// than the default buffalo formatter.
-// For the most part, we only care about
-// the path, the method, and the status code.
-// It's also good to note that internal logs
-// from buffalo should only be allowed in development
-// as our logging-system should be handled from our codebase.
-func Buffalo() buffalo.Logger {
-	l := logrus.New()
-	l.Formatter = &buffaloFormatter{}
-
-	return &buffaloLogger{l}
-}
 
 type buffaloFormatter struct{}
 
@@ -52,19 +37,6 @@ func (buffaloFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	)
 
 	return []byte(str), nil
-}
-
-type buffaloLogger struct{ logrus.FieldLogger }
-
-func (bf *buffaloLogger) WithField(key string, val interface{}) buffalo.Logger {
-	e := bf.FieldLogger.WithField(key, val)
-
-	return &buffaloLogger{e}
-}
-
-func (bf *buffaloLogger) WithFields(fields map[string]interface{}) buffalo.Logger {
-	e := bf.FieldLogger.WithFields(fields)
-	return &buffaloLogger{e}
 }
 
 func fmtBuffaloErr(msg string) []byte {

--- a/pkg/log/buffalo_logger.go
+++ b/pkg/log/buffalo_logger.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"github.com/gobuffalo/buffalo"
+	"github.com/sirupsen/logrus"
+)
+
+// Buffalo returns a more sane logging format
+// than the default buffalo formatter.
+// For the most part, we only care about
+// the path, the method, and the status code.
+// It's also good to note that internal logs
+// from buffalo should only be allowed in development
+// as our logging-system should be handled from our codebase.
+func Buffalo() buffalo.Logger {
+	l := logrus.New()
+	l.Formatter = &buffaloFormatter{}
+
+	return &buffaloLogger{l}
+}
+
+type buffaloLogger struct{ logrus.FieldLogger }
+
+func (bf *buffaloLogger) WithField(key string, val interface{}) buffalo.Logger {
+	e := bf.FieldLogger.WithField(key, val)
+
+	return &buffaloLogger{e}
+}
+
+func (bf *buffaloLogger) WithFields(fields map[string]interface{}) buffalo.Logger {
+	e := bf.FieldLogger.WithFields(fields)
+	return &buffaloLogger{e}
+}

--- a/pkg/log/entry.go
+++ b/pkg/log/entry.go
@@ -1,0 +1,18 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type entry struct {
+	*logrus.Entry
+}
+
+func (e *entry) WithFields(fields map[string]interface{}) Entry {
+	ent := e.Entry.WithFields(fields)
+	return &entry{ent}
+}
+
+func (e *entry) SystemErr(err error) {
+	e.Entry.Error(err)
+}

--- a/pkg/log/entry.go
+++ b/pkg/log/entry.go
@@ -4,6 +4,28 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Entry is an abstraction to the
+// Logger and the logrus.Entry
+// so that *Logger always creates
+// an Entry copy which ensures no
+// Fields are being overwritten.
+type Entry interface {
+	// Basic Logging Operation
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+
+	// Attach contextual information to the logging entry
+	WithFields(fields map[string]interface{}) Entry
+
+	// SystemErr is a method that disects the error
+	// and logs the appropriate level and fields for it.
+	// TODO(marwan-at-work): When we have our own Error struct
+	// this method will be very useful.
+	SystemErr(err error)
+}
+
 type entry struct {
 	*logrus.Entry
 }

--- a/pkg/log/format.go
+++ b/pkg/log/format.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+func getGCPFormatter() logrus.Formatter {
+	return &logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyLevel: "severity",
+			logrus.FieldKeyMsg:   "message",
+			logrus.FieldKeyTime:  "timestamp",
+		},
+	}
+}
+
+func getDevFormatter() logrus.Formatter {
+	return &logrus.TextFormatter{}
+}
+
+func getDefaultFormatter() logrus.Formatter {
+	return &logrus.JSONFormatter{}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -14,8 +14,18 @@ type Logger struct {
 // environment and the cloud platform it is
 // running on. TODO: take cloud arg and env
 // to construct the correct JSON formatter.
-func New() *Logger {
-	return &Logger{Logger: logrus.New()}
+func New(cloudProvider string) *Logger {
+	l := logrus.New()
+	switch cloudProvider {
+	case "GCP":
+		l.Formatter = getGCPFormatter()
+	case "development":
+		l.Formatter = getDevFormatter()
+	default:
+		l.Formatter = getDefaultFormatter()
+	}
+
+	return &Logger{Logger: l}
 }
 
 // Entry is an abstraction to the

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -19,7 +19,7 @@ func New(cloudProvider, level string) *Logger {
 	switch cloudProvider {
 	case "GCP":
 		l.Formatter = getGCPFormatter()
-	case "development":
+	case "none":
 		l.Formatter = getDevFormatter()
 	default:
 		l.Formatter = getDefaultFormatter()

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -14,7 +14,7 @@ type Logger struct {
 // environment and the cloud platform it is
 // running on. TODO: take cloud arg and env
 // to construct the correct JSON formatter.
-func New(cloudProvider string) *Logger {
+func New(cloudProvider, level string) *Logger {
 	l := logrus.New()
 	switch cloudProvider {
 	case "GCP":
@@ -24,6 +24,11 @@ func New(cloudProvider string) *Logger {
 	default:
 		l.Formatter = getDefaultFormatter()
 	}
+	logLevel, err := logrus.ParseLevel(level)
+	if err != nil {
+		panic(err)
+	}
+	l.Level = logLevel
 
 	return &Logger{Logger: l}
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -33,28 +33,6 @@ func New(cloudProvider, level string) *Logger {
 	return &Logger{Logger: l}
 }
 
-// Entry is an abstraction to the
-// Logger and the logrus.Entry
-// so that *Logger always creates
-// an Entry copy which ensures no
-// Fields are being overwritten.
-type Entry interface {
-	// Basic Logging Operation
-	Debugf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-
-	// Attach contextual information to the logging entry
-	WithFields(fields map[string]interface{}) Entry
-
-	// SystemErr is a method that disects the error
-	// and logs the appropriate level and fields for it.
-	// TODO(marwan-at-work): When we have our own Error struct
-	// this method will be very useful.
-	SystemErr(err error)
-}
-
 // SystemErr Entry implementation.
 func (l *Logger) SystemErr(err error) {
 	l.Logger.Error(err)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,53 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// Logger is the main struct that any athens
+// internal service should use to communicate things.
+type Logger struct {
+	*logrus.Logger
+}
+
+// New constructs a new logger based on the
+// environment and the cloud platform it is
+// running on. TODO: take cloud arg and env
+// to construct the correct JSON formatter.
+func New() *Logger {
+	return &Logger{Logger: logrus.New()}
+}
+
+// Entry is an abstraction to the
+// Logger and the logrus.Entry
+// so that *Logger always creates
+// an Entry copy which ensures no
+// Fields are being overwritten.
+type Entry interface {
+	// Basic Logging Operation
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+
+	// Attach contextual information to the logging entry
+	WithFields(fields map[string]interface{}) Entry
+
+	// SystemErr is a method that disects the error
+	// and logs the appropriate level and fields for it.
+	// TODO(marwan-at-work): When we have our own Error struct
+	// this method will be very useful.
+	SystemErr(err error)
+}
+
+// SystemErr Entry implementation.
+func (l *Logger) SystemErr(err error) {
+	l.Logger.Error(err)
+}
+
+// WithFields Entry implementation.
+func (l *Logger) WithFields(fields map[string]interface{}) Entry {
+	e := l.Logger.WithFields(fields)
+
+	return &entry{e}
+}


### PR DESCRIPTION
This PR does two things: 

1. Creates a formatter for buffalo's logs, just so that we can follow the flow of handlers more clearly when developing/debugging only.

2. Creates our own `log` package which will be the broad logging mechanism for the whole Athens system. This PR just defines the behavior of logging so that it can be discussed/tweaked if necessary before changing all the logs in the code base. 

Once this PR is resolved, further prs should come in to spit logs through this package instead of the standard library

Fixes https://github.com/gomods/athens/issues/156

