### PR TITLE
Make the weekly meeting more prominent in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Speaking of contributing, read on!
 
 # Contributing
 
+|<img src="docs/static/meeting-icon.svg" alt="Developer Meetings" width="20" height="20" />Developer Meetings|
+|------------------|
+|We hold weekly developer meetings on a Thursday, to join them, watch previous meeting recordings or find more information, please see [the docs](https://docs.gomods.io/contributing/community/developer-meetings/). Absolutely everyone is invited to attend these, suggest topics, and participate!|
+</br>
+
 This project is early and there's plenty of interesting and challenging work to do.
 
 If you find a bug or want to fix a bug, we :heart: PRs and issues! If you see an issue

--- a/docs/static/meeting-icon.svg
+++ b/docs/static/meeting-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"><path d="M34 20H14v4h20v-4zm4-14h-2V2h-4v4H16V2h-4v4h-2c-2.21 0-3.98 1.79-3.98 4L6 38c0 2.21 1.79 4 4 4h28c2.21 0 4-1.79 4-4V10c0-2.21-1.79-4-4-4zm0 32H10V16h28v22zM28 28H14v4h14v-4z"/></svg>


### PR DESCRIPTION
**What is the problem I am trying to address?**

It's not really that clear that we have developer meetings every week. It'd be cool if 
>Info on our weekly dev meetings could be more prominent.

**How is the fix applied?**

Just a simple table with an icon. It's a nice to have.

Suggestions welcomed for placement of said table and any content changes.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #875 

<!-- 
example: Fixes #123
-->
