### PR TITLE
Make it easier to run all the same commands that Travis does 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,9 @@ env:
     - CODE_COV=1
     - GO_BINARY_PATH=vgo
 before_script:
-  - mkdir bin
-  - go get github.com/golang/lint/golint
-  - go get github.com/golang/dep/cmd/dep
+  - make setup-dev-env
   - wget "https://dl.minio.io/server/minio/release/linux-amd64/minio"
   - chmod +x minio && nohup ./minio server . &
-  - ./scripts/get_buffalo.sh
-  - go get -u -v golang.org/x/vgo
   - buffalo db create
   - buffalo db migrate up
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
     - CODE_COV=1
     - GO_BINARY_PATH=vgo
+    - TMPDIR=/tmp/
 before_script:
   - make setup-dev-env
   - wget "https://dl.minio.io/server/minio/release/linux-amd64/minio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,8 @@ env:
     - ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
     - CODE_COV=1
     - GO_BINARY_PATH=vgo
-script:
-  - test -z $(gofmt -s -l $GO_FILES | tee /dev/stderr)            # Fail if a .go file hasn't been formatted with gofmt
-  - golint -set_exit_status $(go list ./... | grep -v '/mocks')   # Linter
-  - ./scripts/check_deps.sh                                       # Check for Gopkg.* in PR and run dep ensure -dry-run on changes
-  - go test -race -coverprofile cover.out -covermode atomic ./... # Run all the tests with the race detector and code coverage enabled
 before_script:
   - mkdir bin
-  - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)   # All the .go files, excluding vendor/
   - go get github.com/golang/lint/golint
   - go get github.com/golang/dep/cmd/dep
   - wget "https://dl.minio.io/server/minio/release/linux-amd64/minio"
@@ -32,6 +26,8 @@ before_script:
   - go get -u -v golang.org/x/vgo
   - buffalo db create
   - buffalo db migrate up
+script:
+  - make verify test-unit
 after_success:
   - if [ "${CODE_COV}" == "1" ]; then
       curl -s https://codecov.io/bash -o codecov && bash codecov -X fix;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+Hurray! We are glad that you want to contribute to our project! 👍
+
+## Verify your work
+Run `make verify` to run all the same validations that our CI process runs, such
+as checking that the standard go formatting is applied, linting, etc.
+
+## Unit Tests
+Run `make test-unit` to run the unit tests.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,11 @@ this framework to make it as straightforward as possible to get your development
 You'll need Buffalo [v0.12.4](https://github.com/gobuffalo/buffalo/releases/tag/v0.12.4) or later to get started on Athens,
 so be sure to download the CLI and put it into your `PATH`.
 
+See our [Contributing Guide](CONTRIBUTING.md) for tips on how to submit a pull request when you are ready.
+
+# Initial Development Environment Setup
+Athens relies on having a few tools installed locally. Run `make setup-dev-env` to install them.
+
 # Services that Athens Needs
 
 Both the proxy and the registry rely on several services (i.e. databases, etc...) to function

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,20 @@ run: build
 docs:
 	cd docs && hugo
 
+.PHONY: verify
+verify:
+	./scripts/check_gofmt.sh
+	./scripts/check_golint.sh
+	./scripts/check_deps.sh
+
 .PHONY: test
 test:
 	cd cmd/proxy && buffalo test
 	cd cmd/olympus && buffalo test
+
+.PHONY: test-unit
+test-unit:
+	./scripts/test_unit.sh
 
 .PHONY: olympus-docker
 olympus-docker:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ run: build
 docs:
 	cd docs && hugo
 
+.PHONY: setup-dev-env
+setup-dev-env:
+	./scripts/get_dev_tools.sh
+
 .PHONY: verify
 verify:
 	./scripts/check_gofmt.sh

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -10,6 +10,7 @@
 # with the -dry-run option to check for any conflicts in versions or digests
 # which on any exit code > 0 would suggest that action should be taken
 # before a pull request can be merged.
+set -xeuo pipefail
 
 ChangedFiles=`git diff --name-only master`
 

--- a/scripts/check_gofmt.sh
+++ b/scripts/check_gofmt.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# check_gofmt.sh
+# Fail if a .go file hasn't been formatted with gofmt
+set -euo pipefail
+
+GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)   # All the .go files, excluding vendor/
+test -z $(gofmt -s -l $GO_FILES | tee /dev/stderr)

--- a/scripts/check_golint.sh
+++ b/scripts/check_golint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# check_golint.sh
+# Run the linter on everything except generated code
+set -euo pipefail
+
+golint -set_exit_status $(go list ./... | grep -v '/mocks')

--- a/scripts/get_buffalo.sh
+++ b/scripts/get_buffalo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 TAR_GZ="buffalo_0.12.3_linux_amd64.tar.gz"
 BUFFALO_URL="https://github.com/gobuffalo/buffalo/releases/download/v0.12.3/${TAR_GZ}"
 BUFFALO_TARGET_BIN="./bin/buffalo"

--- a/scripts/get_buffalo.sh
+++ b/scripts/get_buffalo.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 TAR_GZ="buffalo_0.12.3_linux_amd64.tar.gz"
 BUFFALO_URL="https://github.com/gobuffalo/buffalo/releases/download/v0.12.3/${TAR_GZ}"
 BUFFALO_TARGET_BIN="./bin/buffalo"
 
-curl -L -o ${TAR_GZ} ${BUFFALO_URL}
-tar -xvf ${TAR_GZ}
-mv buffalo-no-sqlite ${BUFFALO_TARGET_BIN}
+curl -L -o ${TMPDIR}${TAR_GZ} ${BUFFALO_URL}
+tar -xzf ${TMPDIR}${TAR_GZ} -C ${TMPDIR}
+mkdir -p $(dirname ${BUFFALO_TARGET_BIN})
+mv ${TMPDIR}/buffalo-no-sqlite ${BUFFALO_TARGET_BIN}
 chmod +x ${BUFFALO_TARGET_BIN}

--- a/scripts/get_dev_tools.sh
+++ b/scripts/get_dev_tools.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# install_dev_deps.sh
+# Ensure that the tools needed to build locally are present
+set -xeuo pipefail
+
+go get github.com/golang/lint/golint
+go get github.com/golang/dep/cmd/dep
+go get -u -v golang.org/x/vgo
+./scripts/get_buffalo.sh

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# test_all.sh
-# Run all the tests with the race detector and code coverage enabled
+# test_unit.sh
+# Run the unit tests with the race detector and code coverage enabled
 set -xeuo pipefail
 
 go test -race -coverprofile cover.out -covermode atomic ./...

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# test_all.sh
+# Run all the tests with the race detector and code coverage enabled
+set -xeuo pipefail
+
+go test -race -coverprofile cover.out -covermode atomic ./...


### PR DESCRIPTION
* Extract the commands from `.travis.yml` into `./scripts/`
* Add targets to our make file to run groups of scripts
* Changed the buffalo install so that it doesn't do all it's dirty work in the repo repo, because it modifies existing files like our license and readme
* Add a contributing guide that explains our new make targets