### PR TITLE
Use config for trace url

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -89,7 +89,7 @@ func App(conf *config.Config) (*buffalo.App, error) {
 	}
 
 	// Register exporter to export traces
-	exporter, err := observ.RegisterTraceExporter(Service, ENV)
+	exporter, err := observ.RegisterTraceExporter(conf.TraceExporterURL, Service, ENV)
 	if err != nil {
 		lggr.SystemErr(err)
 	} else {

--- a/config.example.toml
+++ b/config.example.toml
@@ -69,7 +69,6 @@ Timeout = 300
 # Env override: ATHENS_ENABLE_CSRF_PROTECTION
 EnableCSRFProtection = false
 
-
 [Proxy]
     # StorageType sets the type of storage backend the proxy will use.
     # Possible values are memory, disk, mongo, gcp, minio
@@ -127,6 +126,10 @@ EnableCSRFProtection = false
     # .cache directory in the Go image).
     # Env override: ATHENS_NETRC_PATH
     NETRCPath = ""
+
+    # TraceExporterURL is the URL to which Athens populates distributed tracing 
+    # inforamtion such as Jaegar. 
+    TraceExporterURL = ""
 
 [Olympus]
     # StorageType sets the type of storage backend Olympus will use.

--- a/pkg/config/env/trace.go
+++ b/pkg/config/env/trace.go
@@ -1,8 +1,0 @@
-package env
-
-import "os"
-
-// TraceExporterURL returns where the trace is stored to
-func TraceExporterURL() string {
-	return os.Getenv("TRACE_EXPORTER")
-}

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -25,6 +25,7 @@ type Config struct {
 	CloudRuntime         string `validate:"required" envconfig:"ATHENS_CLOUD_RUNTIME"`
 	FilterFile           string `envconfig:"ATHENS_FILTER_FILE"`
 	EnableCSRFProtection bool   `envconfig:"ATHENS_ENABLE_CSRF_PROTECTION"`
+	TraceExporterURL     string `envconfig:"TRACE_EXPORTER"`
 	Proxy                *ProxyConfig
 	Olympus              *OlympusConfig `validate:"-"` // ignoring validation until Olympus is up.
 	Storage              *StorageConfig

--- a/pkg/observ/tracing.go
+++ b/pkg/observ/tracing.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/gobuffalo/buffalo"
-	"github.com/gomods/athens/pkg/config/env"
 	"github.com/gomods/athens/pkg/errors"
 	"go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/trace"
@@ -20,15 +19,14 @@ type observabilityContext struct {
 // RegisterTraceExporter returns a jaeger exporter for exporting traces to opencensus.
 // It should in the future have a nice sampling rate defined
 // TODO: Extend beyond jaeger
-func RegisterTraceExporter(service, ENV string) (*(jaeger.Exporter), error) {
+func RegisterTraceExporter(URL, service, ENV string) (*(jaeger.Exporter), error) {
 	const op errors.Op = "RegisterTracer"
-	collectorEndpointURI := env.TraceExporterURL()
-	if collectorEndpointURI == "" {
+	if URL == "" {
 		return nil, errors.E(op, "Exporter URL is empty. Traces won't be exported")
 	}
 
 	je, err := jaeger.NewExporter(jaeger.Options{
-		Endpoint:    collectorEndpointURI,
+		Endpoint:    URL,
 		ServiceName: service,
 	})
 


### PR DESCRIPTION
This gets rid of the last `env` config (I think) 
For now we use Jaegar is the only trace exporter, but I'd like to make it modular so that users can input their own exporter if they like, such as stack driver. 