### PR TITLE
Makefile: Add minio to dev target

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ it easy to get up and running:
 That's it! After the `make dev` command is done, everything will be up and running and you can move
 on to the next step.
 
-If you want to stop everything at any time, run `make down`.
+If you want to stop everything at any time, run `make dev-teardown`.
 
 Note that `make dev` only runs the minimum amount of dependencies needed for things to work. If you'd like to run all the possible dependencies run `make alldeps` or directly the services available in the `docker-compose.yml` file.
 

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,11 @@ alldeps:
 	docker-compose -p athensdev up -d minio
 	docker-compose -p athensdev up -d jaeger
 	echo "sleeping for a bit to wait for the DB to come up"
-	sleep 5	
+	sleep 5
 
 .PHONY: dev
 dev:
+	docker-compose -p athensdev up -d minio
 	docker-compose -p athensdev up -d mongo
 	docker-compose -p athensdev up -d redis
 

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,6 @@ dev:
 	docker-compose -p athensdev up -d mongo
 	docker-compose -p athensdev up -d redis
 
-.PHONY: down
-down:
-	docker-compose -p athensdev down -v
-
 .PHONY: dev-teardown
 dev-teardown:
 	docker-compose -p athensdev down -v


### PR DESCRIPTION
This adds minio to the makefile target `dev`. This is because unit tests require minio to run.

closes #476 