### PR TITLE
pkg/download/goget: ensure each List func gets its own GOPATH

### DIFF
--- a/pkg/download/goget/goget.go
+++ b/pkg/download/goget/goget.go
@@ -102,6 +102,13 @@ func (gg *goget) list(op errors.Op, mod string) (*listResp, error) {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
+	gopath, err := afero.TempDir(gg.fs, "", "athens")
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	defer module.ClearFiles(gg.fs, gopath)
+	cmd.Env = module.PrepareEnv(gopath)
+
 	err = cmd.Run()
 	if err != nil {
 		err = fmt.Errorf("%v: %s", err, stderr)

--- a/pkg/module/disk_ref.go
+++ b/pkg/module/disk_ref.go
@@ -31,7 +31,7 @@ type zipReadCloser struct {
 // It is the caller's responsibility to call this method to free up utilized disk space
 func (rc *zipReadCloser) Close() error {
 	rc.zip.Close()
-	return clearFiles(rc.ref.fs, rc.ref.root)
+	return ClearFiles(rc.ref.fs, rc.ref.root)
 }
 
 func (rc *zipReadCloser) Read(p []byte) (n int, err error) {
@@ -47,9 +47,9 @@ func newDiskRef(fs afero.Fs, root, module, version string) *diskRef {
 	}
 }
 
-// clearFiles deletes all data from the given fs at path root
+// ClearFiles deletes all data from the given fs at path root
 // This function must be called when zip is closed to cleanup the entire GOPATH created by the diskref
-func clearFiles(fs afero.Fs, root string) error {
+func ClearFiles(fs afero.Fs, root string) error {
 	const op errors.Op = "clearFiles"
 	// This is required because vgo ensures dependencies are read-only
 	// See https://github.com/golang/go/issues/24111 and

--- a/pkg/module/disk_ref_test.go
+++ b/pkg/module/disk_ref_test.go
@@ -63,7 +63,7 @@ func (m *ModuleSuite) TestDiskRefClearFail() {
 	root := "testroot"
 	r := m.Require()
 	// This should fail because we haven't created any files
-	err := clearFiles(m.fs, root)
+	err := ClearFiles(m.fs, root)
 	r.EqualError(err, "open testroot: file does not exist")
 }
 
@@ -86,7 +86,7 @@ func (m *ModuleSuite) TestDiskRefClearSuccess() {
 	r.NoError(err)
 
 	// Now clear the files
-	err = clearFiles(m.fs, root)
+	err = ClearFiles(m.fs, root)
 	r.NoError(err)
 
 	// Validate the file has been deleted

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -43,19 +43,19 @@ func (g *goGetFetcher) Fetch(mod, ver string) (Ref, error) {
 	sourcePath := filepath.Join(goPathRoot, "src")
 	modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
 	if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
-		clearFiles(g.fs, goPathRoot)
+		ClearFiles(g.fs, goPathRoot)
 		return nil, errors.E(op, err)
 	}
 
 	// setup the module with barebones stuff
 	if err := Dummy(g.fs, modPath); err != nil {
-		clearFiles(g.fs, goPathRoot)
+		ClearFiles(g.fs, goPathRoot)
 		return nil, errors.E(op, err)
 	}
 
 	err = getSources(g.goBinaryName, g.fs, goPathRoot, modPath, mod, ver)
 	if err != nil {
-		clearFiles(g.fs, goPathRoot)
+		ClearFiles(g.fs, goPathRoot)
 		return nil, errors.E(op, err)
 	}
 
@@ -87,7 +87,7 @@ func getSources(goBinaryName string, fs afero.Fs, gopath, repoRoot, module, vers
 	fullURI := fmt.Sprintf("%s@%s", uri, version)
 
 	cmd := exec.Command(goBinaryName, "mod", "download", fullURI)
-	cmd.Env = prepareEnv(gopath)
+	cmd.Env = PrepareEnv(gopath)
 	cmd.Dir = repoRoot
 	o, err := cmd.CombinedOutput()
 	if err != nil {
@@ -113,7 +113,10 @@ func getSources(goBinaryName string, fs afero.Fs, gopath, repoRoot, module, vers
 	return nil
 }
 
-func prepareEnv(gopath string) []string {
+// PrepareEnv will return all the appropriate
+// environment variables for a Go Command to run
+// successfully (such as GOPATH, GOCACHE, PATH etc)
+func PrepareEnv(gopath string) []string {
 	pathEnv := fmt.Sprintf("PATH=%s", os.Getenv("PATH"))
 	gopathEnv := fmt.Sprintf("GOPATH=%s", gopath)
 	cacheEnv := fmt.Sprintf("GOCACHE=%s", filepath.Join(gopath, "cache"))


### PR DESCRIPTION
Go sends up to 10 protocol commands concurrently, and so if you have the following deps

```
import (
  "github.com/user/pkg"
  "github.comuser/pkg/subpkg"
)
```

Then go might send both requests at the same time, and you'll see weird errors such as `git ls repository already exists`. 

Therefore, we should treat `go list -m` just like `go mod download` in that each time they get a fresh empty GOPATH so that they don't on each other. And make sure we remove it after. 