### PR TITLE
Rename Private filter to Direct

### DIFF
--- a/cmd/proxy/actions/filter.go
+++ b/cmd/proxy/actions/filter.go
@@ -38,7 +38,7 @@ func newFilterMiddleware(mf *module.Filter) buffalo.MiddlewareFunc {
 			switch rule {
 			case module.Exclude:
 				return c.Render(http.StatusForbidden, nil)
-			case module.Private:
+			case module.Direct:
 				return next(c)
 			case module.Include:
 				// TODO : spin up cache filling worker and serve the request using the cache

--- a/cmd/proxy/actions/filter_test.go
+++ b/cmd/proxy/actions/filter_test.go
@@ -28,7 +28,7 @@ func newTestFilter() *module.Filter {
 	f := module.NewFilter()
 	f.AddRule("github.com/gomods/athens/", module.Include)
 	f.AddRule("github.com/athens-artifacts/no-tags", module.Exclude)
-	f.AddRule("github.com/athens-artifacts", module.Private)
+	f.AddRule("github.com/athens-artifacts", module.Direct)
 	return f
 }
 

--- a/pkg/module/filter.go
+++ b/pkg/module/filter.go
@@ -134,8 +134,8 @@ func (f *Filter) initFromConfig() {
 			rule = Include
 		case "-":
 			rule = Exclude
-		case "P":
-			rule = Private
+		case "D":
+			rule = Direct
 		default:
 			continue
 		}

--- a/pkg/module/filterRule.go
+++ b/pkg/module/filterRule.go
@@ -10,6 +10,6 @@ const (
 	Include
 	// Exclude filter rule excludes package and its children from communication
 	Exclude
-	// Private filter rule forces the package to be fetched only from the vcs
-	Private
+	// Direct filter rule forces the package to be fetched directly from the vcs
+	Direct
 )

--- a/pkg/module/filter_test.go
+++ b/pkg/module/filter_test.go
@@ -55,16 +55,16 @@ func (t *FilterTests) Test_OnlyAllowed() {
 	r.Equal(Exclude, f.Rule("bitbucket.com/a/b"))
 }
 
-func (t *FilterTests) Test_Private() {
+func (t *FilterTests) Test_Direct() {
 	r := t.Require()
 
 	f := NewFilter()
 	f.AddRule("github.com/a/b/c", Exclude)
-	f.AddRule("github.com/a/b", Private)
+	f.AddRule("github.com/a/b", Direct)
 	f.AddRule("github.com/a", Include)
 	f.AddRule("", Exclude)
 
 	r.Equal(Include, f.Rule("github.com/a"))
-	r.Equal(Private, f.Rule("github.com/a/b"))
+	r.Equal(Direct, f.Rule("github.com/a/b"))
 	r.Equal(Exclude, f.Rule("github.com/a/b/c/d"))
 }


### PR DESCRIPTION
As agreed on #473 Direct is more descriptive name for filter. 
Therefore changing `Private` -> `Direct`
changing rule syntax: `P github.com/a/b` -> `D github.com/a/b`

Fixes #473 