### PR TITLE
Support custom ca's and make insecure as part optional default being false

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -243,3 +243,8 @@ EnableCSRFProtection = false
         # Defaults to Global Timeout
         # Env override: MONGO_CONN_TIMEOUT_SEC
         Timeout = 300
+
+        # Allows for insecure SSL / http connections to mongo storage
+        # Should be used for testing or development only
+        # Env override: ATHENS_MONGO_INSECURE
+        Insecure = false

--- a/pkg/config/mongo.go
+++ b/pkg/config/mongo.go
@@ -3,6 +3,7 @@ package config
 // MongoConfig specifies the properties required to use MongoDB as the storage backend
 type MongoConfig struct {
 	TimeoutConf
-	URL      string `validate:"required" envconfig:"ATHENS_MONGO_STORAGE_URL"`
-	CertPath string `envconfig:"ATHENS_MONGO_CERT_PATH"`
+	URL          string `validate:"required" envconfig:"ATHENS_MONGO_STORAGE_URL"`
+	CertPath     string `envconfig:"ATHENS_MONGO_CERT_PATH"`
+	InsecureConn bool   `envconfig:"ATHENS_MONGO_INSECURE"`
 }

--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -57,15 +57,15 @@ func TestEnvOverrides(t *testing.T) {
 	expProxy := ProxyConfig{
 		StorageType:           "minio",
 		OlympusGlobalEndpoint: "mytikas.gomods.io",
-		Port:                  ":7000",
-		FilterOff:             false,
-		BasicAuthUser:         "testuser",
-		BasicAuthPass:         "testpass",
-		ForceSSL:              true,
-		ValidatorHook:         "testhook.io",
-		PathPrefix:            "prefix",
-		NETRCPath:             "/test/path/.netrc",
-		HGRCPath:              "/test/path/.hgrc",
+		Port:          ":7000",
+		FilterOff:     false,
+		BasicAuthUser: "testuser",
+		BasicAuthPass: "testpass",
+		ForceSSL:      true,
+		ValidatorHook: "testhook.io",
+		PathPrefix:    "prefix",
+		NETRCPath:     "/test/path/.netrc",
+		HGRCPath:      "/test/path/.hgrc",
 	}
 
 	expOlympus := OlympusConfig{
@@ -202,10 +202,10 @@ func TestParseExampleConfig(t *testing.T) {
 	expProxy := &ProxyConfig{
 		StorageType:           "memory",
 		OlympusGlobalEndpoint: "http://localhost:3001",
-		Port:                  ":3000",
-		FilterOff:             true,
-		BasicAuthUser:         "",
-		BasicAuthPass:         "",
+		Port:          ":3000",
+		FilterOff:     true,
+		BasicAuthUser: "",
+		BasicAuthPass: "",
 	}
 
 	expOlympus := &OlympusConfig{
@@ -248,6 +248,7 @@ func TestParseExampleConfig(t *testing.T) {
 			TimeoutConf: TimeoutConf{
 				Timeout: globalTimeout,
 			},
+			InsecureConn: false,
 		},
 	}
 
@@ -345,6 +346,7 @@ func getEnvMap(config *Config) map[string]string {
 		if storage.Mongo != nil {
 			envVars["ATHENS_MONGO_STORAGE_URL"] = storage.Mongo.URL
 			envVars["ATHENS_MONGO_CERT_PATH"] = storage.Mongo.CertPath
+			envVars["ATHENS_MONGO_INSECURE"] = strconv.FormatBool(storage.Mongo.InsecureConn)
 		}
 	}
 	return envVars

--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -57,15 +57,15 @@ func TestEnvOverrides(t *testing.T) {
 	expProxy := ProxyConfig{
 		StorageType:           "minio",
 		OlympusGlobalEndpoint: "mytikas.gomods.io",
-		Port:          ":7000",
-		FilterOff:     false,
-		BasicAuthUser: "testuser",
-		BasicAuthPass: "testpass",
-		ForceSSL:      true,
-		ValidatorHook: "testhook.io",
-		PathPrefix:    "prefix",
-		NETRCPath:     "/test/path/.netrc",
-		HGRCPath:      "/test/path/.hgrc",
+		Port:                  ":7000",
+		FilterOff:             false,
+		BasicAuthUser:         "testuser",
+		BasicAuthPass:         "testpass",
+		ForceSSL:              true,
+		ValidatorHook:         "testhook.io",
+		PathPrefix:            "prefix",
+		NETRCPath:             "/test/path/.netrc",
+		HGRCPath:              "/test/path/.hgrc",
 	}
 
 	expOlympus := OlympusConfig{
@@ -202,10 +202,10 @@ func TestParseExampleConfig(t *testing.T) {
 	expProxy := &ProxyConfig{
 		StorageType:           "memory",
 		OlympusGlobalEndpoint: "http://localhost:3001",
-		Port:          ":3000",
-		FilterOff:     true,
-		BasicAuthUser: "",
-		BasicAuthPass: "",
+		Port:                  ":3000",
+		FilterOff:             true,
+		BasicAuthUser:         "",
+		BasicAuthPass:         "",
 	}
 
 	expOlympus := &OlympusConfig{

--- a/pkg/storage/mongo/mongo.go
+++ b/pkg/storage/mongo/mongo.go
@@ -81,10 +81,9 @@ func (m *ModuleStore) newSession(timeout time.Duration, insecure bool) (*mgo.Ses
 	dialInfo.Timeout = timeout
 
 	if m.certPath != "" {
-		if insecure == true {
-			tlsConfig.InsecureSkipVerify = true
-		}
 
+		// Sets only when the env var is setup in config.dev.toml
+		tlsConfig.InsecureSkipVerify = insecure
 		var roots *x509.CertPool
 		// See if there is a system cert pool
 		roots, err = x509.SystemCertPool()

--- a/pkg/storage/mongo/mongo.go
+++ b/pkg/storage/mongo/mongo.go
@@ -21,6 +21,7 @@ type ModuleStore struct {
 	c        string // collection
 	url      string
 	certPath string
+	insecure bool // Only to be used for development instances
 	timeout  time.Duration
 }
 
@@ -45,7 +46,7 @@ func (m *ModuleStore) connect() error {
 	const op errors.Op = "mongo.connect"
 
 	var err error
-	m.s, err = m.newSession(m.timeout)
+	m.s, err = m.newSession(m.timeout, m.insecure)
 	if err != nil {
 		return errors.E(op, err)
 	}
@@ -69,7 +70,7 @@ func (m *ModuleStore) initDatabase() error {
 	return c.EnsureIndex(index)
 }
 
-func (m *ModuleStore) newSession(timeout time.Duration) (*mgo.Session, error) {
+func (m *ModuleStore) newSession(timeout time.Duration, insecure bool) (*mgo.Session, error) {
 	tlsConfig := &tls.Config{}
 
 	dialInfo, err := mgo.ParseURL(m.url)
@@ -80,6 +81,10 @@ func (m *ModuleStore) newSession(timeout time.Duration) (*mgo.Session, error) {
 	dialInfo.Timeout = timeout
 
 	if m.certPath != "" {
+		if insecure == true {
+			tlsConfig.InsecureSkipVerify = true
+		}
+
 		var roots *x509.CertPool
 		// See if there is a system cert pool
 		roots, err = x509.SystemCertPool()
@@ -97,7 +102,6 @@ func (m *ModuleStore) newSession(timeout time.Duration) (*mgo.Session, error) {
 			return nil, fmt.Errorf("failed to parse certificate from: %s", m.certPath)
 		}
 
-		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.ClientCAs = roots
 
 		dialInfo.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {

--- a/pkg/storage/mongo/mongo.go
+++ b/pkg/storage/mongo/mongo.go
@@ -81,7 +81,6 @@ func (m *ModuleStore) newSession(timeout time.Duration, insecure bool) (*mgo.Ses
 	dialInfo.Timeout = timeout
 
 	if m.certPath != "" {
-
 		// Sets only when the env var is setup in config.dev.toml
 		tlsConfig.InsecureSkipVerify = insecure
 		var roots *x509.CertPool


### PR DESCRIPTION
**What is the problem I am trying to address?**

Certificates can be used in multiple ways
A) They can be in the system cert pool for which the support is already there fixed in #756 
B) They can be appended to a cert pool that is acquired from the certificate directly within the app.
C) The insecure flag can still be passed for dev and test purposes.

**How is the fix applied?**

Pass an env var to determine if insecure flag is passed or not.

Fixes issue:  #540

Fixes #540

