### PR TITLE
Fix for Windows 10

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -107,6 +107,7 @@ if ($alldeps.IsPresent) {
 if ($dev.IsPresent) {
 	& docker-compose -p athensdev up -d mongo
 	& docker-compose -p athensdev up -d redis
+	execScript "create_default_config.ps1"
 }
 
 if ($test.IsPresent) {

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -131,6 +131,9 @@ func PrepareEnv(gopath string) []string {
 	if runtime.GOOS == "windows" {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("USERPROFILE=%s", os.Getenv("USERPROFILE")))
 		cmdEnv = append(cmdEnv, fmt.Sprintf("SystemRoot=%s", os.Getenv("SystemRoot")))
+		cmdEnv = append(cmdEnv, fmt.Sprintf("ALLUSERSPROFILE=%s", os.Getenv("ALLUSERSPROFILE")))
+		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEDRIVE=%s", os.Getenv("HOMEDRIVE")))
+		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEPATH=%s", os.Getenv("HOMEPATH")))
 	}
 
 	return cmdEnv

--- a/scripts/ps/create_default_config.ps1
+++ b/scripts/ps/create_default_config.ps1
@@ -1,0 +1,6 @@
+$repoDir = Join-Path $PSScriptRoot ".." | Join-Path -ChildPath ".."
+if (-not (Join-Path $repoDir config.toml | Test-Path)) {
+    $example = Join-Path $repoDir config.example.toml
+    $target = Join-Path $repoDir config.toml
+    Copy-Item $example $target
+}


### PR DESCRIPTION
Currently proxy doesn't work on Windows 10.
This PR fixes this issue by adding required ENV variables
It also updates the `test_e2e` powershell script so that it uses `go build -mod=vendor` just like the bash version