### PR TITLE
Some improvements to test scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ bench:
 
 .PHONY: alldeps
 alldeps:
-	docker-compose -p athensdev up -d mysql
 	docker-compose -p athensdev up -d postgres
 	docker-compose -p athensdev up -d mongo
 	docker-compose -p athensdev up -d redis
@@ -74,3 +73,4 @@ down:
 dev-teardown:
 	docker-compose -p athensdev down
 	docker volume prune
+	docker network prune

--- a/cmd/olympus/database.yml
+++ b/cmd/olympus/database.yml
@@ -1,30 +1,21 @@
 development:
-  dialect: "mysql"
-  database: athens
+  dialect: "postgres"
+  database: olympus_development
   host: 127.0.0.1
   port: 3306
   user: vgp
   password: vgp
 
-test_postgres:
-  dialect: "postgres"
-  database: athens_development
-  user: postgres
-  password: ''
-  host: 127.0.0.1
-  pool: 5
-
 test:
-  dialect: "mysql"
-  database: athens
+  dialect: "postgres"
+  database: olympus_testing
   host: 127.0.0.1
-  port: 3306
   user: vgp
   password: vgp
   
 production:
-  dialect: "mysql"
-  database: olympusdb
+  dialect: "postgres"
+  database: olympus
   host: {{ env "DB_HOST" }}
   port: {{ env "DB_PORT" }}
   user: {{ env "DB_USER" }}

--- a/cmd/proxy/database.yml
+++ b/cmd/proxy/database.yml
@@ -1,30 +1,22 @@
 development:
-  dialect: "mysql"
-  database: athens
+  dialect: "postgres"
+  database: proxy_development
   host: 127.0.0.1
   port: 3306
   user: vgp
   password: vgp
 
 test:
-  dialect: "mysql"
-  database: athens
+  dialect: "postgres"
+  database: proxy_testing
   host: 127.0.0.1
-  port: 3306
+  pool: 5
   user: vgp
   password: vgp
 
-test_postgres:
-  dialect: "postgres"
-  database: athens_development
-  user: postgres
-  password: ''
-  host: 127.0.0.1
-  pool: 5
-
 production:
-  dialect: "mysql"
-  database: olympusdb
+  dialect: "postgres"
+  database: proxy
   host: {{ env "DB_HOST" }}
   port: {{ env "DB_PORT" }}
   user: {{ env "DB_USER" }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,19 +9,13 @@ services:
     image: mongo:3.7.9-jessie
     ports:
       - 27017:27017
-  mysql:
-    image: bitnami/mysql:5.7.21-r7
-    ports:
-      - "3306:3306"
-    environment:
-      - "ALLOW_EMPTY_PASSWORD=yes"
-      - "MYSQL_USER=vgp"
-      - "MYSQL_PASSWORD=vgp"
-      - "MYSQL_DATABASE=athens"
   postgres:
     image: postgres:9.6.9-alpine
     ports:
       - "5432:5432"
+    environment:
+      POSTGRES_USER: vgp
+      POSTGRES_PASSWORD: vgp
   minio:
     image: minio/minio:latest
     command: server /data

--- a/scripts/test_unit.sh
+++ b/scripts/test_unit.sh
@@ -2,7 +2,17 @@
 
 # test_unit.sh
 
-source cmd/proxy/.env
+if [ -z ${ATHENS_MONGO_STORAGE_URL} ]; then 
+    export ATHENS_MONGO_STORAGE_URL="mongodb://127.0.0.1:27017"
+fi
+
+if [ -z ${GO_ENV} ]; then
+    export GO_ENV="test_postgres"
+fi
+
+if [ -z ${POP_PATH} ]; then
+    export POP_PATH="${PWD}/cmd/proxy"
+fi
 
 # Run the unit tests with the race detector and code coverage enabled
 set -xeuo pipefail


### PR DESCRIPTION
@robjloranger talked over slack about how it's difficult to run all tests locally. We agreed that https://github.com/gomods/athens/issues/420 would be a good long-term solution, but for now this should improve things. With these changes I was able to reduce the number of test failures on master, but not fix them all.

- Not sourcing from cmd/proxy/.env, because that doesn't export any variables
- Removing mysql support (I feel like 1 database is enough)
- Pruning networks on teardown

I'm happy to split these changes up into separate PRs - it's the end of the day for me so I wanted to get everything in :smile: