### PR TITLE
Storage tests - close zip reader

### DIFF
--- a/pkg/storage/storage_tests/module_storage/storage_test.go
+++ b/pkg/storage/storage_tests/module_storage/storage_test.go
@@ -86,8 +86,7 @@ func (d *TestSuites) TestStorages() {
 		d.testDelete(store)
 
 		// TODO: more tests to come
-
-		store.Cleanup()
+		d.Require().NoError(store.Cleanup())
 	}
 }
 
@@ -158,6 +157,7 @@ func (d *TestSuites) testGetSaveListRoundTrip(ts storage.TestSuite) {
 	zipContent, err := ioutil.ReadAll(zip)
 	r.NoError(err, hrn)
 	r.Equal(d.zip, zipContent, hrn)
+	r.NoError(zip.Close())
 }
 
 func (d *TestSuites) testDelete(ts storage.TestSuite) {


### PR DESCRIPTION
After checking the error from store.Cleanup() the test failed with msg `source.zip: The process cannot access the file because it is being used by another process.`
This fixes that by closing the zip reader we get from storage.