### PR TITLE
Netrc for windows

### DIFF
--- a/cmd/proxy/actions/auth.go
+++ b/cmd/proxy/actions/auth.go
@@ -63,7 +63,7 @@ func netrcFromToken(tok string) {
 	}
 }
 
-func transformAuthFileName(authFileName string) string {	
+func transformAuthFileName(authFileName string) string {
 	if root := strings.TrimLeft(authFileName, "._"); root == "netrc" {
 		return getNetrcFileName()
 	}

--- a/cmd/proxy/actions/auth.go
+++ b/cmd/proxy/actions/auth.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/markbates/goth"
@@ -40,7 +42,8 @@ func initializeAuthFile(path string) {
 		log.Fatalf("could not get homedir: %v", err)
 	}
 
-	rcp := filepath.Join(hdir, filepath.Base(path))
+	fileName := transformAuthFileName(filepath.Base(path))
+	rcp := filepath.Join(hdir, fileName)
 	if err := ioutil.WriteFile(rcp, fileBts, 0600); err != nil {
 		log.Fatalf("could not write to file: %v", err)
 	}
@@ -54,8 +57,23 @@ func netrcFromToken(tok string) {
 	if err != nil {
 		log.Fatalf("netrcFromToken: could not get homedir: %v", err)
 	}
-	rcp := filepath.Join(hdir, ".netrc")
+	rcp := filepath.Join(hdir, getNetrcFileName())
 	if err := ioutil.WriteFile(rcp, []byte(fileContent), 0600); err != nil {
 		log.Fatalf("netrcFromToken: could not write to file: %v", err)
 	}
+}
+
+func transformAuthFileName(authFileName string) string {
+	root := strings.TrimLeft(authFileName, "._")
+	if root == "netrc" {
+		return getNetrcFileName()
+	}
+	return authFileName
+}
+
+func getNetrcFileName() string {
+	if runtime.GOOS == "windows" {
+		return "_netrc"
+	}
+	return ".netrc"
 }

--- a/cmd/proxy/actions/auth.go
+++ b/cmd/proxy/actions/auth.go
@@ -63,9 +63,8 @@ func netrcFromToken(tok string) {
 	}
 }
 
-func transformAuthFileName(authFileName string) string {
-	root := strings.TrimLeft(authFileName, "._")
-	if root == "netrc" {
+func transformAuthFileName(authFileName string) string {	
+	if root := strings.TrimLeft(authFileName, "._"); root == "netrc" {
 		return getNetrcFileName()
 	}
 	return authFileName


### PR DESCRIPTION
**What is the problem I am trying to address?**

Windows expects netrc file to be named "_netrc" instead of ".netrc" 

**How is the fix applied?**

If we;re on windows we will use `_netrc` orherwise `.netrc`
`.hgrc` should be fine 

Fixes #832 