### PR TITLE
Change error log level to info logs when tracing is not initialized

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -77,7 +77,7 @@ func App(conf *config.Config) (*buffalo.App, error) {
 	// Register exporter to export traces
 	exporter, err := observ.RegisterTraceExporter(conf.TraceExporterURL, Service, ENV)
 	if err != nil {
-		lggr.SystemErr(err)
+		lggr.Infof("%s", err)
 	} else {
 		defer exporter.Flush()
 		app.Use(observ.Tracer(Service))


### PR DESCRIPTION
These errors were reported by Brent on Slack.

Are there any additional setup requirements with the tracing stuff that has been added recently? Ran e2e tests locally today and got a new error:
```ERRO[0000] Exporter URL is empty. Traces won't be exported```

Since tracing is not a hard requirement. They should just be an info log for the user so that when they see it they can add it to their system.