### PR TITLE
using the proper env var name for the mongo URL

### DIFF
--- a/charts/proxy/templates/deployment.yaml
+++ b/charts/proxy/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: ATHENS_DISK_STORAGE_ROOT
           value: {{ .Values.storage.disk.storageRoot | quote }}
         {{- else if eq .Values.storage.type "mongo"}}
-        - name: ATHENS_MONGO_CONNECTION_STRING
+        - name: ATHENS_MONGO_STORAGE_URL
           value: {{ .Values.storage.mongo.url | quote }}
         {{- end }}
         {{- if .Values.netrc.enabled }}


### PR DESCRIPTION
**What is the problem I am trying to address?**

When you `helm install` the proxy into a Kubernetes cluster, the proxy doesn't start up. That's because the helm chart sets `ATHENS_MONGO_CONNECTION_STRING` but the code looks for `ATHENS_MONGO_STORAGE_URL`. The result is that each proxy pod never starts serving because it tries to connect to a mongoDB server running on localhost.

**How is the fix applied?**

I changed `ATHENS_MONGO_CONNECTION_STRING` to `ATHENS_MONGO_STORAGE_URL` in the helm chart.

@marwan-at-work could we get this into the `v0.2.0` release by chance?