### PR TITLE
extract log entry from context in pkg/download

### DIFF
--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/middleware"
-	"github.com/sirupsen/logrus"
 )
 
 // ProtocolHandler is a function that takes all that it needs to return
@@ -26,12 +25,7 @@ type HandlerOpts struct {
 // This is like a middleware minus the context magic.
 func LogEntryHandler(ph ProtocolHandler, opts *HandlerOpts) buffalo.Handler {
 	return func(c buffalo.Context) error {
-		req := c.Request()
-		ent := opts.Logger.WithFields(logrus.Fields{
-			"http-method": req.Method,
-			"http-path":   req.URL.Path,
-			"http-url":    req.URL.String(),
-		})
+		ent := log.EntryFromContext(c)
 		handler := ph(opts.Protocol, ent, opts.Engine)
 
 		return handler(c)

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -19,10 +19,10 @@ type HandlerOpts struct {
 	Engine   *render.Engine
 }
 
-// LogEntryHandler constructs a log.Entry out of the given
-// *log.Logger so that it applies default fields to every single
-// incoming request without having to do those in every single handler.
-// This is like a middleware minus the context magic.
+// LogEntryHandler pulls a log entry from the buffalo context. Thanks to the
+// LogEntryMiddleware, we should have a log entry stored in the context for each
+// request with request-specific fields. This will grab the entry and pass it to
+// the protocol handlers
 func LogEntryHandler(ph ProtocolHandler, opts *HandlerOpts) buffalo.Handler {
 	return func(c buffalo.Context) error {
 		ent := log.EntryFromContext(c)


### PR DESCRIPTION
**What is the problem I am trying to address?**

Use the log entry stored in the buffalo context via middleware in pkg/download so that we're not creating log entries from the request in multiple places. #844 creates the middleware but the download package is still creating it's own entry for the protocol handlers. This PR updates that logic. 

**How is the fix applied?**

Use the existing `LogEntryHandler` to extract the log entry from the buffalo context and pass it to the protocol handlers.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #809 
