### PR TITLE
Patch points of test flag leakage.

### DIFF
--- a/cmd/olympus/actions/actions_test.go
+++ b/cmd/olympus/actions/actions_test.go
@@ -23,7 +23,10 @@ type ActionSuite struct {
 }
 
 func Test_ActionSuite(t *testing.T) {
-	conf := config.GetConfLogErr(testConfigFile, t)
+	conf, err := config.GetConf(testConfigFile)
+	if err != nil {
+		t.Fatalf("Unable to parse config file: %s", err.Error())
+	}
 	app, err := App(conf)
 	if err != nil {
 		t.Fatalf("Failed to initialize app: %s", err)

--- a/cmd/proxy/actions/actions_test.go
+++ b/cmd/proxy/actions/actions_test.go
@@ -17,7 +17,10 @@ type ActionSuite struct {
 }
 
 func Test_ActionSuite(t *testing.T) {
-	conf := config.GetConfLogErr(testConfigFile, t)
+	conf, err := config.GetConf(testConfigFile)
+	if err != nil {
+		t.Fatalf("Unable to parse config file: %s", err.Error())
+	}
 	app, err := App(conf)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"testing"
 
 	"github.com/BurntSushi/toml"
 	"github.com/kelseyhightower/envconfig"
@@ -98,15 +97,4 @@ func GetConf(path string) (*Config, error) {
 		return nil, fmt.Errorf("Unable to parse test config file: %s", err.Error())
 	}
 	return conf, nil
-}
-
-// GetConfLogErr is similar to GetConf, except it logs a failure for the calling test
-// if any errors are encountered
-func GetConfLogErr(path string, t *testing.T) *Config {
-	c, err := GetConf(path)
-	if err != nil {
-		t.Fatalf("Unable to parse config file: %s", err.Error())
-		return nil
-	}
-	return c
 }

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -27,7 +27,10 @@ var (
 
 func getDP(t *testing.T) Protocol {
 	t.Helper()
-	conf := config.GetConfLogErr(testConfigPath, t)
+	conf, err := config.GetConf(testConfigPath)
+	if err != nil {
+		t.Fatalf("Unable to parse config file: %s", err.Error())
+	}
 	goBin := conf.GoBinary
 	fs := afero.NewOsFs()
 	mf, err := module.NewGoGetFetcher(goBin, fs)

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -53,7 +53,10 @@ func newTestFilter(filterFile string) *module.Filter {
 func Test_FilterMiddleware(t *testing.T) {
 	r := require.New(t)
 
-	conf := config.GetConfLogErr(testConfigFile, t)
+	conf, err := config.GetConf(testConfigFile)
+	if err != nil {
+		t.Fatalf("Unable to parse config file: %s", err.Error())
+	}
 	if conf.Proxy == nil {
 		t.Fatalf("No Proxy configuration in test config")
 	}

--- a/pkg/module/filter_test.go
+++ b/pkg/module/filter_test.go
@@ -22,7 +22,7 @@ func Test_Filter(t *testing.T) {
 
 func (t *FilterTests) Test_IgnoreSimple() {
 	r := t.Require()
-	conf := config.GetConfLogErr(testConfigFile, t.T())
+	conf := GetConfLogErr(testConfigFile, t.T())
 	f := NewFilter(conf.FilterFile)
 	f.AddRule("github.com/a/b", Exclude)
 
@@ -35,7 +35,7 @@ func (t *FilterTests) Test_IgnoreSimple() {
 
 func (t *FilterTests) Test_IgnoreParentAllowChildren() {
 	r := t.Require()
-	conf := config.GetConfLogErr(testConfigFile, t.T())
+	conf := GetConfLogErr(testConfigFile, t.T())
 	f := NewFilter(conf.FilterFile)
 	f.AddRule("github.com/a/b", Exclude)
 	f.AddRule("github.com/a/b/c", Include)
@@ -50,7 +50,7 @@ func (t *FilterTests) Test_IgnoreParentAllowChildren() {
 func (t *FilterTests) Test_OnlyAllowed() {
 	r := t.Require()
 
-	conf := config.GetConfLogErr(testConfigFile, t.T())
+	conf := GetConfLogErr(testConfigFile, t.T())
 	f := NewFilter(conf.FilterFile)
 	f.AddRule("github.com/a/b", Include)
 	f.AddRule("", Exclude)
@@ -65,7 +65,7 @@ func (t *FilterTests) Test_OnlyAllowed() {
 func (t *FilterTests) Test_Direct() {
 	r := t.Require()
 
-	conf := config.GetConfLogErr(testConfigFile, t.T())
+	conf := GetConfLogErr(testConfigFile, t.T())
 	f := NewFilter(conf.FilterFile)
 	f.AddRule("github.com/a/b/c", Exclude)
 	f.AddRule("github.com/a/b", Direct)
@@ -75,4 +75,15 @@ func (t *FilterTests) Test_Direct() {
 	r.Equal(Include, f.Rule("github.com/a"))
 	r.Equal(Direct, f.Rule("github.com/a/b"))
 	r.Equal(Exclude, f.Rule("github.com/a/b/c/d"))
+}
+
+// GetConfLogErr is similar to GetConf, except it logs a failure for the calling test
+// if any errors are encountered
+func GetConfLogErr(path string, t *testing.T) *config.Config {
+	c, err := config.GetConf(path)
+	if err != nil {
+		t.Fatalf("Unable to parse config file: %s", err.Error())
+		return nil
+	}
+	return c
 }

--- a/pkg/storage/fs/test_suite.go
+++ b/pkg/storage/fs/test_suite.go
@@ -1,21 +1,19 @@
 package fs
 
 import (
-	"github.com/gobuffalo/suite"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/spf13/afero"
 )
 
 // TestSuite implements storage.TestSuite interface
 type TestSuite struct {
-	*suite.Model
 	storage storage.Backend
 	fs      afero.Fs
 	rootDir string
 }
 
 // NewTestSuite creates a common test suite
-func NewTestSuite(model *suite.Model) (storage.TestSuite, error) {
+func NewTestSuite() (storage.TestSuite, error) {
 	osFs := afero.NewOsFs()
 	r, err := afero.TempDir(osFs, "", "athens-fs-storage-tests")
 	if err != nil {
@@ -28,7 +26,6 @@ func NewTestSuite(model *suite.Model) (storage.TestSuite, error) {
 	}
 
 	return &TestSuite{
-		Model:   model,
 		fs:      osFs,
 		rootDir: r,
 		storage: fsStore,

--- a/pkg/storage/mem/test_suite.go
+++ b/pkg/storage/mem/test_suite.go
@@ -1,23 +1,20 @@
 package mem
 
 import (
-	"github.com/gobuffalo/suite"
 	"github.com/gomods/athens/pkg/storage"
 )
 
 // TestSuite implements storage.TestSuite interface
 type TestSuite struct {
-	*suite.Model
 	storage storage.Backend
 }
 
 // NewTestSuite creates a common test suite
-func NewTestSuite(model *suite.Model) (storage.TestSuite, error) {
+func NewTestSuite() (storage.TestSuite, error) {
 	memStore, err := NewStorage()
 
 	return &TestSuite{
 		storage: memStore,
-		Model:   model,
 	}, err
 }
 

--- a/pkg/storage/minio/test_suite.go
+++ b/pkg/storage/minio/test_suite.go
@@ -3,7 +3,6 @@ package minio
 import (
 	"fmt"
 
-	"github.com/gobuffalo/suite"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/storage"
 	minio "github.com/minio/minio-go"
@@ -11,18 +10,16 @@ import (
 
 // TestSuite implements storage.TestSuite interface
 type TestSuite struct {
-	*suite.Model
 	storage storage.Backend
 	conf    *config.MinioConfig
 }
 
 // NewTestSuite creates a common test suite
-func NewTestSuite(model *suite.Model, conf *config.MinioConfig) (storage.TestSuite, error) {
+func NewTestSuite(conf *config.MinioConfig) (storage.TestSuite, error) {
 	minioStorage, err := newTestStore(conf)
 
 	return &TestSuite{
 		storage: minioStorage,
-		Model:   model,
 		conf:    conf,
 	}, err
 }

--- a/pkg/storage/mongo/local_test.go
+++ b/pkg/storage/mongo/local_test.go
@@ -17,15 +17,21 @@ type MongoTests struct {
 }
 
 func (m *MongoTests) SetupTest() {
-	conf := config.GetConfLogErr(testConfigFile, m.T())
+	conf, err := config.GetConf(testConfigFile)
+	if err != nil {
+		m.T().Fatalf("Unable to parse config file: %s", err.Error())
+	}
 
-	_, err := newTestStore(conf.Storage.Mongo)
+	_, err = newTestStore(conf.Storage.Mongo)
 	m.Require().NoError(err)
 }
 
 func (m *MongoTests) TestNewMongoStorage() {
 	r := m.Require()
-	conf := config.GetConfLogErr(testConfigFile, m.T())
+	conf, err := config.GetConf(testConfigFile)
+	if err != nil {
+		m.T().Fatalf("Unable to parse config file: %s", err.Error())
+	}
 	getterSaver, err := NewStorage(conf.Storage.Mongo)
 
 	r.NoError(err)

--- a/pkg/storage/mongo/test_suite.go
+++ b/pkg/storage/mongo/test_suite.go
@@ -4,27 +4,24 @@ import (
 	"fmt"
 
 	"github.com/globalsign/mgo"
-	"github.com/gobuffalo/suite"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/storage"
 )
 
 // TestSuite implements storage.TestSuite interface
 type TestSuite struct {
-	*suite.Model
 	storage *ModuleStore
 	conf    *config.MongoConfig
 }
 
 // NewTestSuite creates a common test suite
-func NewTestSuite(model *suite.Model, conf *config.MongoConfig) (storage.TestSuite, error) {
+func NewTestSuite(conf *config.MongoConfig) (storage.TestSuite, error) {
 	ms, err := newTestStore(conf)
 	if err != nil {
 		return nil, err
 	}
 	return &TestSuite{
 		storage: ms,
-		Model:   model,
 		conf:    conf,
 	}, err
 }

--- a/pkg/storage/s3/all_test.go
+++ b/pkg/storage/s3/all_test.go
@@ -21,7 +21,10 @@ type S3Tests struct {
 
 func Test_ActionSuite(t *testing.T) {
 	uploaderMock := newUploaderMock()
-	conf := config.GetConfLogErr(testConfigFile, t)
+	conf, err := config.GetConf(testConfigFile)
+	if err != nil {
+		t.Fatalf("Unable to parse config file: %s", err.Error())
+	}
 	if conf.Storage == nil || conf.Storage.CDN == nil {
 		t.Fatalf("Invalid CDN Config provided")
 	}

--- a/pkg/storage/storage_tests/module_storage/storage_benchmark_test.go
+++ b/pkg/storage/storage_tests/module_storage/storage_benchmark_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gobuffalo/suite"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/storage"
@@ -129,20 +128,19 @@ func getStores(b *testing.B) []storage.TestSuite {
 	require.NoError(b, err)
 
 	//TODO: create the instance without model or TestSuite
-	model := suite.NewModel()
-	fsStore, err := fs.NewTestSuite(model)
+	fsStore, err := fs.NewTestSuite()
 	require.NoError(b, err, "couldn't create filesystem store")
 	stores = append(stores, fsStore)
 
-	mongoStore, err := mongo.NewTestSuite(model, conf.Storage.Mongo)
+	mongoStore, err := mongo.NewTestSuite(conf.Storage.Mongo)
 	require.NoError(b, err, "couldn't create mongo store")
 	stores = append(stores, mongoStore)
 
-	memStore, err := mem.NewTestSuite(model)
+	memStore, err := mem.NewTestSuite()
 	require.NoError(b, err)
 	stores = append(stores, memStore)
 
-	minioStore, err := minio.NewTestSuite(model, conf.Storage.Minio)
+	minioStore, err := minio.NewTestSuite(conf.Storage.Minio)
 	require.NoError(b, err)
 	stores = append(stores, minioStore)
 

--- a/pkg/storage/storage_tests/module_storage/storage_test.go
+++ b/pkg/storage/storage_tests/module_storage/storage_test.go
@@ -47,22 +47,22 @@ func (d *TestSuites) SetupTest() {
 	ra.NoError(err)
 
 	// file system
-	fsTests, err := fs.NewTestSuite(d.Model)
+	fsTests, err := fs.NewTestSuite()
 	ra.NoError(err)
 	d.storages = append(d.storages, fsTests)
 
 	// mem
-	memStore, err := mem.NewTestSuite(d.Model)
+	memStore, err := mem.NewTestSuite()
 	ra.NoError(err)
 	d.storages = append(d.storages, memStore)
 
 	// minio
-	minioStorage, err := minio.NewTestSuite(d.Model, conf.Storage.Minio)
+	minioStorage, err := minio.NewTestSuite(conf.Storage.Minio)
 	ra.NoError(err)
 	d.storages = append(d.storages, minioStorage)
 
 	// mongo
-	mongoStore, err := mongo.NewTestSuite(d.Model, conf.Storage.Mongo)
+	mongoStore, err := mongo.NewTestSuite(conf.Storage.Mongo)
 	ra.NoError(err)
 	d.storages = append(d.storages, mongoStore)
 


### PR DESCRIPTION
Fixes #653.
@michalpristas 

After looking into this there were two points of leakage.

One was the GetConfLogErr function in `pkg/config/parse.go`. This was a helper function used in several places. To fix this I wrote it out in the long form in the files it was used once and copied it to `pkg/module/filter_test.go` where it was used several times.

The other point of leakage was from the buffalo/suite.Model object being into the `test_suite.go` files of fs, mem, minio, and mongo. This I was a lot less sure on how to fix. It seemed to me that the `*suite.Model` could be removed from the TestSuite structs with no problem though I wasn't sure.