### PR TITLE
Finish spans in the download handlers

### DIFF
--- a/pkg/download/list.go
+++ b/pkg/download/list.go
@@ -19,8 +19,7 @@ const PathList = "/{module:.+}/@v/list"
 func ListHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) func(c buffalo.Context) error {
 	const op errors.Op = "download.ListHandler"
 	return func(c buffalo.Context) error {
-		sp := buffet.SpanFromContext(c)
-		sp.SetOperationName("listHandler")
+		sp := buffet.SpanFromContext(c).SetOperationName("listHandler")
 		defer sp.Finish()
 		mod, err := paths.GetModule(c)
 		if err != nil {

--- a/pkg/download/version_info.go
+++ b/pkg/download/version_info.go
@@ -17,10 +17,9 @@ const PathVersionInfo = "/{module:.+}/@v/{version}.info"
 
 // VersionInfoHandler implements GET baseURL/module/@v/version.info
 func VersionInfoHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) buffalo.Handler {
+	const op errors.Op = "download.versionInfoHandler"
 	return func(c buffalo.Context) error {
-		const op errors.Op = "download.versionInfoHandler"
-		sp := buffet.SpanFromContext(c)
-		sp.SetOperationName("versionInfoHandler")
+		sp := buffet.SpanFromContext(c).SetOperationName("versionInfoHandler")
 		defer sp.Finish()
 		mod, ver, verInfo, err := getModuleVersion(c, lggr, dp)
 		if err != nil {

--- a/pkg/download/version_module.go
+++ b/pkg/download/version_module.go
@@ -15,10 +15,9 @@ const PathVersionModule = "/{module:.+}/@v/{version}.mod"
 
 // VersionModuleHandler implements GET baseURL/module/@v/version.mod
 func VersionModuleHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) buffalo.Handler {
+	const op errors.Op = "download.VersionModuleHandler"
 	return func(c buffalo.Context) error {
-		const op errors.Op = "download.VersionModuleHandler"
-		sp := buffet.SpanFromContext(c)
-		sp.SetOperationName("versionModuleHandler")
+		sp := buffet.SpanFromContext(c).SetOperationName("VersionModuleHandler")
 		defer sp.Finish()
 		mod, ver, verInfo, err := getModuleVersion(c, lggr, dp)
 		if err != nil {

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -19,8 +19,7 @@ func VersionZipHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) buffal
 	const op errors.Op = "download.VersionZipHandler"
 
 	return func(c buffalo.Context) error {
-		sp := buffet.SpanFromContext(c)
-		sp.SetOperationName("versionZipHandler")
+		sp := buffet.SpanFromContext(c).SetOperationName("versionZipHandler")
 		defer sp.Finish()
 		mod, ver, verInfo, err := getModuleVersion(c, lggr, dp)
 		if err != nil {


### PR DESCRIPTION
I don't know a ton about buffet and the opentracing library, but I saw that we're calling `defer sp.Finish()` in other parts of the code, so I figured we should do it here too.

cc/ @manugupt1 @robjloranger