### PR TITLE
Download: test against controlled repositories

### DIFF
--- a/pkg/download/goget/goget.go
+++ b/pkg/download/goget/goget.go
@@ -75,7 +75,7 @@ func (gg *goget) Latest(ctx context.Context, mod string) (*storage.RevInfo, erro
 	const op errors.Op = "goget.Latest"
 	lr, err := gg.list(op, mod)
 	if err != nil {
-		return nil, err
+		return nil, errors.E(op, err)
 	}
 
 	pseudoInfo := strings.Split(lr.Version, "-")

--- a/pkg/download/goget/goget_test.go
+++ b/pkg/download/goget/goget_test.go
@@ -1,27 +1,35 @@
 package goget
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gomods/athens/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
 
-type testCase struct {
-	name    string
-	mod     string
-	version string
+type listTest struct {
+	name string
+	path string
+	tags []string
 }
 
-// TODO(marwan): we should create Test Repos under github.com/gomods
-// so we can get reproducible results from live VCS repos.
-// For now, I cannot test that github.com/pkg/errors returns v0.8.0
-// from goget.Latest, because they could very well introduce a new tag
-// in the near future.
-var tt = []testCase{
-	{"basic list", "github.com/pkg/errors", "latest"},
-	{"list non tagged", "github.com/marwan-at-work/gowatch", "latest"},
-	{"list vanity", "golang.org/x/tools", "latest"},
+var listTests = []listTest{
+	{
+		name: "happy tags",
+		path: "github.com/athens-artifacts/happy-path",
+		tags: []string{"v0.0.1", "v0.0.2", "v0.0.3"},
+	},
+	{
+		name: "no tags",
+		path: "github.com/athens-artifacts/no-tags",
+	},
 }
 
 func TestList(t *testing.T) {
@@ -29,12 +37,164 @@ func TestList(t *testing.T) {
 	require.NoError(t, err, "failed to create protocol")
 	ctx := context.Background()
 
-	for _, tc := range tt {
+	for _, tc := range listTests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := dp.List(ctx, tc.mod) // TODO ensure list is correct per TODO above.
-			if err != nil {
-				t.Fatal(err)
-			}
+			versions, err := dp.List(ctx, tc.path)
+			require.NoError(t, err)
+			require.EqualValues(t, tc.tags, versions)
 		})
 	}
+}
+
+type latestTest struct {
+	name string
+	path string
+	info *storage.RevInfo
+	err  bool
+}
+
+var latestTests = []latestTest{
+	{
+		name: "happy path",
+		path: "github.com/athens-artifacts/no-tags",
+		info: &storage.RevInfo{
+			Name:    "1a540c5d67ab",
+			Short:   "1a540c5d67ab",
+			Version: "v0.0.0-20180803171426-1a540c5d67ab",
+			Time:    time.Date(2018, 8, 3, 17, 14, 26, 0, time.UTC),
+		},
+	},
+	{
+		name: "tagged latest",
+		path: "github.com/athens-artifacts/happy-path",
+		err:  true,
+	},
+}
+
+func TestLatest(t *testing.T) {
+	dp, err := New()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	for _, tc := range latestTests {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := dp.Latest(ctx, tc.path)
+			if !tc.err && err != nil {
+				t.Fatal(err)
+			} else if tc.err && err == nil {
+				t.Fatalf("expected %v error but got nil", tc.err)
+			}
+
+			require.EqualValues(t, tc.info, info)
+		})
+	}
+}
+
+type infoTest struct {
+	name    string
+	path    string
+	version string
+	info    *storage.RevInfo
+}
+
+var infoTests = []infoTest{
+	{
+		name:    "happy path",
+		path:    "github.com/athens-artifacts/happy-path",
+		version: "v0.0.2",
+		info: &storage.RevInfo{
+			Name:    "3017822275edeb343d2d2a56345f9a58090514d8",
+			Version: "v0.0.2",
+			Short:   "3017822275ed",
+			Time:    time.Date(2018, 8, 3, 3, 45, 19, 0, time.UTC),
+		},
+	},
+	{
+		name:    "pseudo version",
+		path:    "github.com/athens-artifacts/no-tags",
+		version: "v0.0.0-20180803035119-e4e0177efdb5",
+		info: &storage.RevInfo{
+			Name:    "e4e0177efdb573c110217ccb01f2069f961154f3",
+			Version: "v0.0.0-20180803035119-e4e0177efdb5",
+			Short:   "e4e0177efdb5",
+			Time:    time.Date(2018, 8, 3, 3, 51, 19, 0, time.UTC),
+		},
+	},
+}
+
+func TestInfo(t *testing.T) {
+	dp, err := New()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	for _, tc := range infoTests {
+		t.Run(tc.name, func(t *testing.T) {
+			bts, err := dp.Info(ctx, tc.path, tc.version)
+			require.NoError(t, err)
+
+			var info storage.RevInfo
+			dec := json.NewDecoder(bytes.NewReader(bts))
+			dec.DisallowUnknownFields()
+			err = dec.Decode(&info)
+			require.NoError(t, err)
+
+			require.EqualValues(t, tc.info, &info)
+		})
+	}
+}
+
+type modTest struct {
+	name    string
+	path    string
+	version string
+	err     bool
+}
+
+var modTests = []modTest{
+	{
+		name:    "no mod file",
+		path:    "github.com/athens-artifacts/no-tags",
+		version: "v0.0.0-20180803035119-e4e0177efdb5",
+	},
+	{
+		name:    "upstream mod file",
+		path:    "github.com/athens-artifacts/happy-path",
+		version: "v0.0.3",
+	},
+	{
+		name:    "incorrect github repo",
+		path:    "github.com/athens-artifacts/not-exists",
+		version: "v1.0.0",
+		err:     true,
+	},
+}
+
+func TestGoMod(t *testing.T) {
+	dp, err := New()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	for _, tc := range modTests {
+		t.Run(tc.name, func(t *testing.T) {
+			mod, err := dp.GoMod(ctx, tc.path, tc.version)
+			require.Equal(t, tc.err, err != nil, err)
+
+			if tc.err {
+				t.Skip()
+			}
+			expected := getGoldenFile(t, tc.name)
+			require.Equal(t, string(expected), string(mod))
+		})
+	}
+}
+
+func getGoldenFile(t *testing.T, name string) []byte {
+	t.Helper()
+	file := filepath.Join("test_data", strings.Replace(name, " ", "_", -1)+".golden")
+	bts, err := ioutil.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return bts
 }

--- a/pkg/download/goget/test_data/no_mod_file.golden
+++ b/pkg/download/goget/test_data/no_mod_file.golden
@@ -1,0 +1,1 @@
+module github.com/athens-artifacts/no-tags

--- a/pkg/download/goget/test_data/upstream_mod_file.golden
+++ b/pkg/download/goget/test_data/upstream_mod_file.golden
@@ -1,0 +1,3 @@
+module github.com/athens-artifacts/happy-path
+
+require github.com/athens-artifacts/no-tags v0.0.0-20180803171426-1a540c5d67ab


### PR DESCRIPTION
This PR introduces GitHub integration tests to our pkg/download/goget Protocol. This tests that goget is getting the right version data from live repos especially /list and /latest. 

I've created a new organization: github.com/athens-artifacts to store dummy repositories. Please ping me if you'd like write access to it. 

Fixes https://github.com/gomods/athens/issues/340