### PR TITLE
adding a docker build target for the proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ test-e2e:
 
 .PHONY: olympus-docker
 olympus-docker:
-	docker build -t gopackages/olympus -f cmd/olympus/Dockerfile .
+	docker build -t gomods/olympus -f cmd/olympus/Dockerfile .
+
+.PHONY: proxy-docker
+	# TODO: this needs to change to gomods/proxy
+	docker build -t gomods/athens -f cmd/proxy/Dockerfile .
 
 bench:
 	./scripts/benchmark.sh


### PR DESCRIPTION
Also changing docker repo to `gomods`

I found this was missing during my helm work (https://github.com/gomods/athens/pull/430)