### PR TITLE
Proxy: add NETRC file mount

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -66,6 +66,10 @@ func App() (*buffalo.App, error) {
 		return nil, err
 	}
 
+	// mount .netrc to home dir
+	// to have access to private repos.
+	initializeNETRC()
+
 	worker, err := getWorker(ctx, store)
 	if err != nil {
 		return nil, err

--- a/cmd/proxy/actions/netrc.go
+++ b/cmd/proxy/actions/netrc.go
@@ -1,0 +1,32 @@
+package actions
+
+import (
+	"io/ioutil"
+	"log"
+	"path/filepath"
+
+	"github.com/gomods/athens/pkg/config/env"
+	"github.com/mitchellh/go-homedir"
+)
+
+// initializeNETRC checks if .netrc is at a pre-configured path
+// and moves to ~/.netrc -- note that this will override whatever
+// .netrc you have in your home directory.
+func initializeNETRC() {
+	p := env.NETRCPath()
+	if p == "" {
+		return
+	}
+
+	netrcBts, err := ioutil.ReadFile(p)
+	if err != nil {
+		log.Fatalf("could not read %s: %v", p, err)
+	}
+
+	hdir, err := homedir.Dir()
+	if err != nil {
+		log.Fatalf("could not get homedir: %v", err)
+	}
+	rcp := filepath.Join(hdir, ".netrc")
+	ioutil.WriteFile(rcp, netrcBts, 0666)
+}

--- a/pkg/config/env/netrc.go
+++ b/pkg/config/env/netrc.go
@@ -1,0 +1,15 @@
+package env
+
+import (
+	"os"
+)
+
+// NETRCPath tells you where the .netrc path initially resides.
+// This is so that you can mount the .netrc file to a secret location
+// in the fs system and then move it ~/.netrc. In certain deployments
+// like Kubernetes, we can't mount directly to ~ because it would then
+// clean out whatever is already there as part of the image (such as
+// .cache directory in the Go image).
+func NETRCPath() string {
+	return os.Getenv("ATHENS_NETRC_PATH")
+}


### PR DESCRIPTION
We need to have a way to authenticate a deployed Proxy to have access to private repos (that's kinda the whole point of the Proxy lol). 

Currently, .netrc is the easiest way possible but we can't mount it directly to the home directory because Kubernetes would remove other files in ~ causing our internal goget to be confused. 

I'd like to open another issue to use the Linux in-memory authentication as suggested [here](https://confluence.atlassian.com/bitbucketserver/permanently-authenticating-with-git-repositories-776639846.html)