### PR TITLE
pkg/errors: add comment to exported function

### DIFF
--- a/pkg/errors/gocmd.go
+++ b/pkg/errors/gocmd.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 )
 
+// IsRepoNotFoundErr returns true if the Go command line
+// hints at a repository not found.
 func IsRepoNotFoundErr(err error) bool {
 	return strings.Contains(err.Error(), "remote: Repository not found")
 }


### PR DESCRIPTION
Not sure why some builds fail and some succeed. 