### PR TITLE
Git ignore .env file

### DIFF
--- a/cmd/proxy/.env
+++ b/cmd/proxy/.env
@@ -1,4 +1,0 @@
-ATHENS_STORAGE_TYPE=mongo
-GO_ENV=development
-TRACE_EXPORTER=http://0.0.0.0:14268
-

--- a/vendor/github.com/gobuffalo/suite/.gitignore
+++ b/vendor/github.com/gobuffalo/suite/.gitignore
@@ -29,3 +29,4 @@ gin-bin
 .gitcookies
 go.mod
 go.sum
+.env


### PR DESCRIPTION
Now that we have a config file, dotenv is not necessary to be checked. 

I'm thinking more about the development flow and how we should tweak config things while writing code locally. And might open an issue or two for the new config flow. 