### PR TITLE
Clean up store before test.

### DIFF
--- a/pkg/storage/storage_tests/module_storage/storage_test.go
+++ b/pkg/storage/storage_tests/module_storage/storage_test.go
@@ -79,6 +79,9 @@ func TestModuleStorages(t *testing.T) {
 
 func (d *TestSuites) TestStorages() {
 	for _, store := range d.storages {
+		// start the test with a clean store
+		store.Cleanup()
+
 		d.testNotFound(store)
 		d.testKindNotFound(store)
 		d.testGetSaveListRoundTrip(store)


### PR DESCRIPTION
I had a failing test due to some stale data in the mongo store. I'm not exactly sure how it happened.

This PR will clean up the stores before the tests are run to avoid any stale data causing failure.
