### PR TITLE
Default to example config

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -18,14 +18,14 @@ FROM alpine
 ENV GO111MODULE=on
 
 COPY --from=builder /bin/app /bin/app
-COPY --from=builder /go/src/github.com/gomods/athens/config.toml /config/config.toml
+COPY --from=builder /go/src/github.com/gomods/athens/config.example.toml /config/config.toml
 COPY --from=builder /go/src/github.com/gomods/athens/cmd/proxy/locales /go/src/github.com/gomods/athens/cmd/proxy/locales
 COPY --from=builder /go/src/github.com/gomods/athens/cmd/proxy/assets /go/src/github.com/gomods/athens/cmd/proxy/assets
 COPY --from=builder /usr/local/go/bin/go /bin/go
 
 RUN apk update &&  \
-		apk add --no-cache bzr git mercurial openssh-client subversion procps fossil && \
-		mkdir -p /usr/local/go
+	apk add --no-cache bzr git mercurial openssh-client subversion procps fossil && \
+	mkdir -p /usr/local/go
 
 ENV GO_ENV=production
 


### PR DESCRIPTION
config.toml is git ignored and so the docker build will fail when merging to master. 
We should default to the config.example.toml then let the user specify their own config on `docker run` if they want to. 