### PR TITLE
disable inline copy to clipboard

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -5,6 +5,7 @@ title = "Athens"
 
 [params]
 disableShortcutsTitle = true
+disableInlineCopyToClipBoard = true
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]


### PR DESCRIPTION
This just disables the little copy to clipboard button in our inline code blocks.

closes #510