### PR TITLE
Deploy docker image during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - ATHENS_MONGO_CONNECTION_STRING=mongodb://127.0.0.1:27017
     - CODE_COV=1
     - ATHENS_DIR=${GOPATH}/src/github.com/gomods/athens
+    - REGISTRY=carolynvs/ # Temporary workaround until we have access to the gomods/ registry
 
 before_script:
   - mkdir -p $ATHENS_DIR && rsync -azr . $ATHENS_DIR && cd $ATHENS_DIR
@@ -30,3 +31,13 @@ after_success:
     else
       echo codecov not enabled;
     fi
+
+before_deploy:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+deploy:
+  provider: script
+  script: make docker-push
+  on:
+    repo: gomods/athens
+    all_branches: true

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ olympus-docker:
 proxy-docker:
 	docker build -t gomods/proxy -f cmd/proxy/Dockerfile .
 
+.PHONY: docker-push
+docker-push: docker
+	./scripts/push-docker-images.sh
+
 bench:
 	./scripts/benchmark.sh
 

--- a/scripts/push-docker-images.sh
+++ b/scripts/push-docker-images.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Push our docker images to a registry
+set -xeuo pipefail
+
+REGISTRY=${REGISTRY:-gomods/}
+
+# Use the travis variables when available because travis clones different than what is on a local dev machine
+# VERSION = the tag if present, otherwise the short commit hash
+# BRANCH = the current branch, empty if not on a branch
+if [[ "${TRAVIS-}" == "true" ]]; then
+    VERSION=${TRAVIS_TAG:-${TRAVIS_COMMIT::7}}
+    BRANCH=${TRAVIS_BRANCH}
+else
+    TAG=$(git describe --tags --exact-match 2> /dev/null || true)
+    COMMIT=$(git rev-parse --short=7 HEAD)
+    VERSION=${VERSION:-${TAG:-${COMMIT}}}
+    BRANCH=${BRANCH:-$(git symbolic-ref -q --short HEAD || echo "")}
+fi
+
+# MUTABLE_TAG is the docker image tag that we will reuse between pushes, it is not a stable tag like a commit hash or tag.
+if [[ "${MUTABLE_TAG:-}" == "" ]]; then
+    # tagged builds
+    if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        MUTABLE_TAG="latest"
+    # master build
+    elif [[ "$BRANCH" == "master" ]]; then
+        MUTABLE_TAG="canary"
+    # branch build
+    else
+        MUTABLE_TAG=${BRANCH}
+    fi
+fi
+
+REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd )/"
+
+docker build -t ${REGISTRY}proxy:${VERSION} -f ${REPO_DIR}cmd/proxy/Dockerfile ${REPO_DIR}
+docker build -t ${REGISTRY}olympus:${VERSION} -f ${REPO_DIR}cmd/olympus/Dockerfile ${REPO_DIR}
+
+# Apply the mutable tag to the immutable version
+docker tag ${REGISTRY}proxy:${VERSION} ${REGISTRY}proxy:${MUTABLE_TAG}
+docker tag ${REGISTRY}olympus:${VERSION} ${REGISTRY}olympus:${MUTABLE_TAG}
+
+docker push ${REGISTRY}proxy:${VERSION}
+docker push ${REGISTRY}proxy:${MUTABLE_TAG}
+docker push ${REGISTRY}olympus:${VERSION}
+docker push ${REGISTRY}olympus:${MUTABLE_TAG}


### PR DESCRIPTION
🚨 I am testing this out on my own repo and registry. Will remove the WIP once it's working as intended.
___

master builds publish using the git describe output  as the immutable tag and canary for the mutable tag. Examples:

    gomods/proxy:abc1234
    gomods/proxy:canary

tagged builds publish using the tag as the immutable tag, which is usually going to be a semver value and with latest for the mutable tag.
Examples:

    gomods/proxy:v1.0.0
    gomods/proxy:latest

branch builds publish using the git describe output as the immutable tag and the branch name for the mutable tag. Examples:

    gomods/proxy:def4567
    gomods/proxy:beta-1

Suggestions welcome on exactly where to document this for others. @jeremyrickard is writing install docs that are going to have people use the images, but it would be nice to also tell people what the tags mean.

TODO:
 - [x] Test out the travis config on my own repo
 - [ ] ~Cache the docker layers between travis builds~ I think this is best done in a follow-up.

Closes #81