### PR TITLE
goget cache: its a moving target

### DIFF
--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -146,5 +146,5 @@ func getRepoDirName(repoURI, version string) string {
 
 // getPackagePath returns the path to the module cache given the gopath and module name
 func getPackagePath(gopath, module string) string {
-	return filepath.Join(gopath, "src", "mod", "cache", "download", module, "@v")
+	return filepath.Join(gopath, "pkg", "mod", "cache", "download", module, "@v")
 }


### PR DESCRIPTION
Go caches its modules inside of `GOPATH/pkg` instead of `GOPATH/src` similar to dep. 

Commit: https://github.com/golang/go/commit/b8f42d74e87aeec189f53e9fdb2a7e6026c099b1#diff-18bbe9fc05441fe3191725c83637e767