### PR TITLE
Remove FilterOff from the env var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Hurray! We are glad that you want to contribute to our project! 👍
 
-If this is your first contribution, not to worry! We have a great [tutorial](https://www.youtube.com/watch?v=bgSDcTyysRc) to help you get started, and you can always ask us for help in the `#athens` channel in the [gopher slack](https://invite.slack.golangbridge.org/). We'll give you whatever guidance you need.
+If this is your first contribution, not to worry! We have a great [tutorial](https://www.youtube.com/watch?v=bgSDcTyysRc) to help you get started, and you can always ask us for help in the `#athens` channel in the [gopher slack](https://invite.slack.golangbridge.org/). We'll give you whatever guidance you need. Another great resource for first time contributors can be found [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md).
 
 ## Claiming an issue
 If you see an issue that you'd like to work on, please just post a comment saying that you want to work on it. Something like "I want to work on this" is fine.

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -119,7 +119,7 @@ func App(conf *config.Config) (*buffalo.App, error) {
 
 	initializeAuth(app)
 
-	if !conf.Proxy.FilterOff {
+	if !conf.FilterOff() {
 		mf := module.NewFilter(conf.FilterFile)
 		app.Use(mw.NewFilterMiddleware(mf, conf.Proxy.GlobalEndpoint))
 	}

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -75,11 +75,6 @@ Timeout = 300
     # Env override: ATHENS_REDIS_QUEUE_ADDRESS
     RedisQueueAddress = ":6379"
 
-    # Flag to turn off Proxy Filter middleware
-    # Defaults to true
-    # Env override: PROXY_FILTER_OFF
-    FilterOff = true
-
     # Username for basic auth
     # Env override: BASIC_AUTH_USER
     BasicAuthUser = ""

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -46,7 +46,7 @@ CloudRuntime = "none"
 
 # The filename for the include exclude filter. Defaults to 'filter.conf'
 # Env override: ATHENS_FILTER_FILE
-FilterFile = "filter.conf"
+FilterFile = ""
 
 # Timeout is the timeout for external network calls in seconds
 # This value is used as the default for storage backends if they don't specify timeouts

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	Storage          *StorageConfig
 }
 
+// FilterOff returns true if the FilterFile is empty
+func (c *Config) FilterOff() bool {
+	return c.FilterFile == ""
+}
+
 // ParseConfigFile parses the given file into an athens config struct
 func ParseConfigFile(configFile string) (*Config, error) {
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -59,7 +59,6 @@ func TestEnvOverrides(t *testing.T) {
 		StorageType:    "minio",
 		GlobalEndpoint: "mytikas.gomods.io",
 		Port:           ":7000",
-		FilterOff:      false,
 		BasicAuthUser:  "testuser",
 		BasicAuthPass:  "testpass",
 		ForceSSL:       true,
@@ -203,7 +202,6 @@ func TestParseExampleConfig(t *testing.T) {
 		StorageType:    "memory",
 		GlobalEndpoint: "http://localhost:3001",
 		Port:           ":3000",
-		FilterOff:      true,
 		BasicAuthUser:  "",
 		BasicAuthPass:  "",
 	}
@@ -304,7 +302,6 @@ func getEnvMap(config *Config) map[string]string {
 		envVars["ATHENS_STORAGE_TYPE"] = proxy.StorageType
 		envVars["ATHENS_GLOBAL_ENDPOINT"] = proxy.GlobalEndpoint
 		envVars["PORT"] = proxy.Port
-		envVars["PROXY_FILTER_OFF"] = strconv.FormatBool(proxy.FilterOff)
 		envVars["BASIC_AUTH_USER"] = proxy.BasicAuthUser
 		envVars["BASIC_AUTH_PASS"] = proxy.BasicAuthPass
 		envVars["PROXY_FORCE_SSL"] = strconv.FormatBool(proxy.ForceSSL)
@@ -410,5 +407,18 @@ func Test_checkFilePerms(t *testing.T) {
 				t.Errorf("checkFilePerms() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestConfig_FilterOff(t *testing.T) {
+	c := &Config{}
+
+	if c.FilterOff() == false {
+		t.Errorf("Config.FilterOff() = %v, want %v", false, true)
+	}
+
+	c.FilterFile = "somefile"
+	if c.FilterOff() == true {
+		t.Errorf("Config.FilterOff() = %v, want %v", true, false)
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,7 +76,6 @@ func TestEnvOverrides(t *testing.T) {
 		BuffaloLogLevel: "info",
 		GoBinary:        "go11",
 		CloudRuntime:    "gcp",
-		FilterFile:      "filter2.conf",
 		TimeoutConf: TimeoutConf{
 			Timeout: 30,
 		},
@@ -261,7 +260,6 @@ func TestParseExampleConfig(t *testing.T) {
 		GoGetWorkers:    30,
 		ProtocolWorkers: 30,
 		CloudRuntime:    "none",
-		FilterFile:      "filter.conf",
 		TimeoutConf: TimeoutConf{
 			Timeout: 300,
 		},
@@ -292,7 +290,6 @@ func getEnvMap(config *Config) map[string]string {
 		"ATHENS_LOG_LEVEL":        config.LogLevel,
 		"BUFFALO_LOG_LEVEL":       config.BuffaloLogLevel,
 		"ATHENS_CLOUD_RUNTIME":    config.CloudRuntime,
-		"ATHENS_FILTER_FILE":      config.FilterFile,
 		"ATHENS_TIMEOUT":          strconv.Itoa(config.Timeout),
 		"ATHENS_TRACE_EXPORTER":   config.TraceExporterURL,
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -409,16 +409,3 @@ func Test_checkFilePerms(t *testing.T) {
 		})
 	}
 }
-
-func TestConfig_FilterOff(t *testing.T) {
-	c := &Config{}
-
-	if c.FilterOff() == false {
-		t.Errorf("Config.FilterOff() = %v, want %v", false, true)
-	}
-
-	c.FilterFile = "somefile"
-	if c.FilterOff() == true {
-		t.Errorf("Config.FilterOff() = %v, want %v", true, false)
-	}
-}

--- a/pkg/config/proxy.go
+++ b/pkg/config/proxy.go
@@ -5,7 +5,6 @@ type ProxyConfig struct {
 	StorageType    string `validate:"required" envconfig:"ATHENS_STORAGE_TYPE"`
 	GlobalEndpoint string `envconfig:"ATHENS_GLOBAL_ENDPOINT"` // This feature is not yet implemented
 	Port           string `validate:"required" envconfig:"PORT"`
-	FilterOff      bool   `validate:"required" envconfig:"PROXY_FILTER_OFF"`
 	BasicAuthUser  string `envconfig:"BASIC_AUTH_USER"`
 	BasicAuthPass  string `envconfig:"BASIC_AUTH_PASS"`
 	ForceSSL       bool   `envconfig:"PROXY_FORCE_SSL"`


### PR DESCRIPTION
**What is the problem I am trying to address?**

We have 2 variables in our config `FilterFile` and `FilterOff`. This can create confusion to users when they have a FilterFile but have set FilterOff. We can actually look if `FilterFile` has been set or not and determine if a `FilterFile` needs to be found.

**How is the fix applied?**

Remove `FilterOff` from `config.dev.toml`

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**
No particular issue, but a general clean up.

