### PR TITLE
pkg/storage: ensure mongo returns KindNotFound

### DIFF
--- a/pkg/storage/mongo/lister.go
+++ b/pkg/storage/mongo/lister.go
@@ -2,8 +2,8 @@ package mongo
 
 import (
 	"context"
-	"strings"
 
+	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/storage"
@@ -19,10 +19,11 @@ func (s *ModuleStore) List(ctx context.Context, module string) ([]string, error)
 	result := make([]storage.Module, 0)
 	err := c.Find(bson.M{"module": module}).All(&result)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			err = errors.E(op, err, errors.M(module), errors.KindNotFound)
+		kind := errors.KindUnexpected
+		if err == mgo.ErrNotFound {
+			kind = errors.KindNotFound
 		}
-		return nil, err
+		return nil, errors.E(op, kind, errors.M(module), err)
 	}
 
 	versions := make([]string, len(result))


### PR DESCRIPTION
In mongo.Zip, KindNotFound is not included which ended up making certain builds fail because we told the donload.Protocol it was an unexpected error, instead of a NotFound error so it ended up returning 500 to cmd/go instead of fetching the module from Upstream. 