### PR TITLE
storage: add context to storage.Exists and storage.Delete

### DIFF
--- a/cmd/olympus/actions/merge_db.go
+++ b/cmd/olympus/actions/merge_db.go
@@ -36,7 +36,7 @@ func mergeDB(ctx context.Context, originURL string, diff dbDiff, eLog eventlog.E
 		}
 	}
 	for _, deleted := range diff.Deleted {
-		if err := delete(deleted, eLog, storage); err != nil {
+		if err := delete(ctx, deleted, eLog, storage); err != nil {
 			errors = multierror.Append(errors, err)
 		}
 	}
@@ -81,7 +81,7 @@ func deprecate(ctx context.Context, event eventlog.Event, originURL string, eLog
 		return err // can't deprecate something that's already deleted
 	}
 	// delete from the CDN
-	if err := storage.Delete(event.Module, event.Version); err != nil {
+	if err := storage.Delete(ctx, event.Module, event.Version); err != nil {
 		log.Printf("error deleting event module %s/%s from CDN (%s)", event.Module, event.Version, err)
 		return err
 	}
@@ -94,9 +94,9 @@ func deprecate(ctx context.Context, event eventlog.Event, originURL string, eLog
 	return nil
 }
 
-func delete(event eventlog.Event, eLog eventlog.Eventlog, storage storage.Backend) error {
+func delete(ctx context.Context, event eventlog.Event, eLog eventlog.Eventlog, storage storage.Backend) error {
 	// delete in the CDN
-	if err := storage.Delete(event.Module, event.Version); err != nil {
+	if err := storage.Delete(ctx, event.Module, event.Version); err != nil {
 		log.Printf("error deleting event module %s/%s from CDN (%s)", event.Module, event.Version, err)
 		return err
 	}

--- a/cmd/proxy/actions/cache_miss_fetcher.go
+++ b/cmd/proxy/actions/cache_miss_fetcher.go
@@ -30,7 +30,7 @@ func GetProcessCacheMissJob(s storage.Backend, w worker.Worker, mf *module.Filte
 			return module.NewErrModuleExcluded(mod)
 		}
 
-		if s.Exists(mod, version) {
+		if s.Exists(context.TODO(), mod, version) {
 			return nil
 		}
 

--- a/pkg/eventlog/multireader.go
+++ b/pkg/eventlog/multireader.go
@@ -1,6 +1,7 @@
 package eventlog
 
 import (
+	"context"
 	"errors"
 
 	"github.com/gomods/athens/pkg/storage"
@@ -119,5 +120,5 @@ func exists(event Event, log []Event, checker storage.Checker) bool {
 		}
 	}
 
-	return checker.Exists(event.Module, event.Version)
+	return checker.Exists(context.Background(), event.Module, event.Version)
 }

--- a/pkg/eventlog/multireader.go
+++ b/pkg/eventlog/multireader.go
@@ -120,5 +120,5 @@ func exists(event Event, log []Event, checker storage.Checker) bool {
 		}
 	}
 
-	return checker.Exists(context.Background(), event.Module, event.Version)
+	return checker.Exists(context.TODO(), event.Module, event.Version)
 }

--- a/pkg/eventlog/multireader_test.go
+++ b/pkg/eventlog/multireader_test.go
@@ -1,6 +1,7 @@
 package eventlog
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -163,6 +164,6 @@ type ModuleStorageChecker struct {
 	Module string
 }
 
-func (s ModuleStorageChecker) Exists(module, version string) bool {
+func (s ModuleStorageChecker) Exists(ctx context.Context, module, version string) bool {
 	return module == s.Module
 }

--- a/pkg/storage/backendconnector.go
+++ b/pkg/storage/backendconnector.go
@@ -24,8 +24,8 @@ func (n noOpConnectedBackend) Connect() error {
 	return nil
 }
 
-func (n noOpConnectedBackend) Exists(module, version string) bool {
-	return n.backend.Exists(module, version)
+func (n noOpConnectedBackend) Exists(ctx context.Context, module, version string) bool {
+	return n.backend.Exists(ctx, module, version)
 }
 
 func (n noOpConnectedBackend) Get(module, vsn string) (*Version, error) {
@@ -37,6 +37,6 @@ func (n noOpConnectedBackend) List(ctx context.Context, module string) ([]string
 func (n noOpConnectedBackend) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
 	return n.backend.Save(ctx, module, version, mod, zip, info)
 }
-func (n noOpConnectedBackend) Delete(module, version string) error {
-	return n.backend.Delete(module, version)
+func (n noOpConnectedBackend) Delete(ctx context.Context, module, version string) error {
+	return n.backend.Delete(ctx, module, version)
 }

--- a/pkg/storage/checker.go
+++ b/pkg/storage/checker.go
@@ -1,8 +1,10 @@
 package storage
 
+import "context"
+
 // Checker is the interface that checks if the version of the module exists
 type Checker interface {
 	// Exists checks whether or not module in specified version is present
 	// in the backing storage
-	Exists(module, version string) bool
+	Exists(ctx context.Context, module, version string) bool
 }

--- a/pkg/storage/deleter.go
+++ b/pkg/storage/deleter.go
@@ -1,8 +1,10 @@
 package storage
 
+import "context"
+
 // Deleter deletes module metadata and its source from underlying storage
 type Deleter interface {
 	// Delete must return ErrVersionNotFound if the module/version are not
 	// found.
-	Delete(module, vsn string) error
+	Delete(ctx context.Context, module, vsn string) error
 }

--- a/pkg/storage/fs/checker.go
+++ b/pkg/storage/fs/checker.go
@@ -1,12 +1,13 @@
 package fs
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/spf13/afero"
 )
 
-func (v *storageImpl) Exists(module, version string) bool {
+func (v *storageImpl) Exists(ctx context.Context, module, version string) bool {
 	versionedPath := v.versionLocation(module, version)
 	exists, err := afero.Exists(v.filesystem, filepath.Join(versionedPath, "go.mod"))
 	if err != nil {

--- a/pkg/storage/fs/deleter.go
+++ b/pkg/storage/fs/deleter.go
@@ -1,13 +1,15 @@
 package fs
 
 import (
+	"context"
+
 	"github.com/gomods/athens/pkg/storage"
 )
 
 // Delete removes a specific version of a module.
-func (v *storageImpl) Delete(module, version string) error {
+func (v *storageImpl) Delete(ctx context.Context, module, version string) error {
 	versionedPath := v.versionLocation(module, version)
-	if !v.Exists(module, version) {
+	if !v.Exists(ctx, module, version) {
 		return storage.ErrVersionNotFound{
 			Module:  module,
 			Version: version,

--- a/pkg/storage/gcp/checker.go
+++ b/pkg/storage/gcp/checker.go
@@ -8,7 +8,6 @@ import (
 
 // Exists implements the (./pkg/storage).Checker interface
 // returning true if the module at version exists in storage
-func (s *Storage) Exists(module, version string) bool {
-	ctx := context.Background()
+func (s *Storage) Exists(ctx context.Context, module, version string) bool {
 	return s.bucket.Exists(ctx, config.PackageVersionedName(module, version, ".mod"))
 }

--- a/pkg/storage/gcp/deleter.go
+++ b/pkg/storage/gcp/deleter.go
@@ -11,8 +11,7 @@ import (
 // Delete implements the (./pkg/storage).Deleter interface and
 // removes a version of a module from storage. Returning ErrNotFound
 // if the version does not exist.
-func (s *Storage) Delete(module, version string) error {
-	ctx := context.Background()
+func (s *Storage) Delete(ctx context.Context, module, version string) error {
 	if exists := s.bucket.Exists(ctx, config.PackageVersionedName(module, version, "mod")); !exists {
 		return storage.ErrVersionNotFound{Module: module, Version: version}
 	}

--- a/pkg/storage/gcp/gcp_test.go
+++ b/pkg/storage/gcp/gcp_test.go
@@ -48,7 +48,7 @@ func (g *GcpTests) TestSaveGetListExistsRoundTrip() {
 	})
 
 	g.T().Run("Module exists", func(t *testing.T) {
-		r.Equal(true, store.Exists(g.module, g.version))
+		r.Equal(true, store.Exists(g.context, g.module, g.version))
 	})
 }
 
@@ -61,10 +61,10 @@ func (g *GcpTests) TestDeleter() {
 	err = store.Save(g.context, g.module, version, mod, bytes.NewReader(zip), info)
 	r.NoError(err)
 
-	err = store.Delete(g.module, version)
+	err = store.Delete(g.context, g.module, version)
 	r.NoError(err)
 
-	exists := store.Exists(g.module, version)
+	exists := store.Exists(g.context, g.module, version)
 	r.Equal(false, exists)
 }
 
@@ -80,7 +80,7 @@ func (g *GcpTests) TestNotFounds() {
 	})
 
 	g.T().Run("Exists module version not found", func(t *testing.T) {
-		r.Equal(false, store.Exists("never", "there"))
+		r.Equal(false, store.Exists(g.context, "never", "there"))
 	})
 
 	g.T().Run("List not found", func(t *testing.T) {

--- a/pkg/storage/gcp/getter.go
+++ b/pkg/storage/gcp/getter.go
@@ -13,8 +13,8 @@ import (
 //
 // The caller is responsible for calling close on the Zip ReadCloser
 func (s *Storage) Get(module, version string) (*storage.Version, error) {
-	ctx := context.Background()
-	if exists := s.Exists(context.TODO(), module, version); !exists {
+	ctx := context.TODO()
+	if exists := s.Exists(ctx, module, version); !exists {
 		return nil, storage.ErrVersionNotFound{Module: module, Version: version}
 	}
 

--- a/pkg/storage/gcp/getter.go
+++ b/pkg/storage/gcp/getter.go
@@ -14,7 +14,7 @@ import (
 // The caller is responsible for calling close on the Zip ReadCloser
 func (s *Storage) Get(module, version string) (*storage.Version, error) {
 	ctx := context.Background()
-	if exists := s.Exists(module, version); !exists {
+	if exists := s.Exists(context.TODO(), module, version); !exists {
 		return nil, storage.ErrVersionNotFound{Module: module, Version: version}
 	}
 

--- a/pkg/storage/gcp/saver.go
+++ b/pkg/storage/gcp/saver.go
@@ -18,7 +18,7 @@ import (
 // Uploaded files are publicly accessable in the storage bucket as per
 // an ACL rule.
 func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
-	if exists := s.Exists(module, version); exists {
+	if exists := s.Exists(ctx, module, version); exists {
 		return stg.ErrVersionAlreadyExists{Module: module, Version: version}
 	}
 

--- a/pkg/storage/minio/checker.go
+++ b/pkg/storage/minio/checker.go
@@ -1,12 +1,13 @@
 package minio
 
 import (
+	"context"
 	"fmt"
 
 	minio "github.com/minio/minio-go"
 )
 
-func (v *storageImpl) Exists(module, version string) bool {
+func (v *storageImpl) Exists(ctx context.Context, module, version string) bool {
 	versionedPath := v.versionLocation(module, version)
 	modPath := fmt.Sprintf("%s/go.mod", versionedPath)
 	_, err := v.minioClient.StatObject(v.bucketName, modPath, minio.StatObjectOptions{})

--- a/pkg/storage/minio/deleter.go
+++ b/pkg/storage/minio/deleter.go
@@ -1,13 +1,14 @@
 package minio
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gomods/athens/pkg/storage"
 )
 
-func (v *storageImpl) Delete(module, version string) error {
-	if !v.Exists(module, version) {
+func (v *storageImpl) Delete(ctx context.Context, module, version string) error {
+	if !v.Exists(ctx, module, version) {
 		return storage.ErrVersionNotFound{
 			Module:  module,
 			Version: version,

--- a/pkg/storage/mongo/checker.go
+++ b/pkg/storage/mongo/checker.go
@@ -1,11 +1,13 @@
 package mongo
 
 import (
+	"context"
+
 	"github.com/globalsign/mgo/bson"
 )
 
 // Exists checks for a specific version of a module
-func (s *ModuleStore) Exists(module, vsn string) bool {
+func (s *ModuleStore) Exists(ctx context.Context, module, vsn string) bool {
 	c := s.s.DB(s.d).C(s.c)
 	count, err := c.Find(bson.M{"module": module, "version": vsn}).Count()
 	return err == nil && count > 0

--- a/pkg/storage/mongo/deleter.go
+++ b/pkg/storage/mongo/deleter.go
@@ -1,13 +1,15 @@
 package mongo
 
 import (
+	"context"
+
 	"github.com/globalsign/mgo/bson"
 	"github.com/gomods/athens/pkg/storage"
 )
 
 // Delete removes a specific version of a module
-func (s *ModuleStore) Delete(module, version string) error {
-	if !s.Exists(module, version) {
+func (s *ModuleStore) Delete(ctx context.Context, module, version string) error {
+	if !s.Exists(ctx, module, version) {
 		return storage.ErrVersionNotFound{
 			Module:  module,
 			Version: version,

--- a/pkg/storage/rdbms/checker.go
+++ b/pkg/storage/rdbms/checker.go
@@ -1,11 +1,13 @@
 package rdbms
 
 import (
+	"context"
+
 	"github.com/gomods/athens/pkg/storage/rdbms/models"
 )
 
 // Exists checks for a specific version of a module
-func (r *ModuleStore) Exists(module, vsn string) bool {
+func (r *ModuleStore) Exists(ctx context.Context, module, vsn string) bool {
 	result := models.Module{}
 	query := r.conn.Where("module = ?", module).Where("version = ?", vsn)
 	count, err := query.Count(&result)

--- a/pkg/storage/rdbms/deleter.go
+++ b/pkg/storage/rdbms/deleter.go
@@ -1,13 +1,15 @@
 package rdbms
 
 import (
+	"context"
+
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/gomods/athens/pkg/storage/rdbms/models"
 )
 
 // Delete removes a specific version of a module.
-func (r *ModuleStore) Delete(module, version string) error {
-	if !r.Exists(module, version) {
+func (r *ModuleStore) Delete(ctx context.Context, module, version string) error {
+	if !r.Exists(ctx, module, version) {
 		return storage.ErrVersionNotFound{
 			Module:  module,
 			Version: version,

--- a/pkg/storage/storage_tests/module_storage/storage_test.go
+++ b/pkg/storage/storage_tests/module_storage/storage_test.go
@@ -149,10 +149,11 @@ func (d *TestSuites) testDelete(ts storage.TestSuite) {
 			version: version,
 		},
 	}
+	ctx := context.Background()
 	for _, test := range tests {
-		err := ts.Storage().Delete(test.module, test.version)
+		err := ts.Storage().Delete(ctx, test.module, test.version)
 		r.Equal(test.want, err)
-		exists := ts.Storage().Exists(test.module, test.version)
+		exists := ts.Storage().Exists(ctx, test.module, test.version)
 		r.Equal(false, exists)
 	}
 }


### PR DESCRIPTION
This PR touches lots of files, but each one only has a few mechanical changes.

Note: I did `Exists` and `Delete` at the same time since every `Delete` function calls `Exists`. This way, we can avoid having this PR add `context.TODO()` everywhere and needing another PR to update those lines again.

Part of #174.