### PR TITLE
Adding CodeTriage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
+# Welcome To Athens, Gophers!
+
 ![Athens Banner](./docs/static/banner.png)
 
-# Welcome Gophers!
+[![Open Source Helpers](https://www.codetriage.com/gomods/athens/badges/users.svg)](https://www.codetriage.com/gomods/athens)
+[![Build Status](https://travis-ci.org/gomods/athens.svg?branch=master)](https://travis-ci.org/gomods/athens)
+[![codecov](https://codecov.io/gh/gomods/athens/branch/master/graph/badge.svg)](https://codecov.io/gh/gomods/athens)
+[![GoDoc](https://godoc.org/github.com/gomods/athens?status.svg)](https://godoc.org/github.com/gomods/athens)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gomods/athens)](https://goreportcard.com/report/github.com/gomods/athens)
 
 Welcome to the Athens project! We're building all things Go package repository in here.
 
@@ -10,11 +16,6 @@ Welcome to the Athens project! We're building all things Go package repository i
 See our documentation site [https://docs.gomods.io](https://docs.gomods.io) for more details on the project.
 
 # Project Status
-
-[![Build Status](https://travis-ci.org/gomods/athens.svg?branch=master)](https://travis-ci.org/gomods/athens)
-[![codecov](https://codecov.io/gh/gomods/athens/branch/master/graph/badge.svg)](https://codecov.io/gh/gomods/athens)
-[![GoDoc](https://godoc.org/github.com/gomods/athens?status.svg)](https://godoc.org/github.com/gomods/athens)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gomods/athens)](https://goreportcard.com/report/github.com/gomods/athens)
 
 Project Athens is in a very early alpha release and everything might change.
 Don't run it in production, but do play around with it and [contribute](#contributing)


### PR DESCRIPTION
Thanks for suggesting this @timraymond!!!

I've submitted Athens to CodeTriage and added the codetriage badge

I also:

- shifted the badges above the athens logo
- shifter the "welcome gophers" header above the logo.
- changed "welcome gophers" to "welcome to athens, gophers"

Fixes https://github.com/gomods/athens/issues/656