### PR TITLE
link to first-contributions docs in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Hurray! We are glad that you want to contribute to our project! 👍
 
-If this is your first contribution, not to worry! We have a great [tutorial](https://www.youtube.com/watch?v=bgSDcTyysRc) to help you get started, and you can always ask us for help in the `#athens` channel in the [gopher slack](https://invite.slack.golangbridge.org/). We'll give you whatever guidance you need.
+If this is your first contribution, not to worry! We have a great [tutorial](https://www.youtube.com/watch?v=bgSDcTyysRc) to help you get started, and you can always ask us for help in the `#athens` channel in the [gopher slack](https://invite.slack.golangbridge.org/). We'll give you whatever guidance you need. Another great resource for first time contributors can be found [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md).
 
 ## Claiming an issue
 If you see an issue that you'd like to work on, please just post a comment saying that you want to work on it. Something like "I want to work on this" is fine.


### PR DESCRIPTION
First time contributors should be given as much info as possible about the best ways to go about contributing to open-source. Often when stepping into a new world it's nice to have a step-by-step guide on what to do. This PR is adding in a link in the contributing docs to the first-contributions docs which is aimed to help first time contributors out.

Fixes #794 
