### PR TITLE
Add a Dockerfile for Hugo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,3 +71,16 @@ then you can run the unit tests:
 ```console
 make test-unit
 ```
+
+# Run the docs
+
+To get started with developing the docs we provide a docker image which you can use from within the `/docs` directory. It should work on all platforms. To get it up and running:
+
+```
+docker run -it --rm \
+        --name hugo-server \
+        -p 1313:1313 \
+        -v $(PWD):/src:cached \
+        gomods/hugo
+        
+```

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ run: build
 
 .PHONY: docs
 docs:
-	cd docs && hugo
+	docker build -t gomods/hugo -f docs/Dockerfile .
 
 .PHONY: setup-dev-env
 setup-dev-env:
@@ -54,7 +54,7 @@ alldeps:
 	docker-compose -p athensdev up -d minio
 	docker-compose -p athensdev up -d jaeger
 	echo "sleeping for a bit to wait for the DB to come up"
-	sleep 5	
+	sleep 5
 
 .PHONY: dev
 dev:

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.8
+
+ENV HUGO_VERSION=0.50
+ENV HUGO_BINARY=hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+
+ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} /tmp
+
+RUN tar -xf /tmp/${HUGO_BINARY} -C /tmp \
+    && mv /tmp/hugo /usr/local/bin/hugo \
+    && rm -rf /tmp/hugo_${HUGO_VERSION}_linux_amd64 \
+    && rm -rf /tmp/${HUGO_BINARY} \
+    && rm -rf /tmp/LICENSE.md \
+    && rm -rf /tmp/README.md \
+    && apk upgrade --update \
+    && apk add --no-cache git asciidoctor libc6-compat libstdc++ ca-certificates
+
+WORKDIR /src
+
+CMD ["hugo", "server", "-s", "/src", "-b", "http://localhost:1313", "--bind", "0.0.0.0"]
+
+EXPOSE 1313


### PR DESCRIPTION
**What is the problem I am trying to address?**

Following yesterdays development meeting they discussed running `hugo` locally. There's no official Dockerfile so lets go and create one!

> In today's dev meeting (November 1, 2018) we discussed having documentation on how to run the documentation site locally. #851 talks about that.

**How is the fix applied?**

I've added a simple Dockerfile tied down to the current version of alpine and hugo. The hugo version can be bumped with the environment variable `HUGO_VERSION` although this might become a chore so I could write a helper script to bump this automatically.

I also changed the Makefile to build the container which we can link up to CI/CD. I can also do this as part of this ticket if needed?

I added some simple documentation to `DEVELOPMENT.md` and can either update the information in #855 or ask @marwan-at-work kindly to do it.

As it's only a local development environment I haven't included the ability to alter whether hugo watches files and whether the base url would change. I have also altered the bind address to use `0.0.0.0` if this is a problem for people we can add a proxy or something.

Fixes #856 