### PR TITLE
adding a space before "(english version)" in the contributor docs

### DIFF
--- a/docs/content/contributing/community/participating.md
+++ b/docs/content/contributing/community/participating.md
@@ -95,7 +95,7 @@ decisions)
 contributors, and other maintainers to review)
 - Help foster a safe and welcoming environment for all project participants.
 This will include enforcing our code of conduct. We adhere to the [Contributor
-Covenant](https://www.contributor-covenant.org), if you haven't read it yet you can do so [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct)(english version).
+Covenant](https://www.contributor-covenant.org), if you haven't read it yet you can do so [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct) (english version).
 
 ## How to Become a Maintainer
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

I noticed in the [participating docs](https://docs.gomods.io/contributing/community/participating/) that in the last bullet point there's no space between the contributor covenant link the `(english version)`

**How is the fix applied?**

So I added a space 😄 
