### PR TITLE
adds development.md to new contributor section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Hurray! We are glad that you want to contribute to our project! 👍
 
-If this is your first contribution, not to worry! We have a great [tutorial](https://www.youtube.com/watch?v=bgSDcTyysRc) to help you get started, and you can always ask us for help in the `#athens` channel in the [gopher slack](https://invite.slack.golangbridge.org/). We'll give you whatever guidance you need.
+If this is your first contribution, not to worry! We have a great [tutorial](https://www.youtube.com/watch?v=bgSDcTyysRc) to help you get started, and you can always ask us for help in the `#athens` channel in the [gopher slack](https://invite.slack.golangbridge.org/). We'll give you whatever guidance you need. Another great resource for first time contributors can be found [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md).
 
 ## Claiming an issue
 If you see an issue that you'd like to work on, please just post a comment saying that you want to work on it. Something like "I want to work on this" is fine.

--- a/docs/content/contributing/new/development.md
+++ b/docs/content/contributing/new/development.md
@@ -1,0 +1,78 @@
+---
+title: "How To Contribute"
+date: 2018-10-30T17:48:51-07:00
+weight: 3
+---
+# Development Guide for Athens
+
+The proxy is built on the [Buffalo](https://gobuffalo.io/) framework. We chose
+this framework to make it as straightforward as possible to get your development environment up and running.
+
+You'll need Buffalo [v0.12.4](https://github.com/gobuffalo/buffalo/releases/tag/v0.12.4) or later to get started on Athens,
+so be sure to download the CLI and put it into your `PATH`.
+
+Athens uses [Go Modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) for dependency management. You will need Go [v1.11](https://golang.org/dl) or later to get started on Athens.
+
+See our [Contributing Guide](CONTRIBUTING.md) for tips on how to submit a pull request when you are ready.
+
+# Initial Development Environment Setup
+Athens relies on having a few tools installed locally. Run `make setup-dev-env` to install them.
+
+### Go version
+Athens is developed on Go1.11+.
+
+To point Athens to a different version of Go set the following environment variable
+```
+GO_BINARY_PATH=go1.11.X
+or whichever binary you want to use with athens
+```
+
+### Dependencies
+
+# Services that Athens Needs
+
+Athens relies on several services (i.e. databases, etc...) to function properly. We use [Docker](http://docker.com/) images to configure and run those services.
+
+If you're not familiar with Docker, that's ok. In the spirit of Buffalo, we've tried to make
+it easy to get up and running:
+
+1. [Download and install docker-compose](https://docs.docker.com/compose/install/) (docker-compose is a tool for easily starting and stopping lots of services at once)
+2. Run `make dev` from the root of this repository
+
+That's it! After the `make dev` command is done, everything will be up and running and you can move
+on to the next step.
+
+If you want to stop everything at any time, run `make down`.
+
+Note that `make dev` only runs the minimum amount of dependencies needed for things to work. If you'd like to run all the possible dependencies run `make alldeps` or directly the services available in the `docker-compose.yml` file. Keep in mind, though, that `make alldeps` does not start up Athens or Oympus, but **only** their dependencies.
+
+# Run the Proxy
+
+After you've set up your dependencies, the `buffalo` CLI makes it easy to launch the proxy: 
+
+```console
+cd cmd/proxy
+buffalo dev
+```
+
+After `buffalo dev` starts up, you'll see some console output like:
+
+```console
+Starting application at 127.0.0.1:3000
+```
+
+And you'll be up and running. As you edit and save code, the `buffalo dev` command will notice and automatically re-compile and restart the server. That makes your life a little easier!
+
+# Run unit tests
+
+In order to run unit tests, services they depend on must be running first:
+
+```console
+make alldeps
+```
+
+then you can run the unit tests:
+
+```console
+make test-unit
+```


### PR DESCRIPTION
Copies the development doc over to the new contributor section. Not sure if this is the best way to do it though; having two copies of the same thing in two locations. Is there a way to create a doc page that links automatically to development.md?

Fixes #836 
