### PR TITLE
Athens: add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tmp
 .vs
 cmd/olympus/bin
 cmd/proxy/bin
+.idea


### PR DESCRIPTION
just starting to use Goland as im struggling with vscode performacne, and it adds this .idea folder so I'm not sure if it's normal for people to add it or ignore it. 