### PR TITLE
Run E2E tests during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 services:
-  - mongodb
-  - postgresql
-  - redis-server
+  - docker
 language: go
 install: false
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - buffalo db create
   - buffalo db migrate up
 script:
-  - make verify test-unit
+  - make verify test-unit test-e2e
 after_success:
   - if [ "${CODE_COV}" == "1" ]; then
       curl -s https://codecov.io/bash -o codecov && bash codecov -X fix;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ env:
     - MINIO_SECRET_KEY=minio123
     - ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
     - CODE_COV=1
-    - GO_BINARY_PATH=vgo
     - TMPDIR=/tmp/
+    - GO_SOURCE=${TMPDIR}go
+    - GO_BINARY_PATH=${TMPDIR}go/bin/go
 before_script:
   - make setup-dev-env
   - wget "https://dl.minio.io/server/minio/release/linux-amd64/minio"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,23 @@ Hurray! We are glad that you want to contribute to our project! 👍
 Run `make verify` to run all the same validations that our CI process runs, such
 as checking that the standard go formatting is applied, linting, etc.
 
+## Setup your dev environment
+
+Run `make setup-dev-env` to install local developer tools and run necessary
+services, such as mongodb, for the end-to-end tests.
+
 ## Unit Tests
 Run `make test-unit` to run the unit tests.
+
+## End-to-End Tests
+End-to-End tests (e2e) are tests from the user perspective that validate that
+everything works when running real live servers, and using `go` with GOPROXY set.
+
+Run `make test-e2e` to run the end-to-end tests.
+
+The first time you run the tests,
+you must run `make setup-dev-env` first, otherwise you will see errors like the one below:
+
+```
+error connecting to storage (no reachable servers)
+```

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ test:
 test-unit:
 	./scripts/test_unit.sh
 
+.PHONY: test-e2e
+test-e2e:
+	./scripts/test_e2e.sh
+
 .PHONY: olympus-docker
 olympus-docker:
 	docker build -t gopackages/olympus -f cmd/olympus/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ docs:
 .PHONY: setup-dev-env
 setup-dev-env:
 	./scripts/get_dev_tools.sh
+	$(MAKE) dev
 
 .PHONY: verify
 verify:

--- a/scripts/get_dev_tools.sh
+++ b/scripts/get_dev_tools.sh
@@ -8,9 +8,11 @@ go get github.com/golang/lint/golint
 go get github.com/golang/dep/cmd/dep
 
 GO_VERSION="go1.11beta2"
-GO_SOURCE=$(go env GOPATH)/src/golang.org/x/go
+GO_SOURCE=${GO_SOURCE:=$(go env GOPATH)/src/golang.org/x/go}
 mkdir -p $(dirname $GO_SOURCE)
-git clone https://go.googlesource.com/go $GO_SOURCE
+if [[ ! -d $GO_SOURCE ]]; then
+  git clone https://go.googlesource.com/go $GO_SOURCE
+fi
 pushd $GO_SOURCE
 git checkout $GO_VERSION
 cd src && ./make.bash

--- a/scripts/get_dev_tools.sh
+++ b/scripts/get_dev_tools.sh
@@ -6,5 +6,14 @@ set -xeuo pipefail
 
 go get github.com/golang/lint/golint
 go get github.com/golang/dep/cmd/dep
-go get -u -v golang.org/x/vgo
+
+GO_VERSION="go1.11beta2"
+GO_SOURCE=$(go env GOPATH)/src/golang.org/x/go
+mkdir -p $(dirname $GO_SOURCE)
+git clone https://go.googlesource.com/go $GO_SOURCE
+pushd $GO_SOURCE
+git checkout $GO_VERSION
+cd src && ./make.bash
+popd
+
 ./scripts/get_buffalo.sh

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# test_e2e.sh
+# Execute end-to-end (e2e) tests to verify that everything is working right
+# from the end user perpsective
+set -xeuo pipefail
+
+REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
+
+# Use a version of Go that supports Go Modules
+export GO111MODULES=on
+GOMOD_CACHE=$(go env GOPATH)/src/mod
+GO_SOURCE=${GO_SOURCE:=$(go env GOPATH)/src/golang.org/x/go}
+export GOROOT=${GO_SOURCE}
+export PATH=${GO_SOURCE}/bin:${PATH}
+go version
+
+clearGoModCache () {
+  # The sudo is a necessary workaround until go is fixed
+  sudo rm -fr ${GOMOD_CACHE}
+}
+
+teardown () {
+  # Cleanup after our tests
+  pkill buffalo || true
+  popd 2> /dev/null || true
+}
+trap teardown EXIT
+
+# Start the proxy in the background and wait for it to be ready
+export GO_BINARY_PATH=${GO_SOURCE}/bin/go
+cd $REPO_DIR/cmd/proxy
+pkill buffalo || true # cleanup old buffalos
+buffalo dev &
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:3000)" != "200" ]]; do sleep 5; done
+
+# Clone our test repo
+TEST_SOURCE=${TMPDIR}go-depmgmt-testrepo
+rm -fr ${TEST_SOURCE} 2> /dev/null || true
+git clone https://github.com/carolynvs/go-depmgmt-testrepo.git ${TEST_SOURCE}
+pushd ${TEST_SOURCE}
+
+clearGoModCache
+
+# Make sure that our test repo works without the GOPROXY first
+unset GOPROXY
+go run main.go
+
+clearGoModCache
+
+# Verify that the test works against the proxy
+export GOPROXY=http://localhost:3000
+go run main.go

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -12,7 +12,7 @@ export GO111MODULES=on
 GOMOD_CACHE=$(go env GOPATH)/src/mod
 GO_SOURCE=${GO_SOURCE:=$(go env GOPATH)/src/golang.org/x/go}
 export GOROOT=${GO_SOURCE}
-export PATH=${GO_SOURCE}/bin:${PATH}
+export PATH=${GO_SOURCE}/bin:${REPO_DIR}/bin:${PATH}
 go version
 
 clearGoModCache () {


### PR DESCRIPTION
* Add `./scripts/test_e2e.sh` which builds a go program that relies on go modules using GOPROXY.
* Add `make test-e2e` target and document it. It's important to run `make setup-dev-env` once, before running the tests.
* Use the same setup for travis and local development for the storage services

Closes #353 