### PR TITLE
Default to in-memory storage for the proxy

### DIFF
--- a/cmd/proxy/.env
+++ b/cmd/proxy/.env
@@ -1,3 +1,4 @@
 ATHENS_MONGO_STORAGE_URL=mongodb://127.0.0.1:27017
+ATHENS_STORAGE_TYPE=mongo
 GO_ENV=test_postgres
 POP_PATH=$PWD/cmd/proxy

--- a/cmd/proxy/actions/storage.go
+++ b/cmd/proxy/actions/storage.go
@@ -18,7 +18,6 @@ import (
 
 // GetStorage returns storage backend based on env configuration
 func GetStorage() (storage.BackendConnector, error) {
-	// changing to mongo storage, memory seems buggy
 	storageType := env.StorageTypeWithDefault("memory")
 	var storageRoot string
 	var err error

--- a/cmd/proxy/actions/storage.go
+++ b/cmd/proxy/actions/storage.go
@@ -19,7 +19,7 @@ import (
 // GetStorage returns storage backend based on env configuration
 func GetStorage() (storage.BackendConnector, error) {
 	// changing to mongo storage, memory seems buggy
-	storageType := env.StorageTypeWithDefault("mongo")
+	storageType := env.StorageTypeWithDefault("memory")
 	var storageRoot string
 	var err error
 


### PR DESCRIPTION
This makes it easier for someone to try out or just run the proxy by executing the binary without further environment setup.