### PR TITLE
Proposal: rough description of community roles

### DIFF
--- a/docs/content/intro/community-roles.md
+++ b/docs/content/intro/community-roles.md
@@ -1,0 +1,104 @@
+---
+title: "Participating in the Athens Community"
+date: 2018-02-11T15:57:56-05:00
+---
+
+Absolutely everyone is welcome to join our community at any time! We
+are a friendly and inclusive group and we'd love to have you. We have three roles in the Athens community:
+
+- Community member
+- Contributor
+- Maintainer (we also call this core maintainer sometimes. They're the same thing)
+
+Read on to find out more!
+
+# Community Members
+
+Community members are folks who decide they want to get involved with our
+community. Absolutely anyone can do that whenever they want. If you want
+to get involved, that doesn't mean you have to continue being involved, but
+we hope our community is welcoming and the work is interesting enough to 
+convince you to say :)
+
+We'll provide all the support we can possibly provide to help you contribute
+in any way you'd like. If you're considering joining us, here are some ideas
+for how you can get involved:
+
+- Comment on an [issue](https://github.com/gomods/athens/issues) that you're
+interested in
+- Submit a [pull request](https://github.com/gomods/athens/pulls) (PR) to fix 
+an issue, or to improve something that doesn't have an issue
+- Review a PR that you're interested in
+- Join us at a weekly [development meeting](https://docs.google.com/document/d/1xpvgmR1Fq4iy1j975Tb4H_XjeXUQUOAvn0FximUzvIk/edit#)
+(or more than one!)
+- Come chat with us in the [gophers slack](https://invite.slack.golangbridge.org/) in the `#athens` channel
+- ... and anything else that's appropriate for you!
+
+# Contributors
+
+As you participate in the community more and more, you'll have the opportunity 
+to become a contributor. Here's what being a contributor means, and what you
+should do to become one.
+
+## What Being a Contributor Means
+
+As a contributor, you'll have issues assigned to you and you'll be requested 
+to review pull requests (PRs) via the 
+[Github pull request review system](https://help.github.com/articles/about-pull-request-reviews/). 
+We rely heavily on Github PR reviews, so if you review a PR as a contributor, you can decide 
+when that PR is ready to be merged.
+
+## How to Become a Contributor
+
+To become a contributor, the core maintainers of the project would like to see you:
+
+- Attend our development meetings regularly<sup>1</sup>
+- Comment on issues with your experiences and opinions
+- Add your comments and reviews on pull requests (anyone can do this as a community member)
+- Contribute PRs to fix issues
+- Open issues as you find them
+
+# Maintainers
+
+After you become a contributor, you'll have the opportunity to become a maintainer.
+Here's what being a maintainer means and how to become one.
+
+## What Being a Maintainer Means
+
+As a maintainer, you'll be doing the same things as a contributor with a few 
+extras:
+
+- Help organize our development meetings (i.e. help organize the agenda)
+- Promote the project and build community (e.g. present on it where possible, write about it, ...) when possible<sup>2</sup>
+- Triage issues (e.g. adding labels, promoting discussions, finalizing decisions)
+- Organize and promote PR reviews (e.g. prompting community members, contributors, and other maintainers to review)
+
+## How to Become a Maintainer
+
+To become a maintainer, we would like you to see you be an effective contributor,
+and show that you can do some of the things maintainers do. Also, if you feel
+that this is you, please reach out to one or more of the maintainers. 
+
+# The End
+
+The above descriptions lay out roughly what each role is and how you can
+move into each of them. Folks all have different strengths, live
+in different places, and so on. We're a diverse group, and we want to keep it
+that way!
+
+So, everything in this document is a guideline, not a hard-and-fast rule.
+If you are really good at something, or can't do something else, talk to
+one of the maintainers and let us know what's up. We will accommodate
+everyone the best we can.
+
+---
+<p><i>
+    <sup>1</sup> Athens development meetings are during the day in US Pacific Time.
+    We know that this time can be problematic for some folks due to work commitments,
+    different time zones, and so on. If you can't come to meetings, that's totally ok
+    and doesn't mean you can't become a contributor! Just let one of the maintainers
+    know about it.
+</i></p>
+<p><i>
+    <sup>2</sup> Anyone and everyone is of course welcome to do this too!
+</i></p>

--- a/docs/content/intro/community-roles.md
+++ b/docs/content/intro/community-roles.md
@@ -72,6 +72,7 @@ extras:
 - Promote the project and build community (e.g. present on it where possible, write about it, ...) when possible<sup>2</sup>
 - Triage issues (e.g. adding labels, promoting discussions, finalizing decisions)
 - Organize and promote PR reviews (e.g. prompting community members, contributors, and other maintainers to review)
+- Handle code of conduct issues
 
 ## How to Become a Maintainer
 


### PR DESCRIPTION
Right now, we have `contributors` and `maintainers` github teams, but they're kinda de-facto defined. This PR is a proposal for defining them more officially. It's a start to #439, but I think there are some big things missing:

- Describe how maintainers make decisions - I feel like it should be something with lazy consensus. maybe 2/3 vote with lazy consensus?
- Describe who makes people contributors and maintainers
    - I feel like contributors & maintainers make people contributors
    - Maybe lazy consensus here too?
- I want everything to be transparent - write that down 😄 
    - Private stuff can't be - so we should prob write that down
- Have a list of maintainers and contributors somewhere
- Somehow weave this in with the philosophy document
- Write down something more descriptive than "handle code of conduct issues"?
    - Also prob link to the CoC

I'd really like to have something in our docs that we're all satisfied with before [gophercon](https://www.gophercon.com/) (Aug. 27th), so comments welcome!