### PR TITLE
Download: introduce sane Entry defaults

### DIFF
--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -118,10 +118,8 @@ func App(config *AppConfig) (*buffalo.App, error) {
 		return nil, err
 	}
 	dp := download.New(gg, config.Storage)
-	app.GET(download.PathList, download.ListHandler(dp, lggr, renderEng))
-	app.GET(download.PathVersionInfo, download.VersionInfoHandler(dp, lggr, renderEng))
-	app.GET(download.PathVersionModule, download.VersionModuleHandler(dp, lggr, renderEng))
-	app.GET(download.PathVersionZip, download.VersionZipHandler(dp, lggr, renderEng))
+	opts := &download.HandlerOpts{Protocol: dp, Logger: lggr, Engine: renderEng}
+	download.RegisterHandlers(app, opts)
 
 	app.ServeFiles("/", assetsBox) // serve files from the public directory
 

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -11,23 +11,20 @@ import (
 
 func addProxyRoutes(
 	app *buffalo.App,
-	storage storage.Backend,
+	s storage.Backend,
 	mf *module.Filter,
-	lggr *log.Logger,
+	l *log.Logger,
 ) error {
 	app.GET("/", proxyHomeHandler)
 
+	// Download Protocol
 	gg, err := goget.New()
 	if err != nil {
 		return err
 	}
-	dp := download.New(gg, storage)
-	// Download Protocol
-	app.GET(download.PathList, download.ListHandler(dp, lggr, proxy))
-	app.GET(download.PathLatest, download.LatestHandler(dp, lggr, proxy))
-	app.GET(download.PathVersionInfo, download.VersionInfoHandler(dp, lggr, proxy))
-	app.GET(download.PathVersionModule, download.VersionModuleHandler(dp, lggr, proxy))
-	app.GET(download.PathVersionZip, download.VersionZipHandler(dp, lggr, proxy))
+	p := download.New(gg, s)
+	opts := &download.HandlerOpts{Protocol: p, Logger: l, Engine: proxy}
+	download.RegisterHandlers(app, opts)
 
 	return nil
 }

--- a/pkg/download/get_module_versions.go
+++ b/pkg/download/get_module_versions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gomods/athens/pkg/storage"
 )
 
-func getModuleVersion(c buffalo.Context, lggr *log.Logger, dp Protocol) (string, string, *storage.Version, error) {
+func getModuleVersion(c buffalo.Context, lggr log.Entry, dp Protocol) (string, string, *storage.Version, error) {
 	const op errors.Op = "download.getModuleVersion"
 	params, err := paths.GetAllParams(c)
 	if err != nil {

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -1,0 +1,54 @@
+package download
+
+import (
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/buffalo/render"
+	"github.com/gomods/athens/pkg/log"
+	"github.com/sirupsen/logrus"
+)
+
+// ProtocolHandler is a function that takes all that it needs to return
+// a ready-to-go buffalo handler that serves up cmd/go's download protocol.
+type ProtocolHandler func(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler
+
+// HandlerOpts are the generic options
+// for a ProtocolHandler
+type HandlerOpts struct {
+	Protocol Protocol
+	Logger   *log.Logger
+	Engine   *render.Engine
+}
+
+// LogEntryHandler constructs a log.Entry out of the given
+// *log.Logger so that it applies default fields to every single
+// incoming request without having to do those in every single handler.
+// This is like a middleware minus the context magic.
+func LogEntryHandler(ph ProtocolHandler, opts *HandlerOpts) buffalo.Handler {
+	return func(c buffalo.Context) error {
+		req := c.Request()
+		ent := opts.Logger.WithFields(logrus.Fields{
+			"http-method": req.Method,
+			"http-path":   req.URL.Path,
+			"http-url":    req.URL.String(),
+		})
+
+		handler := ph(opts.Protocol, ent, opts.Engine)
+
+		return handler(c)
+	}
+}
+
+// RegisterHandlers is a convenience method that registers
+// all the download protocol paths for you.
+func RegisterHandlers(app *buffalo.App, opts *HandlerOpts) {
+	// If true, this would only panic at boot time, static nil checks anyone?
+	if opts == nil || opts.Protocol == nil || opts.Engine == nil || opts.Logger == nil {
+		panic("absolutely unacceptable handler opts")
+	}
+
+	app.GET(PathList, LogEntryHandler(ListHandler, opts))
+	app.GET(PathLatest, LogEntryHandler(LatestHandler, opts))
+	app.GET(PathVersionInfo, LogEntryHandler(VersionInfoHandler, opts))
+	app.GET(PathVersionModule, LogEntryHandler(VersionModuleHandler, opts))
+	app.GET(PathVersionZip, LogEntryHandler(VersionZipHandler, opts))
+}

--- a/pkg/download/latest.go
+++ b/pkg/download/latest.go
@@ -15,7 +15,7 @@ import (
 const PathLatest = "/{module:.+}/@latest"
 
 // LatestHandler implements GET baseURL/module/@latest
-func LatestHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) func(c buffalo.Context) error {
+func LatestHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.LatestHandler"
 	return func(c buffalo.Context) error {
 		sp := buffet.SpanFromContext(c)

--- a/pkg/download/list.go
+++ b/pkg/download/list.go
@@ -16,7 +16,7 @@ import (
 const PathList = "/{module:.+}/@v/list"
 
 // ListHandler implements GET baseURL/module/@v/list
-func ListHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) func(c buffalo.Context) error {
+func ListHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.ListHandler"
 	return func(c buffalo.Context) error {
 		sp := buffet.SpanFromContext(c).SetOperationName("listHandler")

--- a/pkg/download/version_info.go
+++ b/pkg/download/version_info.go
@@ -16,7 +16,7 @@ import (
 const PathVersionInfo = "/{module:.+}/@v/{version}.info"
 
 // VersionInfoHandler implements GET baseURL/module/@v/version.info
-func VersionInfoHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) buffalo.Handler {
+func VersionInfoHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.versionInfoHandler"
 	return func(c buffalo.Context) error {
 		sp := buffet.SpanFromContext(c).SetOperationName("versionInfoHandler")

--- a/pkg/download/version_module.go
+++ b/pkg/download/version_module.go
@@ -12,7 +12,7 @@ import (
 const PathVersionModule = "/{module:.+}/@v/{version}.mod"
 
 // VersionModuleHandler implements GET baseURL/module/@v/version.mod
-func VersionModuleHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) buffalo.Handler {
+func VersionModuleHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.VersionModuleHandler"
 	return func(c buffalo.Context) error {
 		sp := buffet.SpanFromContext(c).SetOperationName("VersionModuleHandler")

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -14,7 +14,7 @@ import (
 const PathVersionZip = "/{module:.+}/@v/{version}.zip"
 
 // VersionZipHandler implements GET baseURL/module/@v/version.zip
-func VersionZipHandler(dp Protocol, lggr *log.Logger, eng *render.Engine) buffalo.Handler {
+func VersionZipHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.VersionZipHandler"
 
 	return func(c buffalo.Context) error {


### PR DESCRIPTION
Every HTTP request should carry a `log.Field` instead of a `*log.Logger`. A log.Field carries request-specific key-val pairs such as: (http-method, http-path, http-url) and more useful things as we see them fit (such as tracing IDs). 

This means that we can't just pass a *Logger instance to the handlers because we will have to repeat ourselves 5 times (or as many times as we have handlers really). 

This PR abstracts the creation of `*log.Logger` -> `log.Field` without having to magically pass things through buffalo middlwares/Context. 

Fixes https://github.com/gomods/athens/issues/328