### PR TITLE
WIP: Adding support for Azure App Insights Distributed Tracing

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -125,7 +125,7 @@ HGRCPath = ""
 TraceExporterURL = ""
 
 # TraceExporter is the service to which the data collected by OpenCensus can be exported to.
-# Possible values are: jaeger, datadog, and stackdriver.
+# Possible values are: jaeger, datadog, stackdriver and appinsights.
 # Env overide: ATHENS_TRACE_EXPORTER
 TraceExporter = ""
 

--- a/pkg/observ/observ.go
+++ b/pkg/observ/observ.go
@@ -34,7 +34,7 @@ func RegisterExporter(traceExporter, URL, service, ENV string) (func(), error) {
 	case "stackdriver":
 		return registerStackdriverExporter(URL, ENV)
 	case "appinsights":
-		return registerAppInsightsExporter(URL, ENV)
+		return registerAppInsightsExporter(URL, service, ENV)
 	case "":
 		return nil, errors.E(op, "Exporter not specified. Traces won't be exported")
 	default:
@@ -98,7 +98,7 @@ func registerStackdriverExporter(projectID, ENV string) (func(), error) {
 	return ex.Flush, nil
 }
 
-func registerAppInsightsExporter(svcName, endpoint, ENV string) (func(), error) {
+func registerAppInsightsExporter(endpoint, svcName, ENV string) (func(), error) {
 	const op errors.Op = "registerAppInsightsExporter"
 	ex, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),


### PR DESCRIPTION
**What is the problem I am trying to address?**

>Our distributed tracing setup doesn't support Application Insights, and it looks like we don't use the default exporter either.

**How is the fix applied?**

I'm adding support for the default exported, which also adds support for talking to the app insights local forwarder. Below are links that explain everything:

- [App Insights distributed tracing for Go](https://cda.ms/JT)
- [Open Census docs for App Insights](https://opencensus.io/exporters/supported-exporters/go/applicationinsights/)
- [Dockerfile for the App Insights local forwarder](https://github.com/bketelsen/censusai)

TODOs

- [ ] `go mod vendor` to get the new OpenCensus package

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #895

<!-- 
example: Fixes #123
-->

I am doing some research & prep for #772. Support for App Insights will help us run the part of the global proxy that runs on Azure