### PR TITLE
Ensure diskRef cleans up everything in it's own GOPATH

### DIFF
--- a/pkg/module/disk_ref.go
+++ b/pkg/module/disk_ref.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -56,24 +55,16 @@ func (d *diskRef) Read() (*storage.Version, error) {
 	var ver storage.Version
 
 	packagePath := getPackagePath(d.root, d.module)
-	infoFile, err := d.fs.Open(filepath.Join(packagePath, fmt.Sprintf("%s.info", d.version)))
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	defer infoFile.Close()
 
-	info, err := ioutil.ReadAll(infoFile)
+	infoFile := filepath.Join(packagePath, fmt.Sprintf("%s.info", d.version))
+	info, err := afero.ReadFile(d.fs, infoFile)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	ver.Info = info
 
-	modFile, err := d.fs.Open(filepath.Join(packagePath, fmt.Sprintf("%s.mod", d.version)))
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	defer modFile.Close()
-	mod, err := ioutil.ReadAll(modFile)
+	modFile := filepath.Join(packagePath, fmt.Sprintf("%s.mod", d.version))
+	mod, err := afero.ReadFile(d.fs, modFile)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/module/disk_ref.go
+++ b/pkg/module/disk_ref.go
@@ -3,6 +3,7 @@ package module
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/gomods/athens/pkg/storage"
@@ -15,14 +16,16 @@ import (
 // Do not create this struct directly. use newDiskRef
 type diskRef struct {
 	root    string
+	module  string
 	fs      afero.Fs
 	version string
 }
 
-func newDiskRef(fs afero.Fs, root, version string) *diskRef {
+func newDiskRef(fs afero.Fs, root, module, version string) *diskRef {
 	return &diskRef{
 		fs:      fs,
 		root:    root,
+		module:  module,
 		version: version,
 	}
 }
@@ -31,6 +34,20 @@ func newDiskRef(fs afero.Fs, root, version string) *diskRef {
 //
 // You should always call this function after you fetch a module into a DiskRef
 func (d *diskRef) Clear() error {
+
+	// This is required because vgo ensures dependencies are read-only
+	// See https://github.com/golang/go/issues/24111 and
+	// https://go-review.googlesource.com/c/vgo/+/96978
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return d.fs.Chmod(path, 0770)
+	}
+	err := afero.Walk(d.fs, d.root, walkFn)
+	if err != nil {
+		return err
+	}
 	return d.fs.RemoveAll(d.root)
 }
 
@@ -38,7 +55,8 @@ func (d *diskRef) Clear() error {
 func (d *diskRef) Read() (*storage.Version, error) {
 	var ver storage.Version
 
-	infoFile, err := d.fs.Open(filepath.Join(d.root, fmt.Sprintf("%s.info", d.version)))
+	packagePath := getPackagePath(d.root, d.module)
+	infoFile, err := d.fs.Open(filepath.Join(packagePath, fmt.Sprintf("%s.info", d.version)))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -50,7 +68,7 @@ func (d *diskRef) Read() (*storage.Version, error) {
 	}
 	ver.Info = info
 
-	modFile, err := d.fs.Open(filepath.Join(d.root, fmt.Sprintf("%s.mod", d.version)))
+	modFile, err := d.fs.Open(filepath.Join(packagePath, fmt.Sprintf("%s.mod", d.version)))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -61,7 +79,7 @@ func (d *diskRef) Read() (*storage.Version, error) {
 	}
 	ver.Mod = mod
 
-	sourceFile, err := d.fs.Open(filepath.Join(d.root, fmt.Sprintf("%s.zip", d.version)))
+	sourceFile, err := d.fs.Open(filepath.Join(packagePath, fmt.Sprintf("%s.zip", d.version)))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -29,30 +29,25 @@ func NewGoGetFetcher(goBinaryName string, fs afero.Fs) Fetcher {
 // Fetch downloads the sources and returns path where it can be found. Make sure to call Clear
 // on the returned Ref when you are done with it
 func (g *goGetFetcher) Fetch(mod, ver string) (Ref, error) {
-	ref := noopRef{}
 
 	// setup the GOPATH
 	goPathRoot, err := afero.TempDir(g.fs, "", "athens")
 	if err != nil {
-		ref.Clear()
 		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 	sourcePath := filepath.Join(goPathRoot, "src")
 	modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
 	if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
-		ref.Clear()
 		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 
 	// setup the module with barebones stuff
 	if err := Dummy(g.fs, modPath); err != nil {
-		ref.Clear()
 		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 
 	err = getSources(g.goBinaryName, g.fs, goPathRoot, modPath, mod, ver)
 	if err != nil {
-		ref.Clear()
 		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -33,22 +33,28 @@ func (g *goGetFetcher) Fetch(mod, ver string) (Ref, error) {
 	// setup the GOPATH
 	goPathRoot, err := afero.TempDir(g.fs, "", "athens")
 	if err != nil {
-		return newDiskRef(g.fs, goPathRoot, "", ""), err
+		return nil, err
 	}
 	sourcePath := filepath.Join(goPathRoot, "src")
 	modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
 	if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
-		return newDiskRef(g.fs, goPathRoot, "", ""), err
+		diskRef := newDiskRef(g.fs, goPathRoot, "", "")
+		diskRef.Clear()
+		return nil, err
 	}
 
 	// setup the module with barebones stuff
 	if err := Dummy(g.fs, modPath); err != nil {
-		return newDiskRef(g.fs, goPathRoot, "", ""), err
+		diskRef := newDiskRef(g.fs, goPathRoot, "", "")
+		diskRef.Clear()
+		return nil, err
 	}
 
 	err = getSources(g.goBinaryName, g.fs, goPathRoot, modPath, mod, ver)
 	if err != nil {
-		return newDiskRef(g.fs, goPathRoot, "", ""), err
+		diskRef := newDiskRef(g.fs, goPathRoot, "", "")
+		diskRef.Clear()
+		return nil, err
 	}
 
 	return newDiskRef(g.fs, goPathRoot, mod, ver), nil

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -34,38 +34,29 @@ func (g *goGetFetcher) Fetch(mod, ver string) (Ref, error) {
 	// setup the GOPATH
 	goPathRoot, err := afero.TempDir(g.fs, "", "athens")
 	if err != nil {
-		// TODO: return a ref for cleaning up the goPathRoot
-		// https://github.com/gomods/athens/issues/329
 		ref.Clear()
-		return ref, err
+		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 	sourcePath := filepath.Join(goPathRoot, "src")
 	modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
 	if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
-		// TODO: return a ref for cleaning up the goPathRoot
-		// https://github.com/gomods/athens/issues/329
 		ref.Clear()
-		return ref, err
+		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 
 	// setup the module with barebones stuff
 	if err := Dummy(g.fs, modPath); err != nil {
-		// TODO: return a ref for cleaning up the goPathRoot
-		// https://github.com/gomods/athens/issues/329
 		ref.Clear()
-		return ref, err
+		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 
-	cachePath, err := getSources(g.goBinaryName, g.fs, goPathRoot, modPath, mod, ver)
+	err = getSources(g.goBinaryName, g.fs, goPathRoot, modPath, mod, ver)
 	if err != nil {
-		// TODO: return a ref that cleans up the goPathRoot
-		// https://github.com/gomods/athens/issues/329
 		ref.Clear()
-		return nil, err
+		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
-	// TODO: make sure this ref also cleans up the goPathRoot
-	// https://github.com/gomods/athens/issues/329
-	return newDiskRef(g.fs, cachePath, ver), err
+
+	return newDiskRef(g.fs, goPathRoot, mod, ver), err
 }
 
 // Dummy Hacky thing makes vgo not to complain
@@ -86,10 +77,8 @@ func Dummy(fs afero.Fs, repoRoot string) error {
 }
 
 // given a filesystem, gopath, repository root, module and version, runs 'vgo get'
-// on module@version from the repoRoot with GOPATH=gopath, and returns the location
-// of the module cache. returns a non-nil error if anything went wrong. always returns
-// the location of the module cache so you can delete it if necessary
-func getSources(goBinaryName string, fs afero.Fs, gopath, repoRoot, module, version string) (string, error) {
+// on module@version from the repoRoot with GOPATH=gopath, and returns a non-nil error if anything went wrong.
+func getSources(goBinaryName string, fs afero.Fs, gopath, repoRoot, module, version string) error {
 	uri := strings.TrimSuffix(module, "/")
 
 	fullURI := fmt.Sprintf("%s@%s", uri, version)
@@ -104,21 +93,19 @@ func getSources(goBinaryName string, fs afero.Fs, gopath, repoRoot, module, vers
 	// this breaks windows.
 	cmd.Env = []string{"PATH=" + os.Getenv("PATH"), gopathEnv, cacheEnv, disableCgo, enableGoModules}
 	cmd.Dir = repoRoot
-
-	packagePath := filepath.Join(gopath, "src", "mod", "cache", "download", module, "@v")
-
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		errMsg := fmt.Sprintf("%v : %s", err, o)
 		// github quota exceeded
 		if isLimitHit(o) {
-			return packagePath, errors.E("module.getSources", errMsg, errors.KindRateLimit)
+			return errors.E("module.getSources", errMsg, errors.KindRateLimit)
 		}
 		// another error in the output
-		return packagePath, errors.E("module.getSources", errMsg)
+		return errors.E("module.getSources", errMsg)
 	}
 	// make sure the expected files exist
-	return packagePath, checkFiles(fs, packagePath, version)
+	packagePath := getPackagePath(gopath, module)
+	return checkFiles(fs, packagePath, version)
 }
 
 func checkFiles(fs afero.Fs, path, version string) error {
@@ -146,4 +133,9 @@ func isLimitHit(o []byte) bool {
 func getRepoDirName(repoURI, version string) string {
 	escapedURI := strings.Replace(repoURI, "/", "-", -1)
 	return fmt.Sprintf("%s-%s", escapedURI, version)
+}
+
+// getPackagePath returns the path to the module cache given the gopath and module name
+func getPackagePath(gopath, module string) string {
+	return filepath.Join(gopath, "src", "mod", "cache", "download", module, "@v")
 }

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -56,7 +56,7 @@ func (g *goGetFetcher) Fetch(mod, ver string) (Ref, error) {
 		return newDiskRef(g.fs, goPathRoot, "", ""), err
 	}
 
-	return newDiskRef(g.fs, goPathRoot, mod, ver), err
+	return newDiskRef(g.fs, goPathRoot, mod, ver), nil
 }
 
 // Dummy Hacky thing makes vgo not to complain

--- a/pkg/module/go_get_fetcher_test.go
+++ b/pkg/module/go_get_fetcher_test.go
@@ -1,8 +1,9 @@
 package module
 
 import (
-	"github.com/spf13/afero"
 	"io/ioutil"
+
+	"github.com/spf13/afero"
 )
 
 func (s *ModuleSuite) TestNewGoGetFetcher() {


### PR DESCRIPTION
This PR addresses https://github.com/gomods/athens/issues/329

Adding info about the root dir and module name to the diskRef and adding the `getPackagePath` function to construct the path to the cached module seemed the cleanest way to achieve what was desired - though I'm open to suggestions for a cleaner implementation :)

Edit - #329 was closed in favor of #318 