### PR TITLE
Remove unused pkg/errors from gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,10 +54,6 @@
   name = "github.com/markbates/grift"
 
 [[constraint]]
-  name = "github.com/pkg/errors"
-  version = "0.8.0"
-
-[[constraint]]
   name = "github.com/rs/cors"
   version = "1.3.0"
 


### PR DESCRIPTION
We have a pkg/errors in gopkg.toml that is not used anymore. We are removing this to remove dep ensure warnings.

Fixes #552