### PR TITLE
docs: add hacking on docs website

### DIFF
--- a/docs/content/contributing/new/docs.md
+++ b/docs/content/contributing/new/docs.md
@@ -1,0 +1,18 @@
+---
+title: "Docs"
+date: 2018-11-01T13:58:58-07:00
+weight: 2
+LastModifierDisplayName: "Marwan"
+LastModifierEmail: "marwan.sameer@gmail.com"
+
+---
+
+### Contributing To Docs
+
+Contributing to docs is just as important, if not more important than, writing code. We use [GoHugo](https://gohugo.io/) to run this website. So if you'd like to improve it, here's how you can run it locally:
+
+1. Install the Hugo binary: https://github.com/gohugoio/hugo#choose-how-to-install 
+2. `cd ./docs && hugo server`
+
+The Hugo server will run on http://localhost:1313 and it will automatically watch your files and update the website every time you make a change. 
+


### PR DESCRIPTION
I decided to not include a dockerized set up of our docs website since I cannot find for sure an official Hugo image on docker hub. If there is, please let me know! Otherwise, we can host our own gomods/docs image which would be pretty cool. 

Fixes https://github.com/gomods/athens/issues/851