### PR TITLE
Goget Fetcher should error out if gobinpath is not valid

### DIFF
--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -113,7 +113,11 @@ func App(config *AppConfig) (*buffalo.App, error) {
 	app.POST("/push", pushNotificationHandler(w))
 
 	// Download Protocol
-	dp := download.New(goget.New(), config.Storage)
+	gg, err := goget.New()
+	if err != nil {
+		return nil, err
+	}
+	dp := download.New(gg, config.Storage)
 	app.GET(download.PathList, download.ListHandler(dp, lggr, renderEng))
 	app.GET(download.PathVersionInfo, download.VersionInfoHandler(dp, lggr, renderEng))
 	app.GET(download.PathVersionModule, download.VersionModuleHandler(dp, lggr, renderEng))

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -17,7 +17,11 @@ func addProxyRoutes(
 ) error {
 	app.GET("/", proxyHomeHandler)
 
-	dp := download.New(goget.New(), storage)
+	gg, err := goget.New()
+	if err != nil {
+		return err
+	}
+	dp := download.New(gg, storage)
 	// Download Protocol
 	app.GET(download.PathList, download.ListHandler(dp, lggr, proxy))
 	app.GET(download.PathLatest, download.LatestHandler(dp, lggr, proxy))

--- a/pkg/download/goget/goget.go
+++ b/pkg/download/goget/goget.go
@@ -22,15 +22,23 @@ import (
 // New returns a download protocol by using
 // go get. You must have a modules supported
 // go binary for this to work.
-func New() download.Protocol {
-	return &goget{
-		goBinPath: env.GoBinPath(),
-		fs:        afero.NewOsFs(),
+func New() (download.Protocol, error) {
+	goBin := env.GoBinPath()
+	fs := afero.NewOsFs()
+	mf, err := module.NewGoGetFetcher(goBin, fs)
+	if err != nil {
+		return nil, fmt.Errorf("go get fetcher can't be initialised with gobinpath: %s", goBin)
 	}
+	return &goget{
+		goBinPath: goBin,
+		fetcher:   mf,
+		fs:        fs,
+	}, nil
 }
 
 type goget struct {
 	goBinPath string
+	fetcher   module.Fetcher
 	fs        afero.Fs
 }
 
@@ -139,11 +147,7 @@ func (gg *goget) Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error
 
 func (gg *goget) Version(ctx context.Context, mod, ver string) (*storage.Version, error) {
 	const op errors.Op = "goget.Version"
-	fetcher, err := module.NewGoGetFetcher(gg.goBinPath, gg.fs)
-	if err != nil {
-		return nil, errors.E(op, err)
-	}
-	ref, err := fetcher.Fetch(mod, ver)
+	ref, err := gg.fetcher.Fetch(mod, ver)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}

--- a/pkg/download/goget/goget.go
+++ b/pkg/download/goget/goget.go
@@ -23,11 +23,12 @@ import (
 // go get. You must have a modules supported
 // go binary for this to work.
 func New() (download.Protocol, error) {
+	const op errors.Op = "goget.New"
 	goBin := env.GoBinPath()
 	fs := afero.NewOsFs()
 	mf, err := module.NewGoGetFetcher(goBin, fs)
 	if err != nil {
-		return nil, fmt.Errorf("go get fetcher can't be initialised with gobinpath: %s", goBin)
+		return nil, errors.E(op, err)
 	}
 	return &goget{
 		goBinPath: goBin,

--- a/pkg/download/goget/goget.go
+++ b/pkg/download/goget/goget.go
@@ -139,7 +139,10 @@ func (gg *goget) Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error
 
 func (gg *goget) Version(ctx context.Context, mod, ver string) (*storage.Version, error) {
 	const op errors.Op = "goget.Version"
-	fetcher := module.NewGoGetFetcher(gg.goBinPath, gg.fs)
+	fetcher, err := module.NewGoGetFetcher(gg.goBinPath, gg.fs)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
 	ref, err := fetcher.Fetch(mod, ver)
 	if err != nil {
 		return nil, errors.E(op, err)

--- a/pkg/download/goget/goget_test.go
+++ b/pkg/download/goget/goget_test.go
@@ -2,7 +2,13 @@ package goget
 
 import (
 	"context"
+	"os"
 	"testing"
+
+	"github.com/gobuffalo/envy"
+	"github.com/gomods/athens/pkg/config/env"
+	cerrors "github.com/gomods/athens/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 type testCase struct {
@@ -34,4 +40,22 @@ func TestList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVersionBinPathError(t *testing.T) {
+	goPath := env.GoBinPath()
+	os.Setenv("GO_BINARY_PATH", "some_invalid_path")
+	defer os.Setenv("GO_BINARY_PATH", goPath)
+	envy.Reload()
+	defer envy.Reload()
+	const vop cerrors.Op = "module.getSources"
+
+	dp := New()
+
+	v, err := dp.Version(context.Background(), "mod", "version")
+
+	assert.Nil(t, v)
+	cerr, ok := err.(cerrors.Error)
+	assert.True(t, ok)
+	assert.EqualError(t, cerr.Err, "Invalid go binary: exit status 1")
 }

--- a/pkg/download/goget/goget_test.go
+++ b/pkg/download/goget/goget_test.go
@@ -2,12 +2,8 @@ package goget
 
 import (
 	"context"
-	"os"
 	"testing"
 
-	"github.com/gobuffalo/envy"
-	"github.com/gomods/athens/pkg/config/env"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,17 +37,4 @@ func TestList(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestInvalidGoBinError(t *testing.T) {
-	goPath := env.GoBinPath()
-	os.Setenv("GO_BINARY_PATH", "some_invalid_path")
-	defer os.Setenv("GO_BINARY_PATH", goPath)
-	envy.Reload()
-	defer envy.Reload()
-
-	dp, err := New()
-
-	assert.Nil(t, dp)
-	assert.EqualError(t, err, "go get fetcher can't be initialised with gobinpath: some_invalid_path")
 }

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -19,13 +19,13 @@ type goGetFetcher struct {
 }
 
 // NewGoGetFetcher creates fetcher which uses go get tool to fetch modules
-func NewGoGetFetcher(goBinaryName string, fs afero.Fs) (Fetcher, error) {
+func NewGoGetFetcher(goBinaryName string) (Fetcher, error) {
 	const op errors.Op = "module.NewGoGetFetcher"
 	if err := validGoBinary(goBinaryName); err != nil {
 		return nil, errors.E(op, err)
 	}
 	return &goGetFetcher{
-		fs:           fs,
+		fs:           afero.NewOsFs(),
 		goBinaryName: goBinaryName,
 	}, nil
 }

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -19,11 +19,16 @@ type goGetFetcher struct {
 }
 
 // NewGoGetFetcher creates fetcher which uses go get tool to fetch modules
-func NewGoGetFetcher(goBinaryName string, fs afero.Fs) Fetcher {
+func NewGoGetFetcher(goBinaryName string, fs afero.Fs) (Fetcher, error) {
+	cmd := exec.Command("which", goBinaryName)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("Invalid go binary: %v", err)
+	}
 	return &goGetFetcher{
 		fs:           fs,
 		goBinaryName: goBinaryName,
-	}
+	}, nil
 }
 
 // Fetch downloads the sources and returns path where it can be found. Make sure to call Clear

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -19,13 +19,13 @@ type goGetFetcher struct {
 }
 
 // NewGoGetFetcher creates fetcher which uses go get tool to fetch modules
-func NewGoGetFetcher(goBinaryName string) (Fetcher, error) {
+func NewGoGetFetcher(goBinaryName string, fs afero.Fs) (Fetcher, error) {
 	const op errors.Op = "module.NewGoGetFetcher"
 	if err := validGoBinary(goBinaryName); err != nil {
 		return nil, errors.E(op, err)
 	}
 	return &goGetFetcher{
-		fs:           afero.NewOsFs(),
+		fs:           fs,
 		goBinaryName: goBinaryName,
 	}, nil
 }

--- a/pkg/module/go_get_fetcher_test.go
+++ b/pkg/module/go_get_fetcher_test.go
@@ -6,20 +6,18 @@ import (
 
 	"github.com/gomods/athens/pkg/config/env"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/spf13/afero"
 )
 
 func (s *ModuleSuite) TestNewGoGetFetcher() {
 	r := s.Require()
-	fetcher, err := NewGoGetFetcher(s.goBinaryName, s.fs)
+	fetcher, err := NewGoGetFetcher(s.goBinaryName)
 	r.NoError(err)
 	_, ok := fetcher.(*goGetFetcher)
 	r.True(ok)
 }
 
 func (s *ModuleSuite) TestGoGetFetcherError() {
-	fetcher, err := NewGoGetFetcher("invalidpath", afero.NewOsFs())
+	fetcher, err := NewGoGetFetcher("invalidpath")
 
 	assert.Nil(s.T(), fetcher)
 	assert.EqualError(s.T(), err, "exec: \"invalidpath\": executable file not found in $PATH")
@@ -29,7 +27,7 @@ func (s *ModuleSuite) TestGoGetFetcherFetch() {
 	r := s.Require()
 	// we need to use an OS filesystem because fetch executes vgo on the command line, which
 	// always writes to the filesystem
-	fetcher, err := NewGoGetFetcher(s.goBinaryName, afero.NewOsFs())
+	fetcher, err := NewGoGetFetcher(s.goBinaryName)
 	r.NoError(err)
 	ref, err := fetcher.Fetch(repoURI, version)
 	r.NoError(err, "fetch shouldn't error")
@@ -56,7 +54,7 @@ func ExampleFetch() {
 	repoURI := "github.com/arschles/assert"
 	version := "v1.0.0"
 	goBinaryName := env.GoBinPath()
-	fetcher, err := NewGoGetFetcher(goBinaryName, afero.NewOsFs())
+	fetcher, err := NewGoGetFetcher(goBinaryName)
 	ref, err := fetcher.Fetch(repoURI, version)
 	// handle errors if any
 	if err != nil {

--- a/pkg/module/go_get_fetcher_test.go
+++ b/pkg/module/go_get_fetcher_test.go
@@ -6,18 +6,20 @@ import (
 
 	"github.com/gomods/athens/pkg/config/env"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/spf13/afero"
 )
 
 func (s *ModuleSuite) TestNewGoGetFetcher() {
 	r := s.Require()
-	fetcher, err := NewGoGetFetcher(s.goBinaryName)
+	fetcher, err := NewGoGetFetcher(s.goBinaryName, s.fs)
 	r.NoError(err)
 	_, ok := fetcher.(*goGetFetcher)
 	r.True(ok)
 }
 
 func (s *ModuleSuite) TestGoGetFetcherError() {
-	fetcher, err := NewGoGetFetcher("invalidpath")
+	fetcher, err := NewGoGetFetcher("invalidpath", afero.NewOsFs())
 
 	assert.Nil(s.T(), fetcher)
 	assert.EqualError(s.T(), err, "exec: \"invalidpath\": executable file not found in $PATH")
@@ -27,7 +29,7 @@ func (s *ModuleSuite) TestGoGetFetcherFetch() {
 	r := s.Require()
 	// we need to use an OS filesystem because fetch executes vgo on the command line, which
 	// always writes to the filesystem
-	fetcher, err := NewGoGetFetcher(s.goBinaryName)
+	fetcher, err := NewGoGetFetcher(s.goBinaryName, afero.NewOsFs())
 	r.NoError(err)
 	ref, err := fetcher.Fetch(repoURI, version)
 	r.NoError(err, "fetch shouldn't error")
@@ -54,7 +56,7 @@ func ExampleFetch() {
 	repoURI := "github.com/arschles/assert"
 	version := "v1.0.0"
 	goBinaryName := env.GoBinPath()
-	fetcher, err := NewGoGetFetcher(goBinaryName)
+	fetcher, err := NewGoGetFetcher(goBinaryName, afero.NewOsFs())
 	ref, err := fetcher.Fetch(repoURI, version)
 	// handle errors if any
 	if err != nil {

--- a/pkg/module/go_get_fetcher_test.go
+++ b/pkg/module/go_get_fetcher_test.go
@@ -22,7 +22,7 @@ func (s *ModuleSuite) TestGoGetFetcherError() {
 	fetcher, err := NewGoGetFetcher("invalidpath", afero.NewOsFs())
 
 	assert.Nil(s.T(), fetcher)
-	assert.Equal(s.T(), "Invalid go binary: exit status 1", err.Error())
+	assert.EqualError(s.T(), err, "exec: \"invalidpath\": executable file not found in $PATH")
 }
 
 func (s *ModuleSuite) TestGoGetFetcherFetch() {

--- a/pkg/module/go_get_fetcher_test.go
+++ b/pkg/module/go_get_fetcher_test.go
@@ -3,6 +3,7 @@ package module
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 
 	"github.com/gomods/athens/pkg/config/env"
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,9 @@ func ExampleFetch() {
 	version := "v1.0.0"
 	goBinaryName := env.GoBinPath()
 	fetcher, err := NewGoGetFetcher(goBinaryName, afero.NewOsFs())
+	if err != nil {
+		log.Fatal(err)
+	}
 	ref, err := fetcher.Fetch(repoURI, version)
 	// handle errors if any
 	if err != nil {


### PR DESCRIPTION
* Using `which gobinary` to verify whether the given binary exists, and if its invalid application exits. 
* Fixes instantiation of fetcher in each `(gg *goget) Version()` call.

Closes #372.