### PR TITLE
Ensure there is only one in-mem storage instance

### DIFF
--- a/pkg/storage/mem/mem.go
+++ b/pkg/storage/mem/mem.go
@@ -31,9 +31,9 @@ func NewStorage() (storage.Backend, error) {
 		return nil, errors.E(op, fmt.Errorf("could not create temp dir for 'In Memory' storage (%s)", err))
 	}
 
-	s, err := fs.NewStorage(tmpDir, memFs)
+	memStorage, err = fs.NewStorage(tmpDir, memFs)
 	if err != nil {
 		return nil, errors.E(op, fmt.Errorf("could not create storage from memory fs (%s)", err))
 	}
-	return s, nil
+	return memStorage, nil
 }


### PR DESCRIPTION
At the moment each mem.NewStorage() will create own instance of afero.Fs which means if we do:
```
s1 = mem.NewStorage()
s1.Save(mod@ver)
```
then `s2.Get(mod@ver)` will return `nil` because `s2` has it's own in-mem file system.
This can be confusing because every other storage would return the module.