### PR TITLE
change go releaser to create draft releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ release:
     owner: gomods
     name: athens
   name_template: '{{.Tag}}'
+  draft: true
 builds:
   -
     goos:


### PR DESCRIPTION
This will have go releaser still generate the binaries on a new tag but only _draft_ a new github release. Leaving it up to a maintainer to read over, edit if necessary, and then publish a release.

I think this will be better than just publishing the generated releases as we may add a message to the community or edit out extra commit messages that are not very relevant, creating a more readable and useful release notice.