### PR TITLE
Proxy: make Force SSL configurable

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -87,7 +87,7 @@ func App() (*buffalo.App, error) {
 
 	// Automatically redirect to SSL
 	app.Use(ssl.ForceSSL(secure.Options{
-		SSLRedirect:     ENV == "production",
+		SSLRedirect:     env.ProxyForceSSL(),
 		SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"},
 	}))
 

--- a/pkg/config/env/ssl.go
+++ b/pkg/config/env/ssl.go
@@ -1,0 +1,13 @@
+package env
+
+import (
+	"os"
+)
+
+// ForceSSL returns true if the PROXY_FORCE_SSL
+// env is set to "true", otherwise defaults to false.
+// This is used to make sure the Proxy would redirect
+// to https on any request.
+func ProxyForceSSL() bool {
+	return os.Getenv("PROXY_FORCE_SSL") == "true"
+}

--- a/pkg/config/env/ssl.go
+++ b/pkg/config/env/ssl.go
@@ -4,7 +4,7 @@ import (
 	"os"
 )
 
-// ForceSSL returns true if the PROXY_FORCE_SSL
+// ProxyForceSSL returns true if the PROXY_FORCE_SSL
 // env is set to "true", otherwise defaults to false.
 // This is used to make sure the Proxy would redirect
 // to https on any request.


### PR DESCRIPTION
HTTPS should not be forced on Production environments for the Proxy because the Proxy can potentially run inside Google App Engine, GKE, or other platforms where certs are provided by the platform and your app doesn't need to have its own certs. 