### PR TITLE
Add datadog to docker-compose as well

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,15 @@ services:
     environment:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: minio123
+  datadag:
+    environment:
+      - DD_API_KEY
+      - DD_LOG_LEVEL=trace
+      - DD_APM_ENABLED=true
+    image:
+      datadog/agent:latest
+    ports:
+      - 8126:8126
   jaeger:
     environment:
       - COLLECTOR_ZIPKIN_HTTP_PORT=9441

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     environment:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: minio123
-  datadag:
+  datadog:
     environment:
-      - DD_API_KEY
+      - DD_API_KEY=
       - DD_LOG_LEVEL=trace
       - DD_APM_ENABLED=true
     image:


### PR DESCRIPTION
**What is the problem I am trying to address?**

We have a docker compose file that has jaeger as self documented tracer. It will be nice to have data dog as well in the list

**How is the fix applied?**

Updated the docker-compose file with datadog images and minimal env var from docs.

