### PR TITLE
Clean up e2e binary

### DIFF
--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -29,7 +29,7 @@ teardown () {
 
   clearGoModCache
   pkill athens-proxy || true
-  rm $REPO_DIR/cmd/proxy/athens-proxy
+  rm $REPO_DIR/cmd/proxy/athens-proxy || true
   rm -fr ${TMPDIR}
   popd 2> /dev/null || true
 }

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -29,6 +29,7 @@ teardown () {
 
   clearGoModCache
   pkill athens-proxy || true
+  rm $REPO_DIR/cmd/proxy/athens-proxy
   rm -fr ${TMPDIR}
   popd 2> /dev/null || true
 }


### PR DESCRIPTION
Noticed when running the e2e tests locally that it creates an `athens-proxy` binary that gets left as an untracked file after the tests finish. Thought it would be good to clean up the file during the test teardown.