### PR TITLE
Clean up Config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -72,37 +72,46 @@ EnableCSRFProtection = false
 
 [Proxy]
     # StorageType sets the type of storage backend the proxy will use.
-    # Possible values are memory, disk, mongo, postgres, sqlite, cockroach, mysql
-    # Defaults to mongo
+    # Possible values are memory, disk, mongo, gcp, minio
+    # Defaults to memory
     # Env override: ATHENS_STORAGE_TYPE
     StorageType = "memory"
+
     # Port sets the port the proxy listens on
     # Env override: PORT
     Port = ":3000"
+
     # The endpoint for Olympus in case of a proxy cache miss
     # Env override: OLYMPUS_GLOBAL_ENDPOINT
     OlympusGlobalEndpoint = "http://localhost:3001"
+
     # Redis queue for buffalo workers
     # Defaults to ":6379"
     # Env override: ATHENS_REDIS_QUEUE_ADDRESS
     RedisQueueAddress = ":6379"
+
     # Flag to turn off Proxy Filter middleware
     # Defaults to true
     # Env override: PROXY_FILTER_OFF
     FilterOff = true
+
     # Username for basic auth
     # Env override: BASIC_AUTH_USER
     BasicAuthUser = ""
+
     # Password for basic auth
     # Env override: BASIC_AUTH_PASS
     BasicAuthPass = ""
+
     # Set to true to force an SSL redirect
     # Env override: PROXY_FORCE_SSL
     ForceSSL = false
+
     # ValidatorHook specifies the endpoint to validate modules against
     # Not used if left blank or not specified
     # Env override: ATHENS_PROXY_VALIDATOR
     ValidatorHook = ""
+
     # PathPrefix specifies whether the Proxy
     # should have a basepath. Certain proxies and services
     # are distinguished based on subdomain, while others are based
@@ -125,6 +134,7 @@ EnableCSRFProtection = false
     # Defaults to memory
     # Env override: ATHENS_STORAGE_TYPE
     StorageType = "memory"
+
     # Port sets the port olympus listens on
     # Env override: PORT
     Port = ":3001"
@@ -132,6 +142,7 @@ EnableCSRFProtection = false
     # Defaults to redis
     # Env override: OLYMPUS_BACKGROUND_WORKER_TYPE
     WorkerType = "redis"
+
     # Redis queue for buffalo workers
     # Defaults to ":6379"
     # Env override: OLYMPUS_REDIS_QUEUE_ADDRESS
@@ -143,51 +154,65 @@ EnableCSRFProtection = false
         # Endpoint for CDN storage
         # Env override: CDN_ENDPOINT
         Endpoint = "cdn.example.com"
+
         # Timeout for networks calls made to the CDN in seconds
         # Defaults to Global Timeout
         Timeout = 300
+
     [Storage.Disk]
         # RootPath is the Athens Disk Root folder 
         # Env override: ATHENS_DISK_STORAGE_ROOT
         RootPath = "/path/on/disk"
+
     [Storage.GCP]
         # ProjectID to use for GCP Storage
         # Env overide: GOOGLE_CLOUD_PROJECT
         ProjectID = "MY_GCP_PROJECT_ID"
+
         # Bucket to use for GCP Storage
         # Env override: ATHENS_STORAGE_GCP_BUCKET
         Bucket = "MY_GCP_BUCKET"
+
         # Timeout for networks calls made to GCP in seconds
         # Defaults to Global Timeout
         Timeout = 300
+
     [Storage.Minio]
         # Endpoint for Minio storage
         # Env override: ATHENS_MINIO_ENDPOINT
         Endpoint = "minio.example.com"
+
         # Access Key for Minio storage
         # Env override: ATHENS_MINIO_ACCESS_KEY_ID
         Key = "MY_KEY"
+
         # Secret Key for Minio storage
         # Env override: ATHENS_MINIO_SECRET_ACCESS_KEY
         Secret = "MY_SECRET"
+
         # Timeout for networks calls made to Minio in seconds
         # Defaults to Global Timeout
         Timeout = 300
+
         # Enable SSL for Minio connections
         # Defaults to true
         # Env override: ATHENS_MINIO_USE_SSL
         EnableSSL = true
+
         # Minio Bucket to use for storage
         # Defaults to gomods
         # Env override: ATHENS_MINIO_BUCKET_NAME
         Bucket = "gomods"
+
     [Storage.Mongo]
         # Full URL for mongo storage
         # Env override: ATHENS_MONGO_STORAGE_URL
         URL = "mongodb://127.0.0.1:27017"
+
         # Path to certificate to use for the mongo connection
         # Env override: ATHENS_MONGO_CERT_PATH
         CertPath = ""
+
         # Timeout for networks calls made to Mongo in seconds
         # Defaults to Global Timeout
         # Env override: MONGO_CONN_TIMEOUT_SEC

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -14,20 +14,20 @@ import (
 // Config provides configuration values for all components
 type Config struct {
 	TimeoutConf
-	GoEnv                string         `validate:"required" envconfig:"GO_ENV"`
-	GoBinary             string         `validate:"required" envconfig:"GO_BINARY_PATH"`
-	GoGetWorkers         int            `validate:"required" envconfig:"ATHENS_GOGET_WORKERS"`
-	ProtocolWorkers      int            `validate:"required" envconfig:"ATHENS_PROTOCOL_WORKERS"`
-	LogLevel             string         `validate:"required" envconfig:"ATHENS_LOG_LEVEL"`
-	BuffaloLogLevel      string         `validate:"required" envconfig:"BUFFALO_LOG_LEVEL"`
-	MaxConcurrency       int            `validate:"required" envconfig:"ATHENS_MAX_CONCURRENCY"`
-	MaxWorkerFails       uint           `validate:"required" envconfig:"ATHENS_MAX_WORKER_FAILS"`
-	CloudRuntime         string         `validate:"required" envconfig:"ATHENS_CLOUD_RUNTIME"`
-	FilterFile           string         `validate:"required" envconfig:"ATHENS_FILTER_FILE"`
-	EnableCSRFProtection bool           `envconfig:"ATHENS_ENABLE_CSRF_PROTECTION"`
-	Proxy                *ProxyConfig   `validate:""`
-	Olympus              *OlympusConfig `validate:""`
-	Storage              *StorageConfig `validate:""`
+	GoEnv                string `validate:"required" envconfig:"GO_ENV"`
+	GoBinary             string `validate:"required" envconfig:"GO_BINARY_PATH"`
+	GoGetWorkers         int    `validate:"required" envconfig:"ATHENS_GOGET_WORKERS"`
+	ProtocolWorkers      int    `validate:"required" envconfig:"ATHENS_PROTOCOL_WORKERS"`
+	LogLevel             string `validate:"required" envconfig:"ATHENS_LOG_LEVEL"`
+	BuffaloLogLevel      string `validate:"required" envconfig:"BUFFALO_LOG_LEVEL"`
+	MaxConcurrency       int    `envconfig:"ATHENS_MAX_CONCURRENCY"`  // only used by Olympus. TODO: remove.
+	MaxWorkerFails       uint   `envconfig:"ATHENS_MAX_WORKER_FAILS"` // only used by Olympus. TODO: remove.
+	CloudRuntime         string `validate:"required" envconfig:"ATHENS_CLOUD_RUNTIME"`
+	FilterFile           string `envconfig:"ATHENS_FILTER_FILE"`
+	EnableCSRFProtection bool   `envconfig:"ATHENS_ENABLE_CSRF_PROTECTION"`
+	Proxy                *ProxyConfig
+	Olympus              *OlympusConfig `validate:"-"` // ignoring validation until Olympus is up.
+	Storage              *StorageConfig
 }
 
 // ParseConfigFile parses the given file into an athens config struct

--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -57,7 +57,6 @@ func TestEnvOverrides(t *testing.T) {
 	expProxy := ProxyConfig{
 		StorageType:           "minio",
 		OlympusGlobalEndpoint: "mytikas.gomods.io",
-		RedisQueueAddress:     ":6380",
 		Port:                  ":7000",
 		FilterOff:             false,
 		BasicAuthUser:         "testuser",
@@ -202,7 +201,6 @@ func TestParseExampleConfig(t *testing.T) {
 	expProxy := &ProxyConfig{
 		StorageType:           "memory",
 		OlympusGlobalEndpoint: "http://localhost:3001",
-		RedisQueueAddress:     ":6379",
 		Port:                  ":3000",
 		FilterOff:             true,
 		BasicAuthUser:         "",
@@ -360,7 +358,6 @@ func getEnvMap(config *Config) map[string]string {
 		envVars["ATHENS_STORAGE_TYPE"] = proxy.StorageType
 		envVars["OLYMPUS_GLOBAL_ENDPOINT"] = proxy.OlympusGlobalEndpoint
 		envVars["PORT"] = proxy.Port
-		envVars["ATHENS_REDIS_QUEUE_ADDRESS"] = proxy.RedisQueueAddress
 		envVars["PROXY_FILTER_OFF"] = strconv.FormatBool(proxy.FilterOff)
 		envVars["BASIC_AUTH_USER"] = proxy.BasicAuthUser
 		envVars["BASIC_AUTH_PASS"] = proxy.BasicAuthPass

--- a/pkg/config/proxy.go
+++ b/pkg/config/proxy.go
@@ -3,10 +3,9 @@ package config
 // ProxyConfig specifies the properties required to run the proxy
 type ProxyConfig struct {
 	StorageType           string `validate:"required" envconfig:"ATHENS_STORAGE_TYPE"`
-	OlympusGlobalEndpoint string `validate:"required" envconfig:"OLYMPUS_GLOBAL_ENDPOINT"`
+	OlympusGlobalEndpoint string `envconfig:"OLYMPUS_GLOBAL_ENDPOINT"`
 	Port                  string `validate:"required" envconfig:"PORT"`
-	RedisQueueAddress     string `validate:"required" envconfig:"ATHENS_REDIS_QUEUE_ADDRESS"`
-	FilterOff             bool   `envconfig:"PROXY_FILTER_OFF"`
+	FilterOff             bool   `validate:"required" envconfig:"PROXY_FILTER_OFF"`
 	BasicAuthUser         string `envconfig:"BASIC_AUTH_USER"`
 	BasicAuthPass         string `envconfig:"BASIC_AUTH_PASS"`
 	ForceSSL              bool   `envconfig:"PROXY_FORCE_SSL"`

--- a/pkg/config/storage.go
+++ b/pkg/config/storage.go
@@ -4,11 +4,11 @@ import validator "gopkg.in/go-playground/validator.v9"
 
 // StorageConfig provides configs for various storage backends
 type StorageConfig struct {
-	CDN   *CDNConfig   `validate:""`
-	Disk  *DiskConfig  `validate:""`
-	GCP   *GCPConfig   `validate:""`
-	Minio *MinioConfig `validate:""`
-	Mongo *MongoConfig `validate:""`
+	CDN   *CDNConfig
+	Disk  *DiskConfig
+	GCP   *GCPConfig
+	Minio *MinioConfig
+	Mongo *MongoConfig
 }
 
 func setStorageTimeouts(s *StorageConfig, defaultTimeout int) {


### PR DESCRIPTION
I'm deploying the new Athens Config stuff and so I'm cleaning up things: 

1. Remove unused config fields 
2. Remove the `validate:""` as it's not needed. 
3. fix some "required" fields. 

There's a few more stuff coming up but they require some code change, so keeping the PRs small. 