### PR TITLE
storage: return ErrVersionNotFound from rdbms Deleter

### DIFF
--- a/pkg/storage/rdbms/deleter.go
+++ b/pkg/storage/rdbms/deleter.go
@@ -1,14 +1,21 @@
 package rdbms
 
 import (
+	"github.com/gomods/athens/pkg/storage"
 	"github.com/gomods/athens/pkg/storage/rdbms/models"
 )
 
-// Delete removes a specific version of a module
-func (r *ModuleStore) Delete(module, vsn string) error {
-	result := models.Module{}
-	query := r.conn.Where("module = ?", module).Where("version = ?", vsn)
-	if err := query.First(&result); err != nil {
+// Delete removes a specific version of a module.
+func (r *ModuleStore) Delete(module, version string) error {
+	if !r.Exists(module, version) {
+		return storage.ErrVersionNotFound{
+			Module:  module,
+			Version: version,
+		}
+	}
+	result := &models.Module{}
+	query := r.conn.Where("module = ?", module).Where("version = ?", version)
+	if err := query.First(result); err != nil {
 		return err
 	}
 	return r.conn.Destroy(result)

--- a/pkg/storage/rdbms/deleter_test.go
+++ b/pkg/storage/rdbms/deleter_test.go
@@ -1,0 +1,42 @@
+package rdbms
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/gomods/athens/pkg/storage"
+)
+
+func (d *RDBMSTestSuite) TestDelete() {
+	r := d.Require()
+
+	version := "delete" + time.Now().String()
+	err := d.storage.Save(context.Background(), module, version, mod, bytes.NewReader(zip), info)
+	r.NoError(err)
+
+	tests := []struct {
+		module  string
+		version string
+		want    error
+	}{
+		{
+			module:  "does/not/exist",
+			version: "v1.0.0",
+			want: storage.ErrVersionNotFound{
+				Module:  "does/not/exist",
+				Version: "v1.0.0",
+			},
+		},
+		{
+			module:  module,
+			version: version,
+		},
+	}
+	for _, test := range tests {
+		err := d.storage.Delete(test.module, test.version)
+		r.Equal(test.want, err)
+		exists := d.storage.Exists(test.module, test.version)
+		r.Equal(false, exists)
+	}
+}


### PR DESCRIPTION
This also fixes a bug caused by calling conn.Destroy on a non-pointer value.

Part of #244.