### PR TITLE
adjust copy path for config file in Olympus Dockerfile

### DIFF
--- a/cmd/olympus/Dockerfile
+++ b/cmd/olympus/Dockerfile
@@ -18,7 +18,6 @@ ADD . .
 
 RUN cd cmd/olympus && buffalo build -s -o /bin/app
 RUN scripts/create_default_config.sh
-COPY config.toml /bin/config.toml
 
 FROM alpine
 RUN apk add --no-cache bash
@@ -27,7 +26,7 @@ RUN apk add --no-cache ca-certificates
 WORKDIR /bin/
 
 COPY --from=builder /bin/app .
-COPY --from=builder /bin/config.toml .
+COPY --from=builder /go/src/github.com/gomods/athens/config.toml .
 
 # Comment out to run the binary in "production" mode:
 # ENV GO_ENV=production


### PR DESCRIPTION
fixes #646 (hopefully 🤞)

Looking more closely at the build failures, the problem seems to be an error building the Olympus Dockerfile (see build output [here](https://travis-ci.org/gomods/athens/builds/430088590#L1733)).

I was able to reproduce the error locally and adjust the path to fix it. This _should_ fix the master build, though I'm not sure how to run the entire deployment section locally without actually deploying.