### PR TITLE
Fix broken link

### DIFF
--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -2,7 +2,6 @@
 title: "Contributing to Athens"
 date: 2018-09-01T19:30:42-07:00
 weight: 4
-
 ---
 
 Welcome, Gopher! We're really glad you're considering contributing to Athens. We'd like to briefly introduce you to our community before you get started.
@@ -21,7 +20,7 @@ We have some hard-and-fast rules in our community, like our [Code of Conduct](ht
 
 We hope you like what you see, and we'd love for you to get involved.
 
-If you're familiar with Git and GitHub basics, read [how to participate in the Athens community](./community-roles) to learn about how we organize ourselves and how to get started.
+If you're familiar with Git and GitHub basics, read [how to participate in the Athens community](./community/participating) to learn about how we organize ourselves and how to get started.
 
 If you're new to Git and GitHub, check out our [guide for new contributors to open source](./new), and then go on to that how to participate document I mentioned above.
 

--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -2,6 +2,7 @@
 title: "Contributing to Athens"
 date: 2018-09-01T19:30:42-07:00
 weight: 4
+
 ---
 
 Welcome, Gopher! We're really glad you're considering contributing to Athens. We'd like to briefly introduce you to our community before you get started.


### PR DESCRIPTION
**What is the problem I am trying to address?**

Found a broken link in the docs. It looks like the previous "community roles" page was renamed "participating". It's on the [contributing page](https://docs.gomods.io/contributing/) when clicking "how to participate in the Athens community".

**How is the fix applied?**

I updated the markdown link to point to `participating.md`. @marwan-at-work I used the new guide for making docs contributions. I had been wondering how to run that locally! Thanks!
