### PR TITLE
makefile target for pushing docker image should not call build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ proxy-docker:
 	docker build -t gomods/proxy -f cmd/proxy/Dockerfile .
 
 .PHONY: docker-push
-docker-push: docker
+docker-push:
 	./scripts/push-docker-images.sh
 
 bench:


### PR DESCRIPTION
**What is the problem I am trying to address?**

The current `makefile` target for `docker-push` also calls `docker`, which calls `proxy-docker` which builds the image. This is redundant as the script called in the target for `docker-push` also builds the image with the proper tags and args.

**How is the fix applied?**

Removed the call for the target `docker` from the target `docker-push`.