### PR TITLE
Ensure Simple Worker is off

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -78,6 +78,7 @@ func App(conf *config.Config) (*buffalo.App, error) {
 		SessionName: "_athens_session",
 		Logger:      blggr,
 		Addr:        conf.Proxy.Port,
+		WorkerOff:   true,
 	})
 	if prefix := conf.Proxy.PathPrefix; prefix != "" {
 		// certain Ingress Controllers (such as GCP Load Balancer)


### PR DESCRIPTION
I believe this got deleted by accident when peeps removed the Redis worker stuff. Buffalo still spins off a Simple Worker unless we explicitly set it off in the options. 