### PR TITLE
Athens: add health check endpoint

### DIFF
--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -114,6 +114,7 @@ func App(config *AppConfig) (*buffalo.App, error) {
 	app.GET("/eventlog/{sequence_id}", eventlogHandler(config.EventLog))
 	app.POST("/cachemiss", cachemissHandler(w))
 	app.POST("/push", pushNotificationHandler(w))
+	app.GET("/healthz", healthHandler)
 
 	// Download Protocol
 	gg, err := goget.New()

--- a/cmd/olympus/actions/health.go
+++ b/cmd/olympus/actions/health.go
@@ -1,0 +1,9 @@
+package actions
+
+import (
+	"github.com/gobuffalo/buffalo"
+)
+
+func healthHandler(c buffalo.Context) error {
+	return c.Render(200, nil)
+}

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -16,6 +16,7 @@ func addProxyRoutes(
 	l *log.Logger,
 ) error {
 	app.GET("/", proxyHomeHandler)
+	app.GET("/healthz", healthHandler)
 
 	// Download Protocol
 	gg, err := goget.New()

--- a/cmd/proxy/actions/health.go
+++ b/cmd/proxy/actions/health.go
@@ -1,0 +1,9 @@
+package actions
+
+import (
+	"github.com/gobuffalo/buffalo"
+)
+
+func healthHandler(c buffalo.Context) error {
+	return c.Render(200, nil)
+}


### PR DESCRIPTION
While trying to deploy the Proxy behind a domain name, Kubernetes' Ingress controller requires a health check endpoint to proxy a domain name to a backend. But regardless of that, we should have a dedicated healthcheck anyway. In the future, we can have the healthcheck ping the storage and other dependencies to get back a true health check :) 