### PR TITLE
Athens: introduce pkg/errors

### DIFF
--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -62,6 +62,7 @@ func App(config *AppConfig) (*buffalo.App, error) {
 			return nil, err
 		}
 
+		lggr := log.New(env.CloudRuntime(), env.LogLevel())
 		app = buffalo.New(buffalo.Options{
 			Addr: port,
 			Env:  ENV,
@@ -117,7 +118,7 @@ func App(config *AppConfig) (*buffalo.App, error) {
 		app.GET(download.PathList, download.ListHandler(config.Storage, renderEng))
 		app.GET(download.PathVersionInfo, download.VersionInfoHandler(config.Storage, renderEng))
 		app.GET(download.PathVersionModule, download.VersionModuleHandler(config.Storage, renderEng))
-		app.GET(download.PathVersionZip, download.VersionZipHandler(config.Storage))
+		app.GET(download.PathVersionZip, download.VersionZipHandler(config.Storage, renderEng, lggr))
 
 		app.ServeFiles("/", assetsBox) // serve files from the public directory
 	}

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -20,7 +20,7 @@ func addProxyRoutes(
 	app.GET(download.PathList, download.ListHandler(storage, proxy))
 	app.GET(download.PathVersionInfo, cacheMissHandler(download.VersionInfoHandler(storage, proxy), app.Worker, mf, lggr))
 	app.GET(download.PathVersionModule, cacheMissHandler(download.VersionModuleHandler(storage, proxy), app.Worker, mf, lggr))
-	app.GET(download.PathVersionZip, cacheMissHandler(download.VersionZipHandler(storage), app.Worker, mf, lggr))
+	app.GET(download.PathVersionZip, cacheMissHandler(download.VersionZipHandler(storage, proxy, lggr), app.Worker, mf, lggr))
 
 	app.POST("/admin/fetch/{module:[a-zA-Z./]+}/{owner}/{repo}/{ref}/{version}", fetchHandler(storage))
 	return nil

--- a/pkg/config/module.go
+++ b/pkg/config/module.go
@@ -7,3 +7,9 @@ import "fmt"
 func PackageVersionedName(module, version, ext string) string {
 	return fmt.Sprintf("%s/@v/%s.%s", module, version, ext)
 }
+
+// FmtModVer is a helper function that can take
+// pkg/a/b and v2.3.1 and returns pkg/a/b@v2.3.1
+func FmtModVer(mod, ver string) string {
+	return fmt.Sprintf("%s@%s", mod, ver)
+}

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -7,34 +7,58 @@ import (
 
 	"github.com/bketelsen/buffet"
 	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/buffalo/render"
+	"github.com/gomods/athens/pkg/errors"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/paths"
 	"github.com/gomods/athens/pkg/storage"
+	"github.com/sirupsen/logrus"
 )
 
 // PathVersionZip URL.
 const PathVersionZip = "/{module:.+}/@v/{version}.zip"
 
 // VersionZipHandler implements GET baseURL/module/@v/version.zip
-func VersionZipHandler(getter storage.Getter) func(c buffalo.Context) error {
+func VersionZipHandler(getter storage.Getter, eng *render.Engine, lggr *log.Logger) func(c buffalo.Context) error {
+	const op errors.Op = "download.VersionZipHandler"
+
 	return func(c buffalo.Context) error {
 		sp := buffet.SpanFromContext(c)
 		sp.SetOperationName("versionZipHandler")
 		params, err := paths.GetAllParams(c)
 		if err != nil {
-			return err
-		}
-		version, err := getter.Get(params.Module, params.Version)
-		if storage.IsNotFoundError(err) {
-			return c.Error(http.StatusNotFound, fmt.Errorf("%s@%s not found", params.Module, params.Version))
-		} else if err != nil {
-			return err
+			lggr.SystemErr(errors.E(op, err))
+			c.Response().WriteHeader(http.StatusInternalServerError) // 500 because handler should not be called in the first place.
+			return nil
 		}
 
+		mod, ver := params.Module, params.Version
+		version, err := getter.Get(mod, ver)
+		if err != nil {
+			lvl := logrus.ErrorLevel
+			status := http.StatusInternalServerError
+			msg := http.StatusText(status)
+			// TODO: move this function to pkg/errors
+			if storage.IsNotFoundError(err) {
+				lvl = logrus.DebugLevel
+				msg = fmt.Sprintf("%s@%s not found", mod, ver)
+				status = http.StatusNotFound
+			}
+
+			lggr.SystemErr(errors.E(op, mod, ver, lvl, err))
+			return c.Render(status, eng.JSON(msg))
+		}
 		defer version.Zip.Close()
 
+		// should we write the status file *after* we ensure io.Copy is
+		// successful or not?
 		c.Response().WriteHeader(http.StatusOK)
 
 		_, err = io.Copy(c.Response(), version.Zip)
-		return err
+		if err != nil {
+			lggr.SystemErr(errors.E(op, mod, ver, err))
+		}
+
+		return nil
 	}
 }

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -45,7 +45,7 @@ func VersionZipHandler(getter storage.Getter, eng *render.Engine, lggr *log.Logg
 				status = http.StatusNotFound
 			}
 
-			lggr.SystemErr(errors.E(op, mod, ver, lvl, err))
+			lggr.SystemErr(errors.E(op, errors.M(mod), errors.V(ver), lvl, err))
 			return c.Render(status, eng.JSON(msg))
 		}
 		defer version.Zip.Close()
@@ -56,7 +56,7 @@ func VersionZipHandler(getter storage.Getter, eng *render.Engine, lggr *log.Logg
 
 		_, err = io.Copy(c.Response(), version.Zip)
 		if err != nil {
-			lggr.SystemErr(errors.E(op, mod, ver, err))
+			lggr.SystemErr(errors.E(op, errors.M(mod), errors.V(ver), err))
 		}
 
 		return nil

--- a/pkg/errors/doc.go
+++ b/pkg/errors/doc.go
@@ -1,17 +1,17 @@
 // Package errors provides a central interface to handling
 // all errors in the Athens domain. It closely follows Upspin's error
-// handling with a few differences that reflects the system design
+// handling with a few differences that reflect the system design
 // of the Athen's architecture. If you're unfamiliar with Upspin's error
-// handling, we recommend that you read this article first then
+// handling, we recommend that you read this article first before
 // coming back here https://commandcenter.blogspot.com/2017/12/error-handling-in-upspin.html.
 // Athen's errors are central around dealing with modules. So every error
 // will most likely carry a Module and a Version inside of them. Furthermore,
-// because Athens is designed to run into multiple clouds, we have to design
+// because Athens is designed to run on multiple clouds, we have to design
 // our errors and our logger to be friendly with each other. Therefore,
 // the logger's SystemError method, although it accepts any type of error,
 // it knows how to deal with errors constructed from this package in a debuggable way.
 // To construct an Athens error, call the errors.E function. The E function takes
-// an Op and a variadic interface{}, but the values of the Error struct is what you can
+// an Op and a variadic interface{}, but the values of the Error struct are what you can
 // pass to it. Values such as the error Kind, Module, Version, Error Message,
 // and Seveirty (seriousness of an error) are all optional. The only truly required value is
 // the errors.Op so you can construct a traceable stack that leads to where

--- a/pkg/errors/doc.go
+++ b/pkg/errors/doc.go
@@ -1,0 +1,22 @@
+// Package errors provides a central interface to handling
+// all errors in the Athens domain. It closely follows Upspin's error
+// handling with a few differences that reflects the system design
+// of the Athen's architecture. If you're unfamiliar with Upspin's error
+// handling, we recommend that you read this article first then
+// coming back here https://commandcenter.blogspot.com/2017/12/error-handling-in-upspin.html.
+// Athen's errors are central around dealing with modules. So every error
+// will most likely carry a Module and a Version inside of them. Furthermore,
+// because Athens is designed to run into multiple clouds, we have to design
+// our errors and our logger to be friendly with each other. Therefore,
+// the logger's SystemError method, although it accepts any type of error,
+// it knows how to deal with errors constructed from this package in a debuggable way.
+// To construct an Athens error, call the errors.E function. The E function takes
+// an Op and a variadic interface{}, but the values of the Error struct is what you can
+// pass to it. Values such as the error Kind, Module, Version, Error Message,
+// and Seveirty (seriousness of an error) are all optional. The only truly required value is
+// the errors.Op so you can construct a traceable stack that leads to where
+// the error happened. However, adding more information can help catch an issue
+// quicker and would help Cloud Log Monitoring services be more efficient to maintainers
+// as you can run queries on Athens Errors such as "Give me all errors of KindUnexpected"
+// or "Give me all errors where caused by a particular Module"
+package errors

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -143,6 +143,7 @@ func Ops(err Error) []Op {
 		}
 
 		ops = append(ops, embeddedErr.Op)
+		err = embeddedErr
 	}
 
 	return ops

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -63,15 +63,15 @@ type V string
 // You can optionally pass a Logrus severity to indicate
 // the log level of an error based on the context it was constructed in.
 func E(op Op, args ...interface{}) error {
+	e := Error{Op: op}
 	if len(args) == 0 {
 		msg := "errors.E called with 0 args"
 		_, file, line, ok := runtime.Caller(1)
 		if ok {
 			msg = fmt.Sprintf("%v - %v:%v", msg, file, line)
 		}
-		return errors.New(msg)
+		e.Err = errors.New(msg)
 	}
-	e := Error{Op: op}
 	for _, a := range args {
 		switch a := a.(type) {
 		case error:
@@ -88,11 +88,9 @@ func E(op Op, args ...interface{}) error {
 			e.Kind = a
 		}
 	}
-
 	if e.Err == nil {
 		e.Err = errors.New("no error message provided")
 	}
-
 	return e
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,158 @@
+package errors
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/marwan-at-work/vgop/semver"
+	"github.com/sirupsen/logrus"
+)
+
+// Kind enums
+const (
+	KindNotFound   = http.StatusNotFound
+	KindBadRequest = http.StatusBadRequest
+	KindUnexpected = http.StatusInternalServerError
+)
+
+// Error is an Athens system error.
+// It carries information and behavior
+// as to what caused this error so that
+// callers can implement logic around it.
+type Error struct {
+	// Kind categories Athens errors into a smaller
+	// subset of errors. This way we can generalize
+	// what an error really is: such as "not found",
+	// "bad request", etc. The official categories
+	// are HTTP status code but the ones we use are
+	// imported into this package.
+	Kind     int
+	Op       Op
+	Module   string
+	Version  string
+	Err      error
+	Severity logrus.Level
+}
+
+// Error returns the underlying error's
+// string message. The logger takes care
+// of filling out the stack levels and
+// extra information.
+func (e Error) Error() string {
+	return e.Err.Error()
+}
+
+// Op describes any independent function or
+// method in Athens. A series of operations
+// forms a more readable stack trace.
+type Op string
+
+// E is a helper function to construct an Error type
+// Operation always comes first, module path and version
+// come second, they are optional. Args must have at least
+// an error or a string to describe what exactly went wrong.
+// You can optionally pass a Logrus severity to indicate
+// the log level of an error based on the context it was constructed in.
+func E(op Op, args ...interface{}) error {
+	if len(args) == 0 {
+		panic("errors.E called with 0 args")
+	}
+	e := Error{Op: op}
+	for _, a := range args {
+		switch a := a.(type) {
+		case error:
+			e.Err = a
+		case string:
+			switch {
+			case isModule(a):
+				e.Module = a
+			case isVersion(a):
+				e.Version = a
+			default:
+				e.Err = errors.New(a)
+			}
+		case logrus.Level:
+			e.Severity = a
+		case int:
+			e.Kind = a
+		}
+	}
+
+	if e.Err == nil {
+		e.Err = errors.New("no error message provided")
+	}
+
+	return e
+}
+
+// Severity returns the log level of an error
+// if non exists, then it's an Error level because
+// it is an unexpected.
+func Severity(err error) logrus.Level {
+	e, ok := err.(Error)
+	if !ok {
+		return logrus.ErrorLevel
+	}
+
+	// if there's no severity (0 is Panic level in logrus
+	// which we should not use since cloud providers only have
+	// debug, info, warn, and error) then look for the
+	// child's severity.
+	if childE, ok := e.Err.(Error); ok && e.Severity == 0 {
+		return Severity(childE)
+	}
+
+	return e.Severity
+}
+
+// Kind recursively searches for the
+// first error kind it finds.
+func Kind(err error) int {
+	e, ok := err.(Error)
+	if !ok {
+		return KindUnexpected
+	}
+
+	if e.Kind != 0 {
+		return e.Kind
+	}
+
+	return Kind(e.Err)
+}
+
+// KindText returns a friendly string
+// of the Kind type. Since we use http
+// status codes to represent error kinds,
+// this method just deferrs to the net/http
+// text representations of statuses.
+func KindText(err error) string {
+	return http.StatusText(Kind(err))
+}
+
+// Ops aggregates the error's operation
+// with all the embedded errors' operations.
+// This way you can construct a queryable
+// stack trace.
+func Ops(err Error) []Op {
+	ops := []Op{err.Op}
+	for {
+		embeddedErr, ok := err.Err.(Error)
+		if !ok {
+			break
+		}
+
+		ops = append(ops, embeddedErr.Op)
+	}
+
+	return ops
+}
+
+func isModule(s string) bool {
+	ss := strings.Split(s, "/")
+	return len(ss) > 1 && strings.Contains(ss[0], ".")
+}
+
+func isVersion(s string) bool {
+	return semver.IsValid(s)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,65 @@
+package errors
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrMsg(t *testing.T) {
+	const op Op = "TestErrMsg"
+	msg := "test error"
+	err := E(op, msg)
+	require.Equal(t, msg, err.Error())
+}
+
+func TestErrEmbed(t *testing.T) {
+	const op Op = "TestErrEmbed"
+	msg := "test error"
+	childErr := errors.New(msg)
+	err := E(op, childErr)
+	require.Equal(t, err.Error(), childErr.Error())
+}
+
+func TestSeverity(t *testing.T) {
+	const op Op = "TestSeverity"
+	msg := "test error"
+
+	err := E(op, msg)
+	require.Equal(t, logrus.ErrorLevel, Severity(err))
+
+	err = E(op, msg, logrus.WarnLevel)
+	require.Equal(t, logrus.WarnLevel, Severity(err))
+
+	err = E(op, err)
+	require.Equal(t, logrus.WarnLevel, Severity(err))
+
+	err = E(op, err, logrus.InfoLevel)
+	require.Equal(t, logrus.InfoLevel, Severity(err))
+}
+
+func TestKind(t *testing.T) {
+	const op Op = "TestKind"
+	msg := "test error"
+
+	err := E(op, msg, KindBadRequest)
+	require.Equal(t, KindBadRequest, Kind(err))
+	require.Equal(t, http.StatusText(http.StatusBadRequest), KindText(err))
+}
+
+func TestOps(t *testing.T) {
+	const (
+		op1 Op = "TestOps.op1"
+		op2 Op = "TestOps.op2"
+		op3 Op = "TestOps.op3"
+	)
+
+	err1 := E(op1, "op 1")
+	err2 := E(op2, err1)
+	err3 := E(op3, err2)
+
+	require.ElementsMatch(t, []Op{op1, op2, op3}, Ops(err3.(Error)))
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -35,7 +35,8 @@ func New(cloudProvider, level string) *Logger {
 
 // SystemErr Entry implementation.
 func (l *Logger) SystemErr(err error) {
-	l.Logger.Error(err)
+	e := &entry{Entry: logrus.NewEntry(l.Logger)}
+	e.SystemErr(err)
 }
 
 // WithFields Entry implementation.

--- a/pkg/paths/path.go
+++ b/pkg/paths/path.go
@@ -1,17 +1,19 @@
 package paths
 
 import (
-	"fmt"
-
 	"github.com/gobuffalo/buffalo"
+	"github.com/gomods/athens/pkg/errors"
 )
 
 // GetModule gets the module from the path of a ?go-get=1 request
 func GetModule(c buffalo.Context) (string, error) {
+	const op errors.Op = "paths.GetModule"
+
 	module := c.Param("module")
 	if module == "" {
-		return "", fmt.Errorf("module missing")
+		return "", errors.E(op, "module missing")
 	}
+
 	return module, nil
 }
 
@@ -24,13 +26,15 @@ type AllPathParams struct {
 
 // GetAllParams fetches the path patams from c and returns them
 func GetAllParams(c buffalo.Context) (*AllPathParams, error) {
+	const op errors.Op = "paths.GetAllParams"
 	mod, err := GetModule(c)
 	if err != nil {
-		return nil, err
+		return nil, errors.E(op, err)
 	}
 	version := c.Param("version")
 	if version == "" {
-		return nil, fmt.Errorf("version not found")
+		return nil, errors.E(op, "version not found")
 	}
+
 	return &AllPathParams{Module: mod, Version: version}, nil
 }

--- a/pkg/paths/path.go
+++ b/pkg/paths/path.go
@@ -11,7 +11,7 @@ func GetModule(c buffalo.Context) (string, error) {
 
 	module := c.Param("module")
 	if module == "" {
-		return "", errors.E(op, "module missing")
+		return "", errors.E(op, "missing module parameter")
 	}
 
 	return module, nil
@@ -33,7 +33,7 @@ func GetAllParams(c buffalo.Context) (*AllPathParams, error) {
 	}
 	version := c.Param("version")
 	if version == "" {
-		return nil, errors.E(op, "version not found")
+		return nil, errors.E(op, "missing version paramater")
 	}
 
 	return &AllPathParams{Module: mod, Version: version}, nil


### PR DESCRIPTION
Fixes https://github.com/gomods/athens/issues/275

Todo: write tests for the errors package and the logger's SystemErr method. 

I'd like to gather some feedback first before writing the tests. 

Things to look out for: 

1. I updated our logger to be "Athens' Errors Friendly" using the SystemErr method.
2. I updated download.VersionZipHandler to use pkg/errors, this is so you can check out what it's like to use the package. 
3. ~I'm using a copy of cmd/go's semver validation to determine whether a string goes into the Version field. We can use Mastermind's package instead (as suggested by @arschles) but we need to confirm that they both agree to the same semver rules (so far I know cmd/go enforces a "v" prefix while Mastermind does not). We can also avoid semver validation by just creating an errors.V type just like errors.Op. Let me know :)~