### PR TITLE
Fix link that leads to a page that does not exist

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -12,7 +12,7 @@ A registry is generally run by one entity, is one logical server that provides a
 
 That's most definitely not what we in the Athens community are going for, and that would harm our community if we did go down that path.
 
-First and foremost, Athens is an _implementation_ of the [Go Modules download API](./intro/protocol). Not only does the standard Go toolchain support any implementation of that API, the Athens proxy is designed to talk to any other server that implements that API as well. That allows Athens to talk to other proxies in the community. 
+First and foremost, Athens is an _implementation_ of the [Go Modules download API](/intro/protocol). Not only does the standard Go toolchain support any implementation of that API, the Athens proxy is designed to talk to any other server that implements that API as well. That allows Athens to talk to other proxies in the community. 
 
 Finally, we're purposefully building this project - and working with the toolchain folks - in a way that everyone who wants to write a proxy can participate.
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

I found a link in our markdown docs that lead to a 404. 

**How is the fix applied?**

Correct the link

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**
No issue