### PR TITLE
Fix: Revert "adding a docker build target for the proxy (#454)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,7 @@ test-e2e:
 
 .PHONY: olympus-docker
 olympus-docker:
-	docker build -t gomods/olympus -f cmd/olympus/Dockerfile .
-
-.PHONY: proxy-docker
-	# TODO: this needs to change to gomods/proxy
-	docker build -t gomods/athens -f cmd/proxy/Dockerfile .
+	docker build -t gopackages/olympus -f cmd/olympus/Dockerfile .
 
 bench:
 	./scripts/benchmark.sh

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,12 @@ test-e2e:
 
 .PHONY: olympus-docker
 olympus-docker:
-	docker build -t gopackages/olympus -f cmd/olympus/Dockerfile .
+	docker build -t gomods/olympus -f cmd/olympus/Dockerfile .
+
+.PHONY: proxy-docker
+proxy-docker:
+	# TODO: this needs to change to gomods/proxy
+	docker build -t gomods/athens -f cmd/proxy/Dockerfile .
 
 bench:
 	./scripts/benchmark.sh


### PR DESCRIPTION
Sorry I got click happy, I wanted to revert and reopen the PR. But apparently l I don't know how to GitHub.

I noticed the non `PHONY` target was missing after I merged. #454