### PR TITLE
Redirect http traffic to https for docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,9 @@
     publish = "docs/public/"
     command = "hugo -v"
     environment = { HUGO_VERSION = "0.37" }
+
+[redirects]
+  from = "http://docs.gomods.io/*"
+  to = "https://docs.gomods.io/:splat"
+  status = 301
+  force = true    

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
     command = "hugo -v"
     environment = { HUGO_VERSION = "0.37" }
 
-[redirects]
+[[redirects]]
   from = "http://docs.gomods.io/*"
   to = "https://docs.gomods.io/:splat"
   status = 301


### PR DESCRIPTION
The commits in this PR should correct issue #597 without taking a more extreme route of not accepting http traffic at all. This fix may not appear to work in Netlify staging environments due to the base URL of the production site being the only one with the redirect.

Information for this commit was gathered from

- https://stackoverflow.com/questions/49712714/can-netlify-redirect-traffic-from-http-to-https-without-forcing-ssl
- https://www.netlify.com/docs/redirects/#structured-configuration 