### PR TITLE
Fetch origin master in order to do deps check

### DIFF
--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -12,7 +12,8 @@
 # before a pull request can be merged.
 set -xeuo pipefail
 
-ChangedFiles=`git diff --name-only master`
+git remote set-branches --add origin master && git fetch
+ChangedFiles=`git diff --name-only origin/master`
 
 # in the casse that ChangedFiles contains Gopkg run dep ensure
 case "$ChangedFiles" in


### PR DESCRIPTION
Response to failed test here: https://github.com/gomods/athens/pull/387
Failed on master arg being ambiguous which happens when the branch is unknown/not fetched.