### PR TITLE
redirect other domain requests to docs.gomods.io

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,16 +8,16 @@
     environment = { HUGO_VERSION = "0.37" }
 
 [[redirects]]
-  from = https://gomods.io/*
-  to = https://docs.gomods.io/:splat
+  from = "https://gomods.io/*"
+  to = "https://docs.gomods.io/:splat"
   status = 303
 
 [[redirects]]
-  from = http://gomods.io/*
-  to = https://docs.gomods.io/:splat
+  from = "http://gomods.io/*"
+  to = "https://docs.gomods.io/:splat"
   status = 303
 
 [[redirects]]
-  from = https://gomods-athens.netlify.com/*
-  to = https://docs.gomods.io/:splat
+  from = "https://gomods-athens.netlify.com/*"
+  to = "https://docs.gomods.io/:splat"
   status = 303

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,18 @@
     publish = "docs/public/"
     command = "hugo -v"
     environment = { HUGO_VERSION = "0.37" }
+
+[[redirects]]
+  from = https://gomods.io/*
+  to = https://docs.gomods.io/:splat
+  status = 303
+
+[[redirects]]
+  from = http://gomods.io/*
+  to = https://docs.gomods.io/:splat
+  status = 303
+
+[[redirects]]
+  from = https://gomods-athens.netlify.com/*
+  to = https://docs.gomods.io/:splat
+  status = 303


### PR DESCRIPTION
I used a 303 status code as the pages currently hosted should always be requested at `docs.gomods.io` not any of the other possible domains. `gomods.io | gomods-athens.netlify.com`.

will close #651