### PR TITLE
scripts/get_buffalo.sh: use 'go get' to install outside of Travis

### DIFF
--- a/scripts/get_buffalo.sh
+++ b/scripts/get_buffalo.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
 
-set -xeuo pipefail
+set -xeo pipefail
 
-TAR_GZ="buffalo_0.12.3_linux_amd64.tar.gz"
-BUFFALO_URL="https://github.com/gobuffalo/buffalo/releases/download/v0.12.3/${TAR_GZ}"
-BUFFALO_TARGET_BIN="./bin/buffalo"
+case "$TRAVIS" in
+true)
+	VERSION=0.12.4
+	TAR_GZ="buffalo_${VERSION}_linux_amd64.tar.gz"
+	URL="https://github.com/gobuffalo/buffalo/releases/download/v${VERSION}/${TAR_GZ}"
+	TARGET_BIN="$(pwd)/bin/buffalo"
+	DIR=$(mktemp -d)
 
-curl -L -o ${TMPDIR}${TAR_GZ} ${BUFFALO_URL}
-tar -xzf ${TMPDIR}${TAR_GZ} -C ${TMPDIR}
-mkdir -p $(dirname ${BUFFALO_TARGET_BIN})
-mv ${TMPDIR}/buffalo-no-sqlite ${BUFFALO_TARGET_BIN}
-chmod +x ${BUFFALO_TARGET_BIN}
+	(
+		cd $DIR
+		curl -L -o ${TAR_GZ} ${URL}
+		tar -xzf ${TAR_GZ}
+		mkdir -p $(dirname ${TARGET_BIN})
+		cp buffalo-no-sqlite ${TARGET_BIN}
+		chmod +x ${TARGET_BIN}
+	)
+	rm -r $DIR
+	;;
+*)
+	go get github.com/gobuffalo/buffalo/buffalo
+	;;
+esac


### PR DESCRIPTION
Since CONTRIBUTING.md and DEVELOPMENT.md asks the reader to run
`make setup-dev-env`, which runs this script, it needs to be support
other platforms besides Linux.

Helps #397