### PR TITLE
proxy: add path prefix

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -83,6 +83,9 @@ func App() (*buffalo.App, error) {
 		WorkerOff:   true, // TODO(marwan): turned off until worker is being used.
 		Logger:      log.Buffalo(),
 	})
+	if prefix := env.AthensPathPrefix(); prefix != "" {
+		app = app.Group(prefix)
+	}
 
 	// Automatically redirect to SSL
 	app.Use(ssl.ForceSSL(secure.Options{

--- a/pkg/config/env/path.go
+++ b/pkg/config/env/path.go
@@ -1,0 +1,13 @@
+package env
+
+import (
+	"os"
+)
+
+// AthensPathPrefix returns whether the Proxy (or Olympus)
+// should have a basepath. Certain proxies and services
+// are distinguished based on subdomain, while others are based
+// on path prefixes.
+func AthensPathPrefix() string {
+	return os.Getenv("ATHENS_PATH_PREFIX")
+}


### PR DESCRIPTION
This makes it so that the entire proxy could run behind a prefix. This is useful if you run Athens Proxy in a Kubernetes cluster that sits behind an Ingress Controller that is separated by different prefix paths, such as this example: https://kubernetes.io/docs/concepts/services-networking/ingress/#simple-fanout

