### PR TITLE
Updated to go1.11rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 language: go
 install: false
 go:
-  - "1.11beta3"
+  - "1.11rc1"
 env:
   global:
     - PATH=${PATH}:./bin

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,17 +16,17 @@ Athens is developed on Go1.11+.
 
 If you have a stable version of go running, then a later version of go can be downloaded.
 
-For example, to get `go1.11beta3`, run the following commands which won't affect your stable version
+For example, to get `go1.11rc1`, run the following commands which won't affect your stable version
 ```
-go get golang.org/dl/go1.11beta3
-go1.11beta3 download
+go get golang.org/dl/go1.11rc1
+go1.11rc1 download
 ```
 
-To point Athens to `go1.11beta3` or to a different version
+To point Athens to `go1.11rc1` or to a different version
 set the following environment variable
 
 ```
-GO_BINARY_PATH=go1.11beta3
+GO_BINARY_PATH=go1.11rc1
 or whichever binary you want to use with athens
 ```
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -20,7 +20,7 @@ So, if you look back to "architecture" above, there are a few discrete "things" 
 
 ## Does Athens integrate with the go toolchain?
 
-Athens is currently supported by the Go 1.11beta3 toolchain via the [download protocol](/intro/protocol/).
+Athens is currently supported by the Go 1.11rc1 toolchain via the [download protocol](/intro/protocol/).
 
 For the TL;DR of the protocol, it's a REST API that lets the go toolchain (i.e. go get) see lists of versions and fetch source code for a specific version.
 

--- a/docs/content/intro/components.md
+++ b/docs/content/intro/components.md
@@ -7,7 +7,7 @@ From a very high-level view, we recognize 4 major components of the system.
 
 ### Client 
 
-The client is a user, powered by go binary with module support. At the moment of writing this document, it is `go1.11beta3`
+The client is a user, powered by go binary with module support. At the moment of writing this document, it is `go1.11rc1`
 
 ### VCS 
 

--- a/pkg/download/goget/goget.go
+++ b/pkg/download/goget/goget.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/gomods/athens/pkg/config"
@@ -78,13 +77,7 @@ func (gg *goget) Latest(ctx context.Context, mod string) (*storage.RevInfo, erro
 		return nil, errors.E(op, err)
 	}
 
-	pseudoInfo := strings.Split(lr.Version, "-")
-	if len(pseudoInfo) < 3 {
-		return nil, errors.E(op, fmt.Errorf("malformed pseudoInfo %v", lr.Version))
-	}
 	return &storage.RevInfo{
-		Name:    pseudoInfo[2],
-		Short:   pseudoInfo[2],
 		Time:    lr.Time,
 		Version: lr.Version,
 	}, nil

--- a/pkg/download/goget/goget_test.go
+++ b/pkg/download/goget/goget_test.go
@@ -65,7 +65,10 @@ var latestTests = []latestTest{
 	{
 		name: "tagged latest",
 		path: "github.com/athens-artifacts/happy-path",
-		err:  true,
+		info: &storage.RevInfo{
+			Version: "v0.0.3",
+			Time:    time.Date(2018, 8, 3, 17, 16, 00, 0, time.UTC),
+		},
 	},
 }
 

--- a/pkg/download/goget/goget_test.go
+++ b/pkg/download/goget/goget_test.go
@@ -58,8 +58,6 @@ var latestTests = []latestTest{
 		name: "happy path",
 		path: "github.com/athens-artifacts/no-tags",
 		info: &storage.RevInfo{
-			Name:    "1a540c5d67ab",
-			Short:   "1a540c5d67ab",
 			Version: "v0.0.0-20180803171426-1a540c5d67ab",
 			Time:    time.Date(2018, 8, 3, 17, 14, 26, 0, time.UTC),
 		},
@@ -103,9 +101,7 @@ var infoTests = []infoTest{
 		path:    "github.com/athens-artifacts/happy-path",
 		version: "v0.0.2",
 		info: &storage.RevInfo{
-			Name:    "3017822275edeb343d2d2a56345f9a58090514d8",
 			Version: "v0.0.2",
-			Short:   "3017822275ed",
 			Time:    time.Date(2018, 8, 3, 3, 45, 19, 0, time.UTC),
 		},
 	},
@@ -114,9 +110,7 @@ var infoTests = []infoTest{
 		path:    "github.com/athens-artifacts/no-tags",
 		version: "v0.0.0-20180803035119-e4e0177efdb5",
 		info: &storage.RevInfo{
-			Name:    "e4e0177efdb573c110217ccb01f2069f961154f3",
 			Version: "v0.0.0-20180803035119-e4e0177efdb5",
-			Short:   "e4e0177efdb5",
 			Time:    time.Date(2018, 8, 3, 3, 51, 19, 0, time.UTC),
 		},
 	},

--- a/pkg/storage/rev_info.go
+++ b/pkg/storage/rev_info.go
@@ -11,7 +11,5 @@ import (
 // (see "Download Protocol" header)
 type RevInfo struct {
 	Version string    `json:"Version"` // version string
-	Name    string    `json:"Name"`    // complete ID in underlying repository
-	Short   string    `json:"Short"`   // shortened ID, for use in pseudo-version
 	Time    time.Time `json:"Time"`    // commit time
 }


### PR DESCRIPTION
RevInfo updated to match go upstream

> // We want to canonicalize to .info files with those fields omitted

By those fields meant: Name and Short
https://github.com/golang/go/blob/daeb0b4f538872a37787626816c47afcf71bfd2c/src/cmd/go/internal/modfetch/cache.go#L312

Looks like @latest is according to specs now, 
retrieves latest version, in case of no version pseudo version is retrieved