### PR TITLE
Update docs for those struggling to set up buffalo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -87,3 +87,11 @@ docker run -it --rm \
         gomods/hugo
         
 ```
+
+# Linting 
+
+In our CI/CD pass, we use golint, so feel free to install and run it locally beforehand: 
+
+```
+go get golang.org/x/lint/golint
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,8 +4,7 @@ The proxy is built on the [Buffalo](https://gobuffalo.io/) framework. We chose
 this framework to make it as straightforward as possible to get your development environment up and running.
 However, **you do not need to install buffalo to run Athens**. 
 
-Buffalo provides nice features like a file watcher for your server, so if you'd like to install Buffalo, download [v0.12.4](https://github.com/gobuffalo/buffalo/releases/tag/v0.12.4) or later to get started on Athens,
-so be sure to download the CLI and put it into your `PATH`.
+Buffalo provides nice features like a file watcher for your server, so if you'd like to install Buffalo, download [v0.12.4](https://github.com/gobuffalo/buffalo/releases/tag/v0.12.4) or later to get started on Athens and be sure to download the CLI and put it into your `PATH`.
 
 Athens uses [Go Modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) for dependency management. You will need Go [v1.11](https://golang.org/dl) or later to get started on Athens.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,16 +2,14 @@
 
 The proxy is built on the [Buffalo](https://gobuffalo.io/) framework. We chose
 this framework to make it as straightforward as possible to get your development environment up and running.
+However, **you do not need to install buffalo to run Athens**. 
 
-You'll need Buffalo [v0.12.4](https://github.com/gobuffalo/buffalo/releases/tag/v0.12.4) or later to get started on Athens,
+Buffalo provides nice features like a file watcher for your server, so if you'd like to install Buffalo, download [v0.12.4](https://github.com/gobuffalo/buffalo/releases/tag/v0.12.4) or later to get started on Athens,
 so be sure to download the CLI and put it into your `PATH`.
 
 Athens uses [Go Modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) for dependency management. You will need Go [v1.11](https://golang.org/dl) or later to get started on Athens.
 
 See our [Contributing Guide](CONTRIBUTING.md) for tips on how to submit a pull request when you are ready.
-
-# Initial Development Environment Setup
-Athens relies on having a few tools installed locally. Run `make setup-dev-env` to install them.
 
 ### Go version
 Athens is developed on Go1.11+.
@@ -22,11 +20,33 @@ GO_BINARY_PATH=go1.11.X
 or whichever binary you want to use with athens
 ```
 
+# Run the Proxy
+After you've set up your dependencies, the `buffalo` CLI makes it easy to launch the proxy: 
+
+```console
+cd cmd/proxy
+buffalo dev
+```
+
+If you don't have Buffalo installed, you can just use the `go` command directly as such: 
+
+```
+cd cmd/proxy
+go build
+./proxy
+```
+
+After the server starts, you'll see some console output like:
+
+```console
+Starting application at 127.0.0.1:3000
+```
+
 ### Dependencies
 
 # Services that Athens Needs
 
-Athens relies on several services (i.e. databases, etc...) to function properly. We use [Docker](http://docker.com/) images to configure and run those services.
+Athens relies on several services (i.e. databases, etc...) to function properly. We use [Docker](http://docker.com/) images to configure and run those services. **However, Athens does not require any storage dependencies by default**. The default storage is in memory, you can opt-in to using the `fs` which would also require no dependencies. But if you'd like to test out Athens against a real storage backend (such as MongoDB, Minio, S3 etc), continue reading this section:
 
 If you're not familiar with Docker, that's ok. In the spirit of Buffalo, we've tried to make
 it easy to get up and running:
@@ -40,23 +60,6 @@ on to the next step.
 If you want to stop everything at any time, run `make down`.
 
 Note that `make dev` only runs the minimum amount of dependencies needed for things to work. If you'd like to run all the possible dependencies run `make alldeps` or directly the services available in the `docker-compose.yml` file. Keep in mind, though, that `make alldeps` does not start up Athens or Oympus, but **only** their dependencies.
-
-# Run the Proxy
-
-After you've set up your dependencies, the `buffalo` CLI makes it easy to launch the proxy: 
-
-```console
-cd cmd/proxy
-buffalo dev
-```
-
-After `buffalo dev` starts up, you'll see some console output like:
-
-```console
-Starting application at 127.0.0.1:3000
-```
-
-And you'll be up and running. As you edit and save code, the `buffalo dev` command will notice and automatically re-compile and restart the server. That makes your life a little easier!
 
 # Run unit tests
 


### PR DESCRIPTION
We should mention that you don't need to install Buffalo to run Athens locally. #allYouNeedIsGo

Later this week, I will also add the "all you need is Docker" part. 

Fixes https://github.com/gomods/athens/issues/872