### PR TITLE
Use config.dev.toml by default for Olympus

### DIFF
--- a/cmd/olympus/main.go
+++ b/cmd/olympus/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	configFile = flag.String("config_file", filepath.Join("..", "..", "config.toml"), "The path to the config file")
+	configFile = flag.String("config_file", filepath.Join("..", "..", "config.dev.toml"), "The path to the config file")
 )
 
 func main() {


### PR DESCRIPTION
**What is the problem I am trying to address?**

Starting buffalo for Olympus gives error:
```
buffalo dev
[POP] 2018/10/05 14:12:19 error - Unable to load config file: unable to find pop config file
buffalo: 2018/10/05 14:12:19 === Rebuild on: :start: ===
buffalo: 2018/10/05 14:12:19 === Running: go build -v -i -tags development -o tmp/olympus-build  (PID: 6918) ===
buffalo: 2018/10/05 14:12:20 === Building Completed (PID: 6918) (Time: 809.277611ms) ===
buffalo: 2018/10/05 14:12:20 === Running: tmp/olympus-build (PID: 6965) ===
2018/10/05 14:12:20 open ../../config.toml: no such file or directory
buffalo: 2018/10/05 14:12:20 === exit status 1
2018/10/05 14:12:20 open ../../config.toml: no such file or directory
 ===
```

**How is the fix applied?**

Reference the development config file instead

**Fixes issue: **

No issue created.