### PR TITLE
Include weekly development meetings within documentation

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -14,6 +14,7 @@ Athens is the name of the combined project that includes a global registry for [
 * If you are interested
 in what is happening between the proxy and the Go Modules feature, the [Walkthrough](/walkthrough)
 explores this in greater depth.
+* Join the [weekly development meeting](/contributing/community/developer-meetings/)! It's a great way to meet folks working on the project, ask questions or just hang out. All are welcome to join and participate.
 * For more detailed information on how to run Athens in production, check out our other documentation (coming soon!!).
 
 ---

--- a/docs/content/contributing/community/_index.md
+++ b/docs/content/contributing/community/_index.md
@@ -1,0 +1,13 @@
+---
+title: "The Athens Community"
+date: 2018-09-02T12:13:00-07:00
+chapter: true
+weight: 1
+
+---
+
+### Contributing
+
+# The Athens Community
+
+The following guide is designed to help members participate within the community by becoming a contributor, maintainer, or even just following the `#athens` slack channel or attending the developer meetings

--- a/docs/content/contributing/community/developer-meetings.md
+++ b/docs/content/contributing/community/developer-meetings.md
@@ -1,0 +1,32 @@
+---
+title: "Developer Meetings"
+date: 2018-09-28T10:40:50-07:00
+weight: 2
+
+---
+
+We hold our weekly developer meetings every Thursday at 11am US Pacific Time. They start with a quick update on the project from the maintainers, and then we discuss things on the agenda.
+
+Absolutely everyone is invited to attend, suggest topics for the agenda, and participate! You don’t have to be a contributor or maintainer to show up and share your perspective, ideas, feelings, etc.
+
+### Meeting Details
+
+They're every Thursday at 11am to 12pm US Pacific Time and you can join the meeting here by following this link: https://zoom.us/j/193797787
+
+### Agenda
+
+The [agenda google doc](https://docs.google.com/document/d/1xpvgmR1Fq4iy1j975Tb4H_XjeXUQUOAvn0FximUzvIk/edit#heading=h.f24qbjkyfv6v)
+ is where you'll can suggest topics and look at all the topics discussed in previous meetings.
+
+If you want to suggest a topic, just add a bullet point (under the appropriate meeting day) with your first name and the topic.
+
+Here's an example of how to suggest a topic:
+
+> * (Bob) Let’s talk about something cool!
+
+> * (Alice) Let’s talk about cool thing #2!
+
+### Past Meetings
+
+Don't worry if you can't make them but want to catch up! All past development meetings available on [YouTube](https://www.youtube.com/playlist?list=PLAk08AWjk5sekD-FRjU4VVe97nltUyZ4W).
+

--- a/docs/content/contributing/community/participating.md
+++ b/docs/content/contributing/community/participating.md
@@ -1,7 +1,8 @@
 ---
-title: "Participating in the Athens Community"
+title: "Participating in the Community"
 date: 2018-08-24T17:01:56-07:00
 weight: 1
+
 ---
 
 Absolutely everyone is welcome to join our community at any time! We
@@ -31,7 +32,7 @@ interested in
 - Submit a [pull request](https://github.com/gomods/athens/pulls) (PR) to fix
 an issue, or to improve something that doesn't have an issue
 - Review a PR that you're interested in
-- Join us at a weekly [development meeting](https://docs.google.com/document/d/1xpvgmR1Fq4iy1j975Tb4H_XjeXUQUOAvn0FximUzvIk/edit#)
+- Join us at a weekly [development meeting](/contributing/community/developer-meetings/)
 (or more than one!)
     - See [here](https://www.youtube.com/playlist?list=PLAk08AWjk5sekD-FRjU4VVe97nltUyZ4W) for recordings of all our past meetings
 - Come chat with us in the [gophers slack](https://invite.slack.golangbridge.org/) in the `#athens` channel

--- a/docs/content/contributing/maintainers/_index.md
+++ b/docs/content/contributing/maintainers/_index.md
@@ -2,6 +2,7 @@
 title: "Maintainers"
 date: 2018-09-28T10:40:50-07:00
 chapter: true
+weight: 3
 
 ---
 

--- a/docs/content/contributing/new/_index.md
+++ b/docs/content/contributing/new/_index.md
@@ -2,6 +2,7 @@
 title: "New Contributors"
 date: 2018-09-02T12:13:00-07:00
 chapter: true
+weight: 2
 
 ---
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

> The Athens development meeting happens weekly but nobody knows where to
> find it.. 

**How is the fix applied?**

I felt that the current organisation of these pages wasn't
easily readable so have sorted the community pages separately from
those on say using Git or GitHub. I took a lot of the content from the
google doc so I altered it slightly so it fits with the voice of the
current document.

The new structure is:
Contributing > The Athens Community > Participating in the Community
Contributing > The Athens Community > Developer Meetings

**Fixes issue:  #[730]**

Signed-off-by: Chris M <millscj01@gmail.com>