### PR TITLE
Provide binary release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+builds:
+  -
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+    main: ./cmd/proxy/main.go
+    binary: athens-proxy
+    env:
+      - CGO_ENABLED=0
+archive:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
+    }}v{{ .Arm }}{{ end }}'
+  format: tar.gz
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,6 @@ archive:
     }}v{{ .Arm }}{{ end }}'
   format: tar.gz
   files:
-  - licence*
-  - LICENCE*
   - license*
   - LICENSE*
   - readme*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,13 @@ archive:
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
     }}v{{ .Arm }}{{ end }}'
   format: tar.gz
+  files:
+  - licence*
+  - LICENCE*
+  - license*
+  - LICENSE*
+  - readme*
+  - README*
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - CODE_COV=1
     - ATHENS_DIR=${GOPATH}/src/github.com/gomods/athens
     - REGISTRY=gomods/
+    - GORELEASER_ON=0
   matrix:
     # remove this after Go1.12 ships
     - GO111MODULE=auto
@@ -38,8 +39,14 @@ before_deploy:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 deploy:
-  provider: script
-  script: make docker-push
-  on:
-    repo: gomods/athens
-    all_branches: true
+  - provider: script
+    script: make docker-push
+    on:
+      repo: gomods/athens
+      all_branches: true
+  - provider: script
+    skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
+    on:
+      tags: true
+      condition: $GORELEASER_ON = 1 AND $GO111MODULE = on

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - CODE_COV=1
     - ATHENS_DIR=${GOPATH}/src/github.com/gomods/athens
     - REGISTRY=gomods/
-    - GORELEASER_ON=0
+    - GORELEASER_ON=1
   matrix:
     # remove this after Go1.12 ships
     - GO111MODULE=auto
@@ -46,7 +46,6 @@ deploy:
       all_branches: true
   - provider: script
     skip_cleanup: true
-    script: curl -sL https://git.io/goreleaser | bash
+    script: curl -sL https://git.io/goreleaser | bash -s -- --snapshot
     on:
-      tags: true
       condition: $GORELEASER_ON = 1 AND $GO111MODULE = on


### PR DESCRIPTION
This PR provides support for binary releases (Windows, Linux, MacOs) of Athens-proxy (Olympus can be easily added)
It does so using goreleaser https://goreleaser.com

It requires a Github token with repo scope set in Travis
@arschles it would be great if you could create one and set it in Travis

Fixes #581 