### PR TITLE
Fix powershell scripts

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -51,7 +51,7 @@ Param(
 	[switch]$down
 )
 function execScript($name) {
-	$scriptsDir = "$(join-path scripts ps)"
+	$scriptsDir = "$(Join-Path scripts ps)"
 	& "$(Join-Path $scriptsDir $name)"
 }
 

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -14,7 +14,7 @@ set -xeuo pipefail
 git remote set-branches --add origin master && git fetch
 ChangedFiles=`git diff --name-only origin/master`
 
-# in the casse that ChangedFiles contains go.mod or go.sum run go mod verify
+# in the case that ChangedFiles contains go.mod or go.sum run go mod verify
 case "$ChangedFiles" in
   go.mod | go.sum)
     go mod verify

--- a/scripts/ps/check_deps.ps1
+++ b/scripts/ps/check_deps.ps1
@@ -13,5 +13,5 @@ $ChangedFiles=$(git diff --name-only origin/master)
 # in the case that ChangedFiles contains go.mod or go.sum run go mod verify
 $contains= $ChangedFiles | Select-String -Pattern "go.mod|go.sum"
 if ($contains.length -gt 0) {
-	go mod verify
+	Write-Error $(go mod verify)
 }

--- a/scripts/ps/check_deps.ps1
+++ b/scripts/ps/check_deps.ps1
@@ -1,0 +1,17 @@
+# check_deps.ps1
+# this script checks for changes to the files go.mod and go.sum
+#
+# this is intended to be used in your CI tests
+#
+# on encountering any changes for these files the script runs go mod verify
+# to check for any conflicts in versions or digests
+# which on any exit code > 0 would suggest that action should be taken
+# before a pull request can be merged.
+git remote set-branches --add origin master ; git fetch
+$ChangedFiles=$(git diff --name-only origin/master)
+
+# in the case that ChangedFiles contains go.mod or go.sum run go mod verify
+$contains= $ChangedFiles | Select-String -Pattern "go.mod|go.sum"
+if ($contains.length -gt 0) {
+	go mod verify
+}

--- a/scripts/ps/check_gofmt.ps1
+++ b/scripts/ps/check_gofmt.ps1
@@ -1,6 +1,6 @@
 # check_gofmt.ps1
 # Fail if a .go file hasn't been formatted with gofmt
-$GO_FILES = Get-ChildItem -Recurse -Filter *.go  -Name | Select-String -Pattern $(Join-Path "vendor" | Join-Path -ChildPath "") -NotMatch
+$GO_FILES = Get-ChildItem -Recurse -Filter *.go  -Name | Select-String -Pattern $(Join-Path "vendor" -ChildPath ".*") -NotMatch
 $out = & gofmt -s -l $GO_FILES
 if ($out.length -gt 0) {
     Write-Error $out


### PR DESCRIPTION
The `scripts/ps` directory was missing `check_deps.ps1`, and had a major typo in `check_gofmt.ps1` that prevented a successful run.
Fixed a couple of typos in related files while I was at it.