### PR TITLE
Make example config the default for dev

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	configFile = flag.String("config_file", filepath.Join("..", "..", "config.toml"), "The path to the config file")
+	configFile = flag.String("config_file", filepath.Join("..", "..", "config.example.toml"), "The path to the config file")
 )
 
 func main() {


### PR DESCRIPTION
We should make onboarding very easy, and asking people to create their own config off the bat is very difficult. 

The config.example.toml works out of the box (and we should always keep it so). 