### PR TITLE
Athens: turn off worker to avoid nil logs

### DIFF
--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -71,6 +71,7 @@ func App(config *AppConfig) (*buffalo.App, error) {
 		},
 		SessionName: "_olympus_session",
 		Worker:      w,
+		WorkerOff:   true, // TODO(marwan): turned off until worker is being used.
 		Logger:      log.Buffalo(),
 	})
 	// Automatically redirect to SSL

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -85,6 +85,7 @@ func App() (*buffalo.App, error) {
 		},
 		SessionName: "_athens_session",
 		Worker:      worker,
+		WorkerOff:   true, // TODO(marwan): turned off until worker is being used.
 		Logger:      log.Buffalo(),
 	})
 
@@ -150,6 +151,5 @@ func getWorker(ctx context.Context, s storage.Backend, mf *module.Filter) (worke
 		MaxFails: env.WorkerMaxFails(),
 	}
 
-	return nil, w.RegisterWithOptions(FetcherWorkerName, opts, GetProcessCacheMissJob(ctx, s, w, mf))
-
+	return w, w.RegisterWithOptions(FetcherWorkerName, opts, GetProcessCacheMissJob(ctx, s, w, mf))
 }


### PR DESCRIPTION
Buffalo was creating an internal worker if opts.Worker was nil, and it was logging nil things. So worker is for now turned off so peeps are aware that it's not being used. 