### PR TITLE
Updated single letter props in stasher

### DIFF
--- a/pkg/stash/stasher.go
+++ b/pkg/stash/stasher.go
@@ -33,8 +33,8 @@ func New(f module.Fetcher, s storage.Backend, wrappers ...Wrapper) Stasher {
 }
 
 type stasher struct {
-	f module.Fetcher
-	s storage.Backend
+	fetcher module.Fetcher
+	storage storage.Backend
 }
 
 func (s *stasher) Stash(ctx context.Context, mod, ver string) error {
@@ -52,7 +52,7 @@ func (s *stasher) Stash(ctx context.Context, mod, ver string) error {
 		return errors.E(op, err)
 	}
 	defer v.Zip.Close()
-	err = s.s.Save(ctx, mod, ver, v.Mod, v.Zip, v.Info)
+	err = s.storage.Save(ctx, mod, ver, v.Mod, v.Zip, v.Info)
 	if err != nil {
 		return errors.E(op, err)
 	}
@@ -61,7 +61,7 @@ func (s *stasher) Stash(ctx context.Context, mod, ver string) error {
 
 func (s *stasher) fetchModule(ctx context.Context, mod, ver string) (*storage.Version, error) {
 	const op errors.Op = "stasher.fetchModule"
-	v, err := s.f.Fetch(ctx, mod, ver)
+	v, err := s.fetcher.Fetch(ctx, mod, ver)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}

--- a/pkg/stash/with_pool.go
+++ b/pkg/stash/with_pool.go
@@ -8,7 +8,7 @@ import (
 )
 
 type withpool struct {
-	s Stasher
+	stasher Stasher
 
 	// see download/addons/with_pool
 	// for design docs on about this channel.
@@ -20,8 +20,8 @@ type withpool struct {
 func WithPool(numWorkers int) Wrapper {
 	return func(s Stasher) Stasher {
 		st := &withpool{
-			s:     s,
-			jobCh: make(chan func()),
+			stasher: s,
+			jobCh:   make(chan func()),
 		}
 		st.start(numWorkers)
 		return st
@@ -47,7 +47,7 @@ func (s *withpool) Stash(ctx context.Context, mod, ver string) error {
 	var err error
 	done := make(chan struct{}, 1)
 	s.jobCh <- func() {
-		err = s.s.Stash(ctx, mod, ver)
+		err = s.stasher.Stash(ctx, mod, ver)
 		close(done)
 	}
 	<-done

--- a/pkg/stash/with_singleflight.go
+++ b/pkg/stash/with_singleflight.go
@@ -16,14 +16,14 @@ import (
 // response to both the first and the second client.
 func WithSingleflight(s Stasher) Stasher {
 	sf := &withsf{}
-	sf.s = s
+	sf.stasher = s
 	sf.subs = map[string][]chan error{}
 
 	return sf
 }
 
 type withsf struct {
-	s Stasher
+	stasher Stasher
 
 	mu   sync.Mutex
 	subs map[string][]chan error
@@ -31,7 +31,7 @@ type withsf struct {
 
 func (s *withsf) process(ctx context.Context, mod, ver string) {
 	mv := config.FmtModVer(mod, ver)
-	err := s.s.Stash(ctx, mod, ver)
+	err := s.stasher.Stash(ctx, mod, ver)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, ch := range s.subs[mv] {


### PR DESCRIPTION
**What is the problem I am trying to address?**

Sometimes it's hard to read `s.s` 

**How is the fix applied?**

single letter props replaced with more meaningful names so
`s.s` becomes `s.storage` and `s.stasher` respectively.
