### PR TITLE
Document trying proxy outside the GOPATH

### DIFF
--- a/docs/content/try-out.md
+++ b/docs/content/try-out.md
@@ -10,8 +10,17 @@ To quickly see Athens in action, follow these steps:
 
 First, make sure you have [Go 1.11 installed](https://gophersource.com/setup/),
 that GOPATH/bin is on your path, and that you have enabled the [Go
-Modules](https://github.com/golang/go/wiki/Modules) feature by exporting
-GO111MODULE=on.
+Modules](https://github.com/golang/go/wiki/Modules) feature.
+
+**Bash**
+```bash
+export GO111MODULE=on
+```
+
+**PowerShell**
+```powershell
+$env:GO111MODULE = "on"
+```
 
 Next, use git and Go to install and run the Athens proxy in a background process.
 

--- a/docs/content/try-out.md
+++ b/docs/content/try-out.md
@@ -8,33 +8,34 @@ menu: shortcuts
 
 To quickly see Athens in action, follow these steps:
 
-First, make sure you have [Go 1.11 installed](https://gophersource.com/setup/) and that GOPATH/bin is on your path.
+First, make sure you have [Go 1.11 installed](https://gophersource.com/setup/),
+that GOPATH/bin is on your path, and that you have enabled the [Go
+Modules](https://github.com/golang/go/wiki/Modules) feature by exporting
+GO111MODULE=on.
 
-Next, use Go to install and run the Athens proxy in a background process
+Next, use git and Go to install and run the Athens proxy in a background process.
 
 ```console
-$ go get -u github.com/gomods/athens/cmd/proxy
-# the source is downloaded to GOPATH/src/github.com/gomods/athens/
+$ git clone https://github.com/gomods/athens
+$ cd athens/cmd/proxy
+$ go install
 $ proxy &
-[1] 25243
-INFO[0000] Starting application at 127.0.0.1:3000
+[1] 37186
+INFO[0000] Exporter not specified. Traces won't be exported
+INFO[0000] Starting application at http://127.0.0.1:3000
 ```
 
-Next, you will need to enable the [Go Modules](https://github.com/golang/go/wiki/Modules)
-feature and configure Go to use the proxy!
+Next, you will need to configure Go to use the proxy!
 
 **Bash**
 ```bash
-export GO111MODULE=on
 export GOPROXY=http://127.0.0.1:3000
 ```
 
 **PowerShell**
 ```powershell
-$env:GO111MODULE = "on"
 $env:GOPROXY = "http://127.0.0.1:3000"
-``@ma`
-
+```
 
 Now, when you build and run this example application, **go** will fetch dependencies via Athens!
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

Try it out documentation is not working due to relative path of config file. Also it does not show the repo working outside the GOPATH.

**How is the fix applied?**

Updated "try it out" documentation to run proxy outside the GOPATH and match expected output.

Also fixes minor formatting issues.

**Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue.**

Fixes #780 