### PR TITLE
Proxy: add cache-control middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tmp
 .vs
 cmd/olympus/bin
 cmd/proxy/bin
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ tmp
 .vs
 cmd/olympus/bin
 cmd/proxy/bin
-.idea

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gomods/athens/pkg/log"
+	"github.com/gomods/athens/pkg/middleware"
 	"github.com/sirupsen/logrus"
 )
 
@@ -44,9 +45,14 @@ func RegisterHandlers(app *buffalo.App, opts *HandlerOpts) {
 	if opts == nil || opts.Protocol == nil || opts.Engine == nil || opts.Logger == nil {
 		panic("absolutely unacceptable handler opts")
 	}
+	noCacheMw := middleware.CacheControl("private, no-store")
 
-	app.GET(PathList, LogEntryHandler(ListHandler, opts))
-	app.GET(PathLatest, LogEntryHandler(LatestHandler, opts))
+	listHandler := LogEntryHandler(ListHandler, opts)
+	app.GET(PathList, noCacheMw(listHandler))
+
+	latestHandler := LogEntryHandler(LatestHandler, opts)
+	app.GET(PathLatest, noCacheMw(latestHandler))
+
 	app.GET(PathVersionInfo, LogEntryHandler(VersionInfoHandler, opts))
 	app.GET(PathVersionModule, LogEntryHandler(VersionModuleHandler, opts))
 	app.GET(PathVersionZip, LogEntryHandler(VersionZipHandler, opts))

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -45,7 +45,7 @@ func RegisterHandlers(app *buffalo.App, opts *HandlerOpts) {
 	if opts == nil || opts.Protocol == nil || opts.Engine == nil || opts.Logger == nil {
 		panic("absolutely unacceptable handler opts")
 	}
-	noCacheMw := middleware.CacheControl("private, no-store")
+	noCacheMw := middleware.CacheControl("no-cache, no-store, must-revalidate")
 
 	listHandler := LogEntryHandler(ListHandler, opts)
 	app.GET(PathList, noCacheMw(listHandler))

--- a/pkg/middleware/cache_control.go
+++ b/pkg/middleware/cache_control.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"github.com/gobuffalo/buffalo"
+)
+
+// CacheControl takes a string and makes a header value to the key Cache-Control.
+// This is so you can set some sane cache defaults to certain endpoints.
+func CacheControl(cacheHeaderValue string) buffalo.MiddlewareFunc {
+	return func(next buffalo.Handler) buffalo.Handler {
+		return func(c buffalo.Context) error {
+			c.Response().Header().Set("Cache-Control", cacheHeaderValue)
+			return next(c)
+		}
+	}
+}

--- a/pkg/middleware/cache_control_test.go
+++ b/pkg/middleware/cache_control_test.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gobuffalo/buffalo"
+)
+
+func TestCacheControl(t *testing.T) {
+	h := func(c buffalo.Context) error { return c.Render(200, nil) }
+	a := buffalo.New(buffalo.Options{})
+	a.GET("/test", h)
+
+	expected := "private, no-store"
+	a.Use(CacheControl(expected))
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/test", nil)
+	a.ServeHTTP(w, r)
+
+	given := w.Result().Header.Get("Cache-Control")
+	if given != expected {
+		t.Fatalf("expected cache-control header to be %v but got %v", expected, given)
+	}
+}

--- a/pkg/middleware/cache_control_test.go
+++ b/pkg/middleware/cache_control_test.go
@@ -13,7 +13,7 @@ func TestCacheControl(t *testing.T) {
 	a := buffalo.New(buffalo.Options{})
 	a.GET("/test", h)
 
-	expected := "no-cache, no-store, must-revalidate"
+	expected := "private, no-store"
 	a.Use(CacheControl(expected))
 
 	w := httptest.NewRecorder()

--- a/pkg/middleware/cache_control_test.go
+++ b/pkg/middleware/cache_control_test.go
@@ -13,7 +13,7 @@ func TestCacheControl(t *testing.T) {
 	a := buffalo.New(buffalo.Options{})
 	a.GET("/test", h)
 
-	expected := "private, no-store"
+	expected := "no-cache, no-store, must-revalidate"
 	a.Use(CacheControl(expected))
 
 	w := httptest.NewRecorder()

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -8,17 +8,15 @@ import (
 	"testing"
 
 	"github.com/bketelsen/buffet"
-	"github.com/sirupsen/logrus"
-	"github.com/uber/jaeger-client-go/config"
-
 	"github.com/gobuffalo/buffalo"
 	"github.com/gomods/athens/pkg/config/env"
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/module"
 	"github.com/markbates/willie"
-
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber/jaeger-client-go/config"
 )
 
 // Avoid import cycle.

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gomods/athens/pkg/config/env"
-	"github.com/gomods/athens/pkg/download"
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/module"
 	"github.com/markbates/willie"
@@ -21,6 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+// Avoid import cycle.
+const pathList = "/{module:.+}/@v/list"
+const pathVersionInfo = "/{module:.+}/@v/{version}.info"
 
 func middlewareFilterApp() *buffalo.App {
 	h := func(c buffalo.Context) error {
@@ -32,8 +35,8 @@ func middlewareFilterApp() *buffalo.App {
 	a.Use(NewFilterMiddleware(mf))
 	initializeTracing(a)
 
-	a.GET(download.PathList, h)
-	a.GET(download.PathVersionInfo, h)
+	a.GET(pathList, h)
+	a.GET(pathVersionInfo, h)
 	return a
 }
 
@@ -73,8 +76,8 @@ func hookFilterApp(hook string) *buffalo.App {
 	a.Use(LogEntryMiddleware(NewValidationMiddleware, log.New("none", logrus.DebugLevel), hook))
 	initializeTracing(a)
 
-	a.GET(download.PathList, h)
-	a.GET(download.PathVersionInfo, h)
+	a.GET(pathList, h)
+	a.GET(pathVersionInfo, h)
 	return a
 }
 


### PR DESCRIPTION
Certain Download Protocol handlers must be careful not to cache anything down the network. In particular, /list and /@latest because they always depend on upstream and are subject to change in real time. 

This PR adds a middleware to set custom Cache-Control header and adds it to the two handlers that need it. 