### PR TITLE
Filter: fixing after refactoring

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -119,11 +119,6 @@ func App(conf *config.Config) (*buffalo.App, error) {
 
 	initializeAuth(app)
 
-	// Having the hook set means we want to use it
-	if vHook := conf.ValidatorHook; vHook != "" {
-		app.Use(mw.LogEntryMiddleware(mw.NewValidationMiddleware, lggr, vHook))
-	}
-
 	user, pass, ok := conf.BasicAuth()
 	if ok {
 		app.Use(basicAuth(user, pass))
@@ -135,6 +130,11 @@ func App(conf *config.Config) (*buffalo.App, error) {
 			lggr.Fatal(err)
 		}
 		app.Use(mw.NewFilterMiddleware(mf, conf.GlobalEndpoint))
+	}
+
+	// Having the hook set means we want to use it
+	if vHook := conf.ValidatorHook; vHook != "" {
+		app.Use(mw.LogEntryMiddleware(mw.NewValidationMiddleware, lggr, vHook))
 	}
 
 	if err := addProxyRoutes(app, store, lggr, conf.GoBinary, conf.GoGetWorkers, conf.ProtocolWorkers); err != nil {

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -117,15 +117,7 @@ func App(conf *config.Config) (*buffalo.App, error) {
 		app.Use(paramlogger.ParameterLogger)
 	}
 
-	initializeAuth(app)
-
-	if !conf.FilterOff() {
-		mf, err := module.NewFilter(conf.FilterFile)
-		if err != nil {
-			lggr.Fatal(err)
-		}
-		app.Use(mw.NewFilterMiddleware(mf, conf.GlobalEndpoint))
-	}
+	initializeAuth(app)	
 
 	// Having the hook set means we want to use it
 	if vHook := conf.ValidatorHook; vHook != "" {
@@ -135,6 +127,14 @@ func App(conf *config.Config) (*buffalo.App, error) {
 	user, pass, ok := conf.BasicAuth()
 	if ok {
 		app.Use(basicAuth(user, pass))
+	}
+
+	if !conf.FilterOff() {
+		mf, err := module.NewFilter(conf.FilterFile)
+		if err != nil {
+			lggr.Fatal(err)
+		}
+		app.Use(mw.NewFilterMiddleware(mf, conf.GlobalEndpoint))
 	}
 
 	if err := addProxyRoutes(app, store, lggr, conf.GoBinary, conf.GoGetWorkers, conf.ProtocolWorkers); err != nil {

--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -117,7 +117,7 @@ func App(conf *config.Config) (*buffalo.App, error) {
 		app.Use(paramlogger.ParameterLogger)
 	}
 
-	initializeAuth(app)	
+	initializeAuth(app)
 
 	// Having the hook set means we want to use it
 	if vHook := conf.ValidatorHook; vHook != "" {

--- a/pkg/middleware/filter.go
+++ b/pkg/middleware/filter.go
@@ -25,14 +25,6 @@ func NewFilterMiddleware(mf *module.Filter, upstreamEndpoint string) buffalo.Mid
 				return next(c)
 			}
 
-			// not checking the error. Not all requests include a version
-			// i.e. list requests path is like /{module:.+}/@v/list with no version parameter
-			version, _ := paths.GetVersion(c)
-
-			if isPseudoVersion(version) {
-				return next(c)
-			}
-
 			rule := mf.Rule(mod)
 			switch rule {
 			case module.Exclude:
@@ -50,10 +42,6 @@ func NewFilterMiddleware(mf *module.Filter, upstreamEndpoint string) buffalo.Mid
 			return next(c)
 		}
 	}
-}
-
-func isPseudoVersion(version string) bool {
-	return strings.HasPrefix(version, "v0.0.0-")
 }
 
 func redirectToUpstreamURL(registryEndpoint string, u *url.URL) string {

--- a/pkg/middleware/filter.go
+++ b/pkg/middleware/filter.go
@@ -44,6 +44,6 @@ func NewFilterMiddleware(mf *module.Filter, upstreamEndpoint string) buffalo.Mid
 	}
 }
 
-func redirectToUpstreamURL(registryEndpoint string, u *url.URL) string {
-	return strings.TrimSuffix(registryEndpoint, "/") + u.Path
+func redirectToUpstreamURL(upstreamEndpoint string, u *url.URL) string {
+	return strings.TrimSuffix(upstreamEndpoint, "/") + u.Path
 }

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -51,9 +51,9 @@ func newTestFilter(filterFile string) (*module.Filter, error) {
 	if err != nil {
 		return nil, err
 	}
-	f.AddRule("github.com/gomods/athens/", module.Include)
+	f.AddRule("github.com/gomods/athens/", module.Direct)
 	f.AddRule("github.com/athens-artifacts/no-tags", module.Exclude)
-	f.AddRule("github.com/athens-artifacts", module.Direct)
+	f.AddRule("github.com/athens-artifacts", module.Include)
 	return f, nil
 }
 

--- a/pkg/module/filterRule.go
+++ b/pkg/module/filterRule.go
@@ -4,12 +4,13 @@ package module
 type FilterRule int
 
 const (
-	// Default filter rule does not alter default behavior
+	// Default filter rule does not alter default/parent behavior
 	Default FilterRule = iota
-	// Include filter rule includes package and its children from communication
+	// Include treats modules the usual way
+	// Used for reverting Exclude of parent path
 	Include
 	// Exclude filter rule excludes package and its children from communication
 	Exclude
-	// Direct filter rule forces the package to be fetched directly from the vcs
+	// Direct filter rule forces the package to be fetched directly from upstream proxy
 	Direct
 )


### PR DESCRIPTION
**What is the problem I am trying to address?**

After we went away from workers and redesigned data flow, filters stayed one step behind.
This PR brings them even and adds a bit different meaning to filtering keywords considering new data flow.

**How is the fix applied?**

Change is following
- Include:
  - Treats module as it should be without using filter functionality used to reset parent behavior change
- Exclude:
  - Results in exclusion of the module entirely
- Direct:
  - Goes to the upstream proxy without consulting a local storage
  - Before: went to VCS  directly without consulting Olympus as a backup, treated module as a private repo

Filtering middleware moved after auth. So we don't tell whether we treat or we don't particular modules for unauthenticated users.

Removed handling of pseudo versions, it is treated just as a module rule tells it to