### PR TITLE
put git and go in runtime image

### DIFF
--- a/cmd/olympus/Dockerfile
+++ b/cmd/olympus/Dockerfile
@@ -1,9 +1,4 @@
-# This is a multi-stage Dockerfile and requires >= Docker 17.05
-# https://docs.docker.com/engine/userguide/eng-image/multistage-build/
-#
-# use 'make olympus-docker' from the root of the athens repo to build
-# the olympus docker image
-FROM gobuffalo/buffalo:v0.11.0 as builder
+FROM gobuffalo/buffalo:v0.12.6 as builder
 
 RUN mkdir -p $GOPATH/src/github.com/gomods/athens/cmd/olympus
 WORKDIR $GOPATH/src/github.com/gomods/athens/cmd/olympus
@@ -18,13 +13,11 @@ ADD . .
 
 RUN cd cmd/olympus && buffalo build -s -o /bin/app
 
-FROM alpine
-RUN apk add --no-cache bash
-RUN apk add --no-cache ca-certificates
 
-WORKDIR /bin/
+FROM golang:1.11-rc-alpine
+RUN apk add --no-cache bash git openssh ca-certificates
 
-COPY --from=builder /bin/app .
+COPY --from=builder /bin/app /bin/app
 
 # Comment out to run the binary in "production" mode:
 # ENV GO_ENV=production

--- a/cmd/olympus/actions/app.go
+++ b/cmd/olympus/actions/app.go
@@ -1,7 +1,9 @@
 package actions
 
 import (
+	"fmt"
 	stdlog "log"
+	"strings"
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/middleware"
@@ -56,6 +58,9 @@ var (
 // This is the nerve center of your application.
 func App(config *AppConfig) (*buffalo.App, error) {
 	port := env.Port(":3001")
+	if hasColon := strings.HasPrefix(port, ":"); hasColon == false {
+		port = fmt.Sprintf(":%s", port)
+	}
 
 	w, err := getWorker(config.Storage, config.EventLog)
 	if err != nil {

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -1,13 +1,28 @@
-FROM golang:1.11-rc
+FROM gobuffalo/buffalo:v0.12.6 as buffalo-builder
+
+RUN mkdir -p $GOPATH/src/github.com/gomods/athens/cmd/proxy
+WORKDIR $GOPATH/src/github.com/gomods/athens/cmd/proxy
+
+# this will cache the npm install step, unless package.json changes
+ADD cmd/proxy/package.json .
+ADD cmd/proxy/yarn.lock .
+RUN yarn install --no-progress
 
 RUN mkdir -p $GOPATH/src/github.com/gomods/athens
 WORKDIR $GOPATH/src/github.com/gomods/athens
 
-COPY . .
+ADD . .
+RUN cd cmd/proxy && buffalo build -s -o /bin/app
 
-RUN CGO_ENABLED=0 go build -o /bin/app ./cmd/proxy
+
+FROM golang:1.11-rc-alpine
+RUN apk add --no-cache bash git openssh ca-certificates
+
+COPY --from=buffalo-builder /bin/app /bin/app
 
 ENV GO_ENV=production
+# Bind the app to 0.0.0.0 (all interfaces) so it can be seen from outside the container
+ENV ADDR=0.0.0.0
 
 EXPOSE 3000
 


### PR DESCRIPTION
The `goget` impl of the Download protocol requires both go 1.11 and git on the system. I updated the Dockerfile accordingly.

@marwan-at-work you removed much of the proxy Dockerfile, but without it my builds fail. Can you PTAL? Thanks!