### PR TITLE
Tag with stable insead of latest on semver git tag

### DIFF
--- a/scripts/push-docker-images.sh
+++ b/scripts/push-docker-images.sh
@@ -22,7 +22,7 @@ fi
 if [[ "${MUTABLE_TAG:-}" == "" ]]; then
     # tagged builds
     if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-        MUTABLE_TAG="latest"
+        MUTABLE_TAG="stable"
     # master build
     elif [[ "$BRANCH" == "master" ]]; then
         MUTABLE_TAG="canary"


### PR DESCRIPTION
**What is the problem I am trying to address?**
At the moment we tag the docker image with `latest` on each semver git tag. This causes confusion since latest is often misunderstood.
https://github.com/gomods/athens/blob/8f4e3dc3c0f5b8752829e02ef3be90b9774cb454/scripts/push-docker-images.sh#L24-L25

Mention briefly how you have applied the fix.
I renamed `latest` to `stable` .
**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #843 

