### PR TITLE
Using the buffalo built-in logger

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -120,6 +120,7 @@ func App() (*buffalo.App, error) {
 		app.Stop(err)
 	}
 	app.Use(T.Middleware())
+	app.Use(mw.LogEntryMiddleware)
 
 	if !env.FilterOff() {
 		mf := module.NewFilter()
@@ -128,7 +129,7 @@ func App() (*buffalo.App, error) {
 
 	// Having the hook set means we want to use it
 	if validatorHook, ok := env.ValidatorHook(); ok {
-		app.Use(mw.LogEntryMiddleware(mw.NewValidationMiddleware, lggr, validatorHook))
+		app.Use(mw.NewValidationMiddleware(validatorHook))
 	}
 
 	user, pass, ok := env.BasicAuth()

--- a/pkg/download/latest.go
+++ b/pkg/download/latest.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gomods/athens/pkg/errors"
-	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/paths"
 )
 
@@ -14,18 +13,20 @@ import (
 const PathLatest = "/{module:.+}/@latest"
 
 // LatestHandler implements GET baseURL/module/@latest
-func LatestHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
+func LatestHandler(dp Protocol, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.LatestHandler"
 	return func(c buffalo.Context) error {
 		mod, err := paths.GetModule(c)
 		if err != nil {
-			lggr.SystemErr(errors.E(op, err))
+			c.Logger().Warn(errors.E(op, err))
+			// lggr.SystemErr(errors.E(op, err))
 			return c.Render(500, nil)
 		}
 
 		info, err := dp.Latest(c, mod)
 		if err != nil {
-			lggr.SystemErr(errors.E(op, err))
+			c.Logger().Warn(errors.E(op, err))
+			// lggr.SystemErr(errors.E(op, err))
 			return c.Render(errors.Kind(err), eng.JSON(errors.KindText(err)))
 		}
 

--- a/pkg/download/list.go
+++ b/pkg/download/list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gomods/athens/pkg/errors"
-	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/paths"
 )
 
@@ -15,18 +14,20 @@ import (
 const PathList = "/{module:.+}/@v/list"
 
 // ListHandler implements GET baseURL/module/@v/list
-func ListHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
+func ListHandler(dp Protocol, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.ListHandler"
 	return func(c buffalo.Context) error {
 		mod, err := paths.GetModule(c)
 		if err != nil {
-			lggr.SystemErr(errors.E(op, err))
+			c.Logger().Warn(errors.E(op, err))
+			// lggr.SystemErr(errors.E(op, err))
 			return c.Render(500, nil)
 		}
 
 		versions, err := dp.List(c, mod)
 		if err != nil {
-			lggr.SystemErr(errors.E(op, err))
+			c.Logger().Warn(errors.E(op, err))
+			// lggr.SystemErr(errors.E(op, err))
 			return c.Render(errors.Kind(err), eng.JSON(errors.KindText(err)))
 		}
 

--- a/pkg/download/version_info.go
+++ b/pkg/download/version_info.go
@@ -8,26 +8,27 @@ import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gomods/athens/pkg/errors"
-	"github.com/gomods/athens/pkg/log"
 )
 
 // PathVersionInfo URL.
 const PathVersionInfo = "/{module:.+}/@v/{version}.info"
 
 // VersionInfoHandler implements GET baseURL/module/@v/version.info
-func VersionInfoHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
+func VersionInfoHandler(dp Protocol, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.versionInfoHandler"
 	return func(c buffalo.Context) error {
 		ctx, span := observ.StartSpan(c, op.String())
 		defer span.End()
 		mod, ver, err := getModuleParams(c, op)
 		if err != nil {
-			lggr.SystemErr(err)
+			c.Logger().Warn(errors.E(op, err))
+			// lggr.SystemErr(err)
 			return c.Render(errors.Kind(err), nil)
 		}
 		info, err := dp.Info(ctx, mod, ver)
 		if err != nil {
-			lggr.SystemErr(errors.E(op, err, errors.M(mod), errors.V(ver)))
+			c.Logger().Warn(errors.E(op, err, errors.M(mod), errors.V(ver)))
+			// lggr.SystemErr(errors.E(op, err, errors.M(mod), errors.V(ver)))
 			return c.Render(errors.Kind(err), nil)
 		}
 

--- a/pkg/download/version_module.go
+++ b/pkg/download/version_module.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gomods/athens/pkg/errors"
-	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/observ"
 )
 
@@ -12,20 +11,22 @@ import (
 const PathVersionModule = "/{module:.+}/@v/{version}.mod"
 
 // VersionModuleHandler implements GET baseURL/module/@v/version.mod
-func VersionModuleHandler(dp Protocol, lggr log.Entry, eng *render.Engine) buffalo.Handler {
+func VersionModuleHandler(dp Protocol, eng *render.Engine) buffalo.Handler {
 	const op errors.Op = "download.VersionModuleHandler"
 	return func(c buffalo.Context) error {
 		ctx, span := observ.StartSpan(c, op.String())
 		defer span.End()
 		mod, ver, err := getModuleParams(c, op)
 		if err != nil {
-			lggr.SystemErr(err)
+			c.Logger().Warn(errors.E(op, err))
+			// lggr.SystemErr(err)
 			return c.Render(errors.Kind(err), nil)
 		}
 		modBts, err := dp.GoMod(ctx, mod, ver)
 		if err != nil {
 			err = errors.E(op, errors.M(mod), errors.V(ver), err)
-			lggr.SystemErr(err)
+			c.Logger().Warn(err)
+			// lggr.SystemErr(err)
 			return c.Render(errors.Kind(err), nil)
 		}
 

--- a/pkg/middleware/log_entry.go
+++ b/pkg/middleware/log_entry.go
@@ -2,25 +2,19 @@ package middleware
 
 import (
 	"github.com/gobuffalo/buffalo"
-	"github.com/gomods/athens/pkg/log"
 	"github.com/sirupsen/logrus"
 )
 
-type middlewareFunc func(entry log.Entry, validatorHook string) buffalo.MiddlewareFunc
-
 // LogEntryMiddleware builds a log.Entry applying the request parameter to the given
 // log.Logger and propagates it to the given MiddlewareFunc
-func LogEntryMiddleware(middleware middlewareFunc, lggr *log.Logger, validatorHook string) buffalo.MiddlewareFunc {
-	return func(next buffalo.Handler) buffalo.Handler {
-		return func(c buffalo.Context) error {
-			req := c.Request()
-			ent := lggr.WithFields(logrus.Fields{
-				"http-method": req.Method,
-				"http-path":   req.URL.Path,
-				"http-url":    req.URL.String(),
-			})
-			m := middleware(ent, validatorHook)
-			return m(next)(c)
-		}
+func LogEntryMiddleware(next buffalo.Handler) buffalo.Handler {
+	return func(c buffalo.Context) error {
+		req := c.Request()
+		c.LogFields(logrus.Fields{
+			"http-method": req.Method,
+			"http-path":   req.URL.Path,
+			"http-url":    req.URL.String(),
+		})
+		return next(c)
 	}
 }

--- a/pkg/middleware/validation.go
+++ b/pkg/middleware/validation.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gomods/athens/pkg/errors"
-	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/paths"
 )
 
 // NewValidationMiddleware builds a middleware function that performs validation checks by calling
 // an external webhook
-func NewValidationMiddleware(entry log.Entry, validatorHook string) buffalo.MiddlewareFunc {
+func NewValidationMiddleware(validatorHook string) buffalo.MiddlewareFunc {
 	const op errors.Op = "actions.ValidationMiddleware"
 
 	return func(next buffalo.Handler) buffalo.Handler {
@@ -32,7 +31,11 @@ func NewValidationMiddleware(entry log.Entry, validatorHook string) buffalo.Midd
 			if version != "" {
 				valid, err := validate(validatorHook, mod, version)
 				if err != nil {
-					entry.SystemErr(err)
+					// Not sure if we can create a `SystemErr` function instead of this?
+					//
+					// If we can, maybe we could call log.SystemErr(c.Logger(), err)
+					// c.Logger().SystemErr(err)
+					c.Logger().Error(err)
 					return c.Render(http.StatusInternalServerError, nil)
 				}
 


### PR DESCRIPTION
Instead of trying to thread log entries down the stack, we can use the built-in buffalo logger and pass that down the stack as we already do. The buffalo logger is backed by logrus too.

@fedepaol and I discussed this on slack today. I think it can fix #537 if people are ok with it.

cc/ @marwan-at-work - I know you were pretty deep in conversation about this topic

Ref #537 