### PR TITLE
[Docs] Added mutli-stage build to Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,17 +1,17 @@
-FROM alpine:3.8
+FROM alpine:3.8 as builder
 
 ENV HUGO_VERSION=0.50
 ENV HUGO_BINARY=hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
 
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} /tmp
 
-RUN tar -xf /tmp/${HUGO_BINARY} -C /tmp \
-    && mv /tmp/hugo /usr/local/bin/hugo \
-    && rm -rf /tmp/hugo_${HUGO_VERSION}_linux_amd64 \
-    && rm -rf /tmp/${HUGO_BINARY} \
-    && rm -rf /tmp/LICENSE.md \
-    && rm -rf /tmp/README.md \
-    && apk upgrade --update \
+RUN tar -xf /tmp/${HUGO_BINARY} -C /tmp
+
+FROM alpine:3.8
+
+COPY --from=builder /tmp/hugo /usr/local/bin/hugo
+
+RUN apk upgrade --update \
     && apk add --no-cache git asciidoctor libc6-compat libstdc++ ca-certificates
 
 WORKDIR /src


### PR DESCRIPTION
Added the multi-stage build in order to avoid all the `rm` commands and just copying `hugo` binary to a fresh image.
Kept the packages as I'm not sure if they're needed "in the long run".

For debugging purpose, I kept the `ENV` values, however if needed, the `builder` part could be changed to the following for "always" up to date Hugo version:
```Dockerfile
FROM alpine:3.8 as builder
RUN apk add curl wget jq
WORKDIR /tmp
RUN curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | jq -r ".assets[] | select(.name | contains(\"Linux-64bit.tar.gz\")) | .browser_download_url" | grep -v extended | wget -qi -
RUN tar -xzf hugo*.tar.gz
```


**What is the problem I am trying to address?**

Describe the issue you have been trying to solve.

**How is the fix applied?**

Mention briefly how you have applied the fix.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #

<!-- 
example: Fixes #123
-->
