### PR TITLE
Bring more clarity on how to run unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Run `make setup-dev-env` to install local developer tools and run necessary
 services, such as mongodb, for the end-to-end tests.
 
 ## Unit Tests
-Run `make alldeps` and `make test-unit` to run the unit tests.
+For futher details see [DEVELOPMENT.md](DEVELOPMENT.md#L84)
 
 ## End-to-End Tests
 End-to-End tests (e2e) are tests from the user perspective that validate that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Run `make setup-dev-env` to install local developer tools and run necessary
 services, such as mongodb, for the end-to-end tests.
 
 ## Unit Tests
-Run `make test-unit` to run the unit tests.
+Run `make alldeps` and `make test-unit` to run the unit tests.
 
 ## End-to-End Tests
 End-to-End tests (e2e) are tests from the user perspective that validate that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Run `make setup-dev-env` to install local developer tools and run necessary
 services, such as mongodb, for the end-to-end tests.
 
 ## Unit Tests
-For futher details see [DEVELOPMENT.md](DEVELOPMENT.md#L84)
+For further details see [DEVELOPMENT.md](DEVELOPMENT.md#L84)
 
 ## End-to-End Tests
 End-to-End tests (e2e) are tests from the user perspective that validate that

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,3 +80,12 @@ Starting application at 127.0.0.1:3000
 
 And you'll be up and running. As you edit and save code, the `buffalo dev` command will notice and automatically
 re-compile and restart the server.
+
+# Run unit tests
+
+In order to run unit tests dependencies need to be run first:
+
+```console
+make alldeps
+make test-unit
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,9 +83,28 @@ re-compile and restart the server.
 
 # Run unit tests
 
-In order to run unit tests dependencies need to be run first:
+In order to run unit tests, services they depend on must be running first:
 
 ```console
 make alldeps
+```
+
+and env vars exported:
+```console
+export GO_ENV=test_postgres
+export POP_PATH=$PWD/cmd/proxy
+export ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
+export TMPDIR=/tmp/
+```
+
+and database created:
+```console
+buffalo db create
+buffalo db migrate up
+```
+
+Then you can run the unit tests:
+
+```console
 make test-unit
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,21 +89,14 @@ In order to run unit tests, services they depend on must be running first:
 make alldeps
 ```
 
-and env vars exported:
-```console
-export GO_ENV=test_postgres
-export POP_PATH=$PWD/cmd/proxy
-export ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
-export TMPDIR=/tmp/
-```
-
 and database created:
+
 ```console
 buffalo db create
 buffalo db migrate up
 ```
 
-Then you can run the unit tests:
+then you can run the unit tests:
 
 ```console
 make test-unit

--- a/cmd/proxy/.env
+++ b/cmd/proxy/.env
@@ -1,1 +1,5 @@
 ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
+GO_ENV=test_postgres
+POP_PATH=$PWD/cmd/proxy
+ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
+TMPDIR=$(mktemp -d)

--- a/cmd/proxy/.env
+++ b/cmd/proxy/.env
@@ -1,4 +1,3 @@
 ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
 GO_ENV=test_postgres
 POP_PATH=$PWD/cmd/proxy
-TMPDIR=$(mktemp -d)

--- a/cmd/proxy/.env
+++ b/cmd/proxy/.env
@@ -1,5 +1,4 @@
 ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
 GO_ENV=test_postgres
 POP_PATH=$PWD/cmd/proxy
-ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
 TMPDIR=$(mktemp -d)

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# test_unit.sh
+source cmd/proxy/.env
+
 # Run the unit tests with the race detector and code coverage enabled
 set -xeuo pipefail
-
-source cmd/proxy/.env
 go test -race -coverprofile cover.out -covermode atomic ./...

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -3,6 +3,7 @@
 # test_unit.sh
 
 source cmd/proxy/.env
+export TMPDIR=$(mktemp -d)
 
 # Run the unit tests with the race detector and code coverage enabled
 set -xeuo pipefail

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# test_unit.sh
+
 source cmd/proxy/.env
 
 # Run the unit tests with the race detector and code coverage enabled

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -4,4 +4,5 @@
 # Run the unit tests with the race detector and code coverage enabled
 set -xeuo pipefail
 
+source cmd/proxy/.env
 go test -race -coverprofile cover.out -covermode atomic ./...

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -3,7 +3,6 @@
 # test_unit.sh
 
 source cmd/proxy/.env
-export TMPDIR=$(mktemp -d)
 
 # Run the unit tests with the race detector and code coverage enabled
 set -xeuo pipefail


### PR DESCRIPTION
The commit chages behaivour of `make test-unit` by adding sourcing of
env vars. Documentation is updated to provide more clarity on how to run
unit tests.