### PR TITLE
No conflicts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Run `make test-e2e` to run the end-to-end tests.
 
 The first time you run the tests,
 you must run `make setup-dev-env` first, otherwise you will see errors like the one below:
-<<<<<<<HEAD
+
 ```
 error connecting to storage (no reachable servers)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Run `make test-e2e` to run the end-to-end tests.
 
 The first time you run the tests,
 you must run `make setup-dev-env` first, otherwise you will see errors like the one below:
-
+<<<<<<<HEAD
 ```
 error connecting to storage (no reachable servers)
 ```

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ verify:
 	./scripts/check_gofmt.sh
 	./scripts/check_golint.sh
 	./scripts/check_deps.sh
+	./scripts/check_conflicts.sh
 
 .PHONY: test
 test:

--- a/scripts/check_conflicts.sh
+++ b/scripts/check_conflicts.sh
@@ -11,8 +11,12 @@
 # CI build to fail. Merge conflict artifacts must be removed before continuing.
 
 git remote set-branches --add origin master && git fetch
-COUNT=$(git diff origin/master -- . ':!*.go' ':!go.mod' ':!go.sum' | grep -Ec "^[\+~][<>=]{7}\w{0,}")
+COUNT=$(git diff origin/master -- . ':!*.go' ':!go.mod' ':!go.sum' | grep -Ec "^\+[<>=]{7}\w{0,}")
 
 if (($COUNT > 0));then
+  echo "************************************************************"
+  echo "The following files contained merge conflict artifacts:\n"
+  exec git diff --name-only -G'^[<>=]{7}\w?' origin/master -- . ':!*.go' ':!go.mod' ':!go.sum'
+  echo "************************************************************"
   exit 1
 fi

--- a/scripts/check_conflicts.sh
+++ b/scripts/check_conflicts.sh
@@ -11,7 +11,7 @@
 # CI build to fail. Merge conflict artifacts must be removed before continuing.
 
 git remote set-branches --add origin master && git fetch
-COUNT=$(git diff origin/master -- . ':1*.go' ':!go.mod' ':!go.sum' | grep -Ec "^[\+~][<>=]{7}\w{0,}")
+COUNT=$(git diff origin/master -- . ':!*.go' ':!go.mod' ':!go.sum' | grep -Ec "^[\+~][<>=]{7}\w{0,}")
 
 if (($COUNT > 0));then
   exit 1

--- a/scripts/check_conflicts.sh
+++ b/scripts/check_conflicts.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# check_conflicts.sh
+# this script checks for changes to files OTHER THAN *.go, go.mod and go.sum
+# ensuring no git merge conflict artifacts are being commited.
+# i.e. <<<<<<<HEAD or ======= or >>>>>>>branch-name
+#
+# this is intended to be used in your CI tests
+#
+# the script will exit with code 1 on finding any matches, causing the
+# CI build to fail. Merge conflict artifacts must be removed before continuing.
+
+git remote set-branches --add origin master && git fetch
+COUNT=$(git diff -- . ':1*.go' ':!go.mod' ':!go.sum' origin/master | grep -Ec "^[\+~][<>=]{7}\w{0,}")
+
+if (($COUNT > 0));then
+  exit 1
+fi

--- a/scripts/check_conflicts.sh
+++ b/scripts/check_conflicts.sh
@@ -11,7 +11,7 @@
 # CI build to fail. Merge conflict artifacts must be removed before continuing.
 
 git remote set-branches --add origin master && git fetch
-COUNT=$(git diff -- . ':1*.go' ':!go.mod' ':!go.sum' origin/master | grep -Ec "^[\+~][<>=]{7}\w{0,}")
+COUNT=$(git diff origin/master -- . ':1*.go' ':!go.mod' ':!go.sum' | grep -Ec "^[\+~][<>=]{7}\w{0,}")
 
 if (($COUNT > 0));then
   exit 1


### PR DESCRIPTION
This new script returns exit code 1 when any files other than '*.go,go.mod,go,sum' contain merge conflict artifacts. `<<<<<<<HEAD`, `=======` or `>>>>>>>branch-name`.

It skips the mentioned files as those will be caught during linting and dependency checks.

closes #273 