### PR TITLE
Proxy: fix init nil dereference

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/buffalo/middleware/csrf"
 	"github.com/gobuffalo/buffalo/middleware/i18n"
 	"github.com/gobuffalo/buffalo/middleware/ssl"
+	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/buffalo/worker"
 	"github.com/gobuffalo/gocraft-work-adapter"
 	"github.com/gobuffalo/packr"
@@ -50,6 +51,19 @@ func init() {
 		panic(err)
 	}
 	gopath = g
+
+	proxy = render.New(render.Options{
+		// HTML layout to be used for all HTML requests:
+		HTMLLayout:       "application.html",
+		JavaScriptLayout: "application.js",
+
+		// Box containing all of the templates:
+		TemplatesBox: packr.NewBox("../templates/proxy"),
+		AssetsBox:    assetsBox,
+
+		// Add template helpers here:
+		Helpers: render.Helpers{},
+	})
 }
 
 // App is where all routes and middleware for buffalo
@@ -95,6 +109,7 @@ func App() (*buffalo.App, error) {
 			app.Use(middleware.ParameterLogger)
 		}
 		initializeTracing(app)
+		initializeAuth(app)
 		// Protect against CSRF attacks. https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
 		// Remove to disable this.
 		if env.EnableCSRFProtection() {

--- a/cmd/proxy/actions/auth.go
+++ b/cmd/proxy/actions/auth.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/gobuffalo/buffalo"
@@ -12,11 +11,7 @@ import (
 	"github.com/markbates/goth/providers/github"
 )
 
-func init() {
-	app, err := App()
-	if err != nil {
-		log.Fatal(err)
-	}
+func initializeAuth(app *buffalo.App) {
 	gothic.Store = app.SessionStore
 
 	goth.UseProviders(

--- a/cmd/proxy/actions/render.go
+++ b/cmd/proxy/actions/render.go
@@ -7,18 +7,3 @@ import (
 
 var proxy *render.Engine
 var assetsBox = packr.NewBox("../public")
-
-func init() {
-	proxy = render.New(render.Options{
-		// HTML layout to be used for all HTML requests:
-		HTMLLayout:       "application.html",
-		JavaScriptLayout: "application.js",
-
-		// Box containing all of the templates:
-		TemplatesBox: packr.NewBox("../templates/proxy"),
-		AssetsBox:    assetsBox,
-
-		// Add template helpers here:
-		Helpers: render.Helpers{},
-	})
-}


### PR DESCRIPTION
For some reason, having two inits in the same package caused panics because the `proxy` variable was being passed down to the Download Protocol Handlers as nil. 