### PR TITLE
Golist

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -141,7 +141,7 @@ func App(conf *config.Config) (*buffalo.App, error) {
 	// TODO This middleware is a workaround in place for
 	// https://github.com/golang/go/issues/27947
 	// Once it's fixed the middleware can be removed
-	app.Use(mw.NewPseudoversionMiddleware(fs, conf.GoBinary))
+	app.Use(mw.NewPseudoversionMiddleware(lggr, fs, conf.GoBinary))
 
 	user, pass, ok := conf.Proxy.BasicAuth()
 	if ok {

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -138,6 +138,9 @@ func App(conf *config.Config) (*buffalo.App, error) {
 	}
 
 	fs := afero.NewOsFs()
+	// TODO This middleware is a workaround in place for
+	// https://github.com/golang/go/issues/27947
+	// Once it's fixed the middleware can be removed
 	app.Use(mw.NewPseudoversionMiddleware(fs, conf.GoBinary))
 
 	user, pass, ok := conf.Proxy.BasicAuth()

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -18,7 +18,7 @@ func addProxyRoutes(
 	goBin string,
 	goGetWorkers int,
 	protocolWorkers int,
-	fs afero.Fs
+	fs afero.Fs,
 ) error {
 	app.GET("/", proxyHomeHandler)
 	app.GET("/healthz", healthHandler)

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -18,6 +18,7 @@ func addProxyRoutes(
 	goBin string,
 	goGetWorkers int,
 	protocolWorkers int,
+	fs afero.Fs
 ) error {
 	app.GET("/", proxyHomeHandler)
 	app.GET("/healthz", healthHandler)
@@ -44,7 +45,6 @@ func addProxyRoutes(
 	// 2. The singleflight passes the stash to its parent: stashpool.
 	// 3. The stashpool manages limiting concurrent requests and passes them to stash.
 	// 4. The plain stash.New just takes a request from upstream and saves it into storage.
-	fs := afero.NewOsFs()
 	mf, err := module.NewGoGetFetcher(goBin, fs)
 	if err != nil {
 		return err

--- a/pkg/config/module.go
+++ b/pkg/config/module.go
@@ -7,9 +7,3 @@ import "fmt"
 func PackageVersionedName(module, version, ext string) string {
 	return fmt.Sprintf("%s/@v/%s.%s", module, version, ext)
 }
-
-// FmtModVer is a helper function that can take
-// pkg/a/b and v2.3.1 and returns pkg/a/b@v2.3.1
-func FmtModVer(mod, ver string) string {
-	return fmt.Sprintf("%s@%s", mod, ver)
-}

--- a/pkg/download/upstream_lister.go
+++ b/pkg/download/upstream_lister.go
@@ -7,9 +7,9 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/module"
+	"github.com/gomods/athens/pkg/paths"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/spf13/afero"
 )
@@ -46,7 +46,7 @@ func (l *vcsLister) List(mod string) (*storage.RevInfo, []string, error) {
 	cmd := exec.Command(
 		l.goBinPath,
 		"list", "-m", "-versions", "-json",
-		config.FmtModVer(mod, "latest"),
+		paths.FmtModVer(mod, "latest"),
 	)
 	cmd.Dir = hackyPath
 	stdout := &bytes.Buffer{}

--- a/pkg/middleware/log_entry.go
+++ b/pkg/middleware/log_entry.go
@@ -13,14 +13,19 @@ type middlewareFunc func(entry log.Entry, validatorHook string) buffalo.Middlewa
 func LogEntryMiddleware(middleware middlewareFunc, lggr *log.Logger, validatorHook string) buffalo.MiddlewareFunc {
 	return func(next buffalo.Handler) buffalo.Handler {
 		return func(c buffalo.Context) error {
-			req := c.Request()
-			ent := lggr.WithFields(logrus.Fields{
-				"http-method": req.Method,
-				"http-path":   req.URL.Path,
-				"http-url":    req.URL.String(),
-			})
+			ent := logEntryFromContext(c, lggr)
 			m := middleware(ent, validatorHook)
 			return m(next)(c)
 		}
 	}
+}
+
+func logEntryFromContext(c buffalo.Context, lggr *log.Logger) log.Entry {
+	req := c.Request()
+	ent := lggr.WithFields(logrus.Fields{
+		"http-method": req.Method,
+		"http-path":   req.URL.Path,
+		"http-url":    req.URL.String(),
+	})
+	return ent
 }

--- a/pkg/middleware/pseudoversion.go
+++ b/pkg/middleware/pseudoversion.go
@@ -21,8 +21,9 @@ func NewPseudoversionMiddleware(lggr *log.Logger, fs afero.Fs, gobin string) buf
 	return func(next buffalo.Handler) buffalo.Handler {
 		return func(c buffalo.Context) error {
 			// TODO this can be changed once we figure out how to propagate the same
-			// log entry down to all the middlewares. As for now it does not make any sense to have another
-			// wrapper to the middleware because the two middleware will have two log entries.
+			// log entry down to all the middlewares (see https://github.com/gomods/athens/issues/537).
+			// Given the current status it does not make any sense to have another LogEntry wrapper
+			// to the middleware because the two middlewares will have two log entries in any case.
 			entry := logEntryFromContext(c, lggr)
 			mod, err := paths.GetModule(c)
 			if err != nil {

--- a/pkg/middleware/pseudoversion.go
+++ b/pkg/middleware/pseudoversion.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gomods/athens/pkg/errors"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/module"
 	"github.com/gomods/athens/pkg/paths"
 	"github.com/spf13/afero"
@@ -14,11 +15,15 @@ import (
 // NewPseudoversionMiddleware builds a middleware function that detects if the asked version
 // is a hash and translates it into the mapped pseudoversion. It implements a workaround
 // for https://github.com/golang/go/issues/27947
-func NewPseudoversionMiddleware(fs afero.Fs, gobin string) buffalo.MiddlewareFunc {
+func NewPseudoversionMiddleware(lggr *log.Logger, fs afero.Fs, gobin string) buffalo.MiddlewareFunc {
 	const op errors.Op = "actions.NewFilterMiddleware"
 
 	return func(next buffalo.Handler) buffalo.Handler {
 		return func(c buffalo.Context) error {
+			// TODO this can be changed once we figure out how to propagate the same
+			// log entry down to all the middlewares. As for now it does not make any sense to have another
+			// wrapper to the middleware because the two middleware will have two log entries.
+			entry := logEntryFromContext(c, lggr)
 			mod, err := paths.GetModule(c)
 			if err != nil {
 				return next(c)
@@ -34,6 +39,10 @@ func NewPseudoversionMiddleware(fs afero.Fs, gobin string) buffalo.MiddlewareFun
 			}
 
 			newVersion, err := module.PseudoVersionFromHash(c, fs, gobin, mod, version)
+			if err != nil {
+				entry.SystemErr(errors.E(op, err))
+				return c.Render(http.StatusInternalServerError, nil)
+			}
 			newURL := strings.Replace(c.Request().URL.Path, version, newVersion, 1)
 			return c.Redirect(http.StatusSeeOther, newURL)
 		}

--- a/pkg/middleware/pseudoversion.go
+++ b/pkg/middleware/pseudoversion.go
@@ -11,7 +11,9 @@ import (
 	"github.com/spf13/afero"
 )
 
-// NewPseudoversionMiddleware builds a middleware function that implements
+// NewPseudoversionMiddleware builds a middleware function that detects if the asked version
+// is a hash and translates it into the mapped pseudoversion. It implements a workaround
+// for https://github.com/golang/go/issues/27947
 func NewPseudoversionMiddleware(fs afero.Fs, gobin string) buffalo.MiddlewareFunc {
 	const op errors.Op = "actions.NewFilterMiddleware"
 

--- a/pkg/middleware/pseudoversion.go
+++ b/pkg/middleware/pseudoversion.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/gomods/athens/pkg/errors"
+	"github.com/gomods/athens/pkg/module"
+	"github.com/gomods/athens/pkg/paths"
+	"github.com/spf13/afero"
+)
+
+// NewPseudoversionMiddleware builds a middleware function that implements
+func NewPseudoversionMiddleware(fs afero.Fs, gobin string) buffalo.MiddlewareFunc {
+	const op errors.Op = "actions.NewFilterMiddleware"
+
+	return func(next buffalo.Handler) buffalo.Handler {
+		return func(c buffalo.Context) error {
+			mod, err := paths.GetModule(c)
+			if err != nil {
+				return next(c)
+			}
+
+			version, err := paths.GetVersion(c)
+			if err != nil {
+				return next(c)
+			}
+
+			if module.IsSemVersion(version) {
+				return next(c)
+			}
+
+			newVersion, err := module.PseudoVersionFromHash(c, fs, gobin, mod, version)
+			newURL := strings.Replace(c.Request().URL.Path, version, newVersion, 1)
+			return c.Redirect(http.StatusSeeOther, newURL)
+		}
+	}
+}

--- a/pkg/middleware/pseudoversion_test.go
+++ b/pkg/middleware/pseudoversion_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/envy"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/markbates/willie"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -17,8 +19,8 @@ func middlewarePseudoverApp(fs afero.Fs) *buffalo.App {
 
 	a := buffalo.New(buffalo.Options{})
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
-
-	a.Use(NewPseudoversionMiddleware(fs, goBinaryPath))
+	lggr := log.New("none", logrus.DebugLevel)
+	a.Use(NewPseudoversionMiddleware(lggr, fs, goBinaryPath))
 	a.GET(pathList, h)
 	a.GET(pathVersionInfo, h)
 	return a

--- a/pkg/middleware/pseudoversion_test.go
+++ b/pkg/middleware/pseudoversion_test.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/envy"
+	"github.com/markbates/willie"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func middlewarePseudoverApp(fs afero.Fs) *buffalo.App {
+	h := func(c buffalo.Context) error {
+		return c.Render(200, nil)
+	}
+
+	a := buffalo.New(buffalo.Options{})
+	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
+
+	a.Use(NewPseudoversionMiddleware(fs, goBinaryPath))
+	a.GET(pathList, h)
+	a.GET(pathVersionInfo, h)
+	return a
+}
+
+func Test_FilterPseudoversion(t *testing.T) {
+	r := require.New(t)
+	fs := afero.NewOsFs()
+
+	app := middlewarePseudoverApp(fs)
+	w := willie.New(app)
+
+	// List, no change
+	res := w.Request("/github.com/gomods/athens/@v/list").Get()
+	r.Equal(200, res.Code)
+
+	// Hash, expects redirect to pseudover
+	res = w.Request("/github.com/arschles/assert/@v/fc2da9844984ce5093111298174706e14d4c0c47.info").Get()
+	r.Equal(303, res.Code)
+	r.Equal("/github.com/arschles/assert/@v/v0.0.0-20160620175154-fc2da9844984.info", res.HeaderMap.Get("Location"))
+
+	// Normal version, no redirect
+	res = w.Request("/github.com/arschles/assert/@v/v1.0.0.info").Get()
+	r.Equal(200, res.Code)
+}

--- a/pkg/middleware/pseudoversion_test.go
+++ b/pkg/middleware/pseudoversion_test.go
@@ -38,11 +38,11 @@ func Test_FilterPseudoversion(t *testing.T) {
 	r.Equal(200, res.Code)
 
 	// Hash, expects redirect to pseudover
-	res = w.Request("/github.com/arschles/assert/@v/fc2da9844984ce5093111298174706e14d4c0c47.info").Get()
+	res = w.Request("/github.com/athens-artifacts/no-tags/@v/1a540c5d67ab9b13099b229d10362c6ad96c462d.info").Get()
 	r.Equal(303, res.Code)
-	r.Equal("/github.com/arschles/assert/@v/v0.0.0-20160620175154-fc2da9844984.info", res.HeaderMap.Get("Location"))
+	r.Equal("/github.com/athens-artifacts/no-tags/@v/v0.0.0-20180803171426-1a540c5d67ab.info", res.HeaderMap.Get("Location"))
 
 	// Normal version, no redirect
-	res = w.Request("/github.com/arschles/assert/@v/v1.0.0.info").Get()
+	res = w.Request("/github.com/athens-artifacts/maturelib/@v/v2.0.0.info").Get()
 	r.Equal(200, res.Code)
 }

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/observ"
+	"github.com/gomods/athens/pkg/paths"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/spf13/afero"
 )
@@ -133,7 +134,7 @@ func Dummy(fs afero.Fs, repoRoot string) error {
 // on module@version from the repoRoot with GOPATH=gopath, and returns a non-nil error if anything went wrong.
 func downloadModule(goBinaryName string, fs afero.Fs, gopath, repoRoot, module, version string) (goModule, error) {
 	const op errors.Op = "module.downloadModule"
-	fullURI := getVersionURI(module, version)
+	fullURI := paths.FmtModVer(module, version)
 
 	cmd := exec.Command(goBinaryName, "mod", "download", "-json", fullURI)
 	cmd.Env = PrepareEnv(gopath)
@@ -208,10 +209,4 @@ func validGoBinary(name string) error {
 		return errors.E(op, err)
 	}
 	return nil
-}
-
-func getVersionURI(mod, ver string) string {
-	uri := strings.TrimSuffix(mod, "/")
-	return fmt.Sprintf("%s@%s", uri, ver)
-
 }

--- a/pkg/module/go_pseudoversion.go
+++ b/pkg/module/go_pseudoversion.go
@@ -19,7 +19,7 @@ type goListResult struct {
 
 // PseudoVersionFromHash returns the go mod pseudoversion associated to the given commit hash used as version
 func PseudoVersionFromHash(ctx context.Context, fs afero.Fs, gobinary, mod, ver string) (string, error) {
-	const op errors.Op = "goGetFetcher.PseudoVersionFromHash"
+	const op errors.Op = "module.PseudoVersionFromHash"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 

--- a/pkg/module/go_pseudoversion.go
+++ b/pkg/module/go_pseudoversion.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/observ"
+	"github.com/gomods/athens/pkg/paths"
 	"github.com/spf13/afero"
 )
 
@@ -27,7 +28,7 @@ func PseudoVersionFromHash(ctx context.Context, fs afero.Fs, gobinary, mod, ver 
 		return ver, nil
 	}
 
-	fullURI := getVersionURI(mod, ver)
+	fullURI := paths.FmtModVer(mod, ver)
 	cmd := exec.Command(gobinary, "list", "-m", "-json", fullURI)
 
 	tmpRoot, err := afero.TempDir(fs, "", "pseudover")

--- a/pkg/module/go_pseudoversion.go
+++ b/pkg/module/go_pseudoversion.go
@@ -23,7 +23,7 @@ func PseudoVersionFromHash(ctx context.Context, fs afero.Fs, gobinary, mod, ver 
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
-	if IsModVersion(ver) {
+	if IsSemVersion(ver) {
 		return ver, nil
 	}
 
@@ -54,8 +54,8 @@ func PseudoVersionFromHash(ctx context.Context, fs afero.Fs, gobinary, mod, ver 
 	return r.Version, nil
 }
 
-// IsModVersion tells whether the passed string respects the semantic version pattern
-func IsModVersion(ver string) bool {
+// IsSemVersion tells whether the passed string respects the semantic version pattern
+func IsSemVersion(ver string) bool {
 	res, _ := regexp.Match("v\\d+\\.\\d+.\\d+", []byte(ver))
 	return res
 }

--- a/pkg/module/go_pseudoversion.go
+++ b/pkg/module/go_pseudoversion.go
@@ -1,0 +1,54 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/gomods/athens/pkg/errors"
+	"github.com/gomods/athens/pkg/observ"
+)
+
+type goListResult struct {
+	Path    string `json:"Path"`
+	Version string `json:"Version"`
+	Time    string `json:"String"`
+}
+
+// PseudoVersionFromHash returns the go mod pseudoversion associated to the given commit hash used as version
+func PseudoVersionFromHash(ctx context.Context, gobinary, mod, ver string) (string, error) {
+	const op errors.Op = "goGetFetcher.PseudoVersionFromHash"
+	ctx, span := observ.StartSpan(ctx, op.String())
+	defer span.End()
+
+	if IsModVersion(ver) {
+		return ver, nil
+	}
+
+	uri := strings.TrimSuffix(mod, "/")
+	fullURI := fmt.Sprintf("%s@%s", uri, ver)
+
+	cmd := exec.Command(gobinary, "list", "-m", "-json", fullURI)
+	cmd.Env = PrepareEnv(".")
+
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.E(op, err)
+	}
+
+	var r goListResult
+	err = json.Unmarshal(o, &r)
+	if err != nil {
+		return "", errors.E(op, err)
+	}
+	return r.Version, nil
+}
+
+// IsModVersion tells whether the passed string respects the semantic version pattern
+func IsModVersion(ver string) bool {
+	res, _ := regexp.Match("v\\d+\\.\\d+.\\d+", []byte(ver))
+	return res
+}

--- a/pkg/module/go_pseudoversion_test.go
+++ b/pkg/module/go_pseudoversion_test.go
@@ -36,5 +36,12 @@ func TestPseudoFromHash(t *testing.T) {
 	v, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, version)
 	assert.NoError(t, err)
 	assert.Equal(t, "v0.0.0-20160620175154-fc2da9844984", v)
+}
 
+func TestInvalidHash(t *testing.T) {
+	version := "asdasdasdasdada"
+	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
+	fs := afero.NewOsFs()
+	_, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, version)
+	assert.Error(t, err)
 }

--- a/pkg/module/go_pseudoversion_test.go
+++ b/pkg/module/go_pseudoversion_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gobuffalo/envy"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -15,33 +15,38 @@ var (
 )
 
 func TestIsVersion(t *testing.T) {
+	r := require.New(t)
+
 	// Testing the regex
-	assert.True(t, IsModVersion("v1.0.0"))
-	assert.True(t, IsModVersion("v12.345.6789"))
-	assert.False(t, IsModVersion("v248dadf4e9068a0b3e79f02ed0a610d935de5302"))
+	r.True(IsSemVersion("v1.0.0"))
+	r.True(IsSemVersion("v12.345.6789"))
+	r.False(IsSemVersion("v248dadf4e9068a0b3e79f02ed0a610d935de5302"))
 }
 
 func TestRealVersion(t *testing.T) {
+	r := require.New(t)
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
 	fs := afero.NewOsFs()
 	v, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, "v1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, v, version)
+	r.NoError(err)
+	r.Equal(v, version)
 }
 
 func TestPseudoFromHash(t *testing.T) {
+	r := require.New(t)
 	version := "fc2da9844984ce5093111298174706e14d4c0c47"
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
 	fs := afero.NewOsFs()
 	v, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, version)
-	assert.NoError(t, err)
-	assert.Equal(t, "v0.0.0-20160620175154-fc2da9844984", v)
+	r.NoError(err)
+	r.Equal("v0.0.0-20160620175154-fc2da9844984", v)
 }
 
 func TestInvalidHash(t *testing.T) {
+	r := require.New(t)
 	version := "asdasdasdasdada"
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
 	fs := afero.NewOsFs()
 	_, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, version)
-	assert.Error(t, err)
+	r.Error(err)
 }

--- a/pkg/module/go_pseudoversion_test.go
+++ b/pkg/module/go_pseudoversion_test.go
@@ -29,7 +29,7 @@ func TestRealVersion(t *testing.T) {
 	fs := afero.NewOsFs()
 	v, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, "v1.0.0")
 	r.NoError(err)
-	r.Equal(v, version)
+	r.Equal(v, "v1.0.0")
 }
 
 func TestPseudoFromHash(t *testing.T) {

--- a/pkg/module/go_pseudoversion_test.go
+++ b/pkg/module/go_pseudoversion_test.go
@@ -1,0 +1,30 @@
+package module
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gobuffalo/envy"
+	"github.com/stretchr/testify/assert"
+)
+
+var localCtx = context.Background()
+
+func TestIsVersion(t *testing.T) {
+	// Testing the regex
+	assert.True(t, IsModVersion("v1.0.0"))
+	assert.True(t, IsModVersion("v12.345.6789"))
+	assert.False(t, IsModVersion("v248dadf4e9068a0b3e79f02ed0a610d935de5302"))
+}
+
+func TestPseudoversion(t *testing.T) {
+	mod := "github.com/arschles/assert"
+	version := "v1.0.0"
+	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
+
+	v, err := PseudoVersionFromHash(localCtx, goBinaryPath, mod, version)
+	assert.NoError(t, err)
+	assert.Equal(t, v, version)
+
+	"fc2da9844984ce5093111298174706e14d4c0c47"
+}

--- a/pkg/module/go_pseudoversion_test.go
+++ b/pkg/module/go_pseudoversion_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/envy"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +23,8 @@ func TestIsVersion(t *testing.T) {
 
 func TestRealVersion(t *testing.T) {
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
-	v, err := PseudoVersionFromHash(localCtx, goBinaryPath, mod, "v1.0.0")
+	fs := afero.NewOsFs()
+	v, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, "v1.0.0")
 	assert.NoError(t, err)
 	assert.Equal(t, v, version)
 }
@@ -30,7 +32,8 @@ func TestRealVersion(t *testing.T) {
 func TestPseudoFromHash(t *testing.T) {
 	version := "fc2da9844984ce5093111298174706e14d4c0c47"
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
-	v, err := PseudoVersionFromHash(localCtx, goBinaryPath, mod, version)
+	fs := afero.NewOsFs()
+	v, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, version)
 	assert.NoError(t, err)
 	assert.Equal(t, "v0.0.0-20160620175154-fc2da9844984", v)
 

--- a/pkg/module/go_pseudoversion_test.go
+++ b/pkg/module/go_pseudoversion_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var localCtx = context.Background()
+var (
+	localCtx = context.Background()
+	mod      = "github.com/arschles/assert"
+)
 
 func TestIsVersion(t *testing.T) {
 	// Testing the regex
@@ -17,14 +20,18 @@ func TestIsVersion(t *testing.T) {
 	assert.False(t, IsModVersion("v248dadf4e9068a0b3e79f02ed0a610d935de5302"))
 }
 
-func TestPseudoversion(t *testing.T) {
-	mod := "github.com/arschles/assert"
-	version := "v1.0.0"
+func TestRealVersion(t *testing.T) {
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
-
-	v, err := PseudoVersionFromHash(localCtx, goBinaryPath, mod, version)
+	v, err := PseudoVersionFromHash(localCtx, goBinaryPath, mod, "v1.0.0")
 	assert.NoError(t, err)
 	assert.Equal(t, v, version)
+}
 
-	"fc2da9844984ce5093111298174706e14d4c0c47"
+func TestPseudoFromHash(t *testing.T) {
+	version := "fc2da9844984ce5093111298174706e14d4c0c47"
+	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
+	v, err := PseudoVersionFromHash(localCtx, goBinaryPath, mod, version)
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.0.0-20160620175154-fc2da9844984", v)
+
 }

--- a/pkg/module/go_pseudoversion_test.go
+++ b/pkg/module/go_pseudoversion_test.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	localCtx = context.Background()
-	mod      = "github.com/arschles/assert"
+	mod      = "github.com/athens-artifacts/no-tags"
 )
 
 func TestIsVersion(t *testing.T) {
@@ -34,12 +34,12 @@ func TestRealVersion(t *testing.T) {
 
 func TestPseudoFromHash(t *testing.T) {
 	r := require.New(t)
-	version := "fc2da9844984ce5093111298174706e14d4c0c47"
+	version := "1a540c5d67ab9b13099b229d10362c6ad96c462d"
 	goBinaryPath := envy.Get("GO_BINARY_PATH", "go")
 	fs := afero.NewOsFs()
 	v, err := PseudoVersionFromHash(localCtx, fs, goBinaryPath, mod, version)
 	r.NoError(err)
-	r.Equal("v0.0.0-20160620175154-fc2da9844984", v)
+	r.Equal("v0.0.0-20180803171426-1a540c5d67ab", v)
 }
 
 func TestInvalidHash(t *testing.T) {

--- a/pkg/paths/decode.go
+++ b/pkg/paths/decode.go
@@ -19,6 +19,12 @@ func DecodePath(encoding string) (path string, err error) {
 	return path, nil
 }
 
+// FmtModVer is a helper function that can take
+// pkg/a/b and v2.3.1 and returns pkg/a/b@v2.3.1
+func FmtModVer(mod, ver string) string {
+	return fmt.Sprintf("%s@%s", mod, ver)
+}
+
 // Ripped from cmd/go
 func decodeString(encoding string) (string, bool) {
 	var buf []byte

--- a/pkg/stash/with_singleflight.go
+++ b/pkg/stash/with_singleflight.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/observ"
+	"github.com/gomods/athens/pkg/paths"
 )
 
 // WithSingleflight returns a singleflight stasher.
@@ -30,7 +30,7 @@ type withsf struct {
 }
 
 func (s *withsf) process(ctx context.Context, mod, ver string) {
-	mv := config.FmtModVer(mod, ver)
+	mv := paths.FmtModVer(mod, ver)
 	err := s.s.Stash(ctx, mod, ver)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -45,7 +45,7 @@ func (s *withsf) Stash(ctx context.Context, mod, ver string) error {
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
-	mv := config.FmtModVer(mod, ver)
+	mv := paths.FmtModVer(mod, ver)
 	s.mu.Lock()
 	subCh := make(chan error, 1)
 	_, inFlight := s.subs[mv]


### PR DESCRIPTION
**What is the problem I am trying to address?**

Due to https://github.com/golang/go/issues/27947, Go mod does not work with commit hashes. It needs pseudoversions.

**How is the fix applied?**

Calls go mod list in order to get the pseudoversion associated with the commit hash and redirects the caller to it. More details on the issue comments. This is a temporay workaround that can be removed when go issues will be fixed.

**Fixes issue:  #699**
