### PR TITLE
Rename docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docker: proxy-docker
 
 .PHONY: proxy-docker
 proxy-docker:
-	docker build -t gomods/proxy -f cmd/proxy/Dockerfile .
+	docker build -t gomods/athens -f cmd/proxy/Dockerfile .
 
 .PHONY: docker-push
 docker-push:

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: athens-proxy
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.2.0
+appVersion: 0.2.0
 description: The proxy server for Go modules
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 image:
   registry: docker.io
   repository: gomods/athens
-  tag: v0.1.0
+  tag: v0.2.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   registry: docker.io
-  repository: gomods/proxy
+  repository: gomods/athens
   tag: v0.1.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -25,9 +25,9 @@ ingress:
   annotations:
   # Provide an array of values for the ingress host mapping
   hosts:
-  # Provide a base64 encoded cert for TLS use 
-  tls: 
-    
+  # Provide a base64 encoded cert for TLS use
+  tls:
+
 storage:
   type: disk
   disk:

--- a/docs/content/configuration/authentication.md
+++ b/docs/content/configuration/authentication.md
@@ -8,12 +8,12 @@ weight: 1
 
 ## SVN private repositories
 
-1. Subversion creates an authentication structure in 
-        
+1. Subversion creates an authentication structure in
+
         ~/.subversion/auth/svn.simple/<hash>
 
 2. In order to properly create the authentication file for your SVN servers you will need to authenticate to them and let svn build out the proper hashed files.
-	
+
 		$ svn list http://<domain:port>/svn/<somerepo>
 		Authentication realm: <http://<domain> Subversion Repository
 		Username: test
@@ -34,7 +34,7 @@ weight: 1
       --name athens-proxy \
       --restart always \
       -p 3000:3000 \
-      gomods/proxy:latest
+      gomods/athens:latest
     ```
 
     **PowerShell**
@@ -50,7 +50,7 @@ weight: 1
       --name athens-proxy `
       --restart always `
       -p 3000:3000 `
-      gomods/proxy:latest
+      gomods/athens:latest
     ```
 
 ## Bazaar(bzr) private repositories
@@ -58,18 +58,18 @@ weight: 1
 1. Bazaaar config files are located in
 
   - Unix
-       
+
         ~/.bazaar/
   - Windows
-        
+
         C:\Documents and Settings\<username>\Application Data\Bazaar\2.0
 
   - You can check your location using
-  
+
         bzr version
 
 2. There are 3 typical configuration files
-   
+
   - bazaar.conf
     - default config options
   - locations.conf
@@ -83,12 +83,12 @@ weight: 1
   - [header] this denotes a section header
   - section options reside in a header section and contain an option name an equals sign and a value
     - EXAMPLE:
-        
+
           [DEFAULT]
           email = John Doe <jdoe@isp.com>
 
 4. Authentication Configuration
-   
+
      Allows one to specify credentials for remote servers.
      This can be used for all the supported transports and any part of bzr that requires authentication(smtp for example).
      The syntax obeys the same rules as the others except for the option policies which don't apply.
@@ -157,7 +157,7 @@ weight: 1
       --name athens-proxy \
       --restart always \
       -p 3000:3000 \
-      gomods/proxy:latest
+      gomods/athens:latest
     ```
 
     **PowerShell**
@@ -173,6 +173,5 @@ weight: 1
       --name athens-proxy `
       --restart always `
       -p 3000:3000 `
-      gomods/proxy:latest
+      gomods/athens:latest
     ```
-

--- a/docs/content/install/_index.md
+++ b/docs/content/install/_index.md
@@ -17,7 +17,7 @@ We feel that Athens should keep the community federated and open, and nobody sho
 
 To make sure it's easy to install, we try to provide as many ways as possible to install and run Athens:
 
-- It's written in Go, so we provide a self-contained binary. You can configure and run the binary on your machine(s) 
+- It's written in Go, so we provide a self-contained binary. You can configure and run the binary on your machine(s)
     - Instructions on how to run directly from the binary are coming soon
-- We provide a [Docker image](https://hub.docker.com/r/gomods/proxy/) and [instructions on how to run it](./shared-team-instance)
+- We provide a [Docker image](https://hub.docker.com/r/gomods/athens/) and [instructions on how to run it](./shared-team-instance)
 - We provide [Kubernetes](https://kubernetes.io) [Helm Charts](https://helm.sh) with [instructions on how to run Athens on Kubernetes](./install-on-kubernetes)

--- a/docs/content/install/shared-team-instance.md
+++ b/docs/content/install/shared-team-instance.md
@@ -26,7 +26,7 @@ docker run -d -v $ATHENS_STORAGE:/var/lib/athens \
    --name athens-proxy \
    --restart always \
    -p 3000:3000 \
-   gomods/proxy:latest
+   gomods/athens:latest
 ```
 
 **PowerShell**
@@ -39,7 +39,7 @@ docker run -d -v "$($env:ATHENS-STORAGE):/var/lib/athens" `
    --name athens-proxy `
    --restart always `
    -p 3000:3000 `
-   gomods/proxy:latest
+   gomods/athens:latest
 ```
 
 Note: if you have not previously mounted this drive with Docker for Windows, you may be prompted to allow access
@@ -49,7 +49,7 @@ Athens should now be running as a Docker container with the local directory, `at
 ```console
 $ docker ps
 CONTAINER ID        IMAGE                               COMMAND           PORTS                    NAMES
-f0429b81a4f9        gomods/proxy:latest   "/bin/app"        0.0.0.0:3000->3000/tcp   athens-proxy
+f0429b81a4f9        gomods/athens:latest   "/bin/app"        0.0.0.0:3000->3000/tcp   athens-proxy
 ```
 
 Now, we can use Athens from any development machine that has Go 1.11 installed. To verify this, try the following example:
@@ -142,7 +142,7 @@ docker run -d -v $ATHENS_STORAGE:/var/lib/athens \
    --name athens-proxy \
    --restart always \
    -p 3000:3000 \
-   gomods/proxy:latest
+   gomods/athens:latest
 ```
 
 **PowerShell**
@@ -153,7 +153,7 @@ docker run -d -v "$($env:ATHENS-STORAGE):/var/lib/athens" `
    --name athens-proxy `
    --restart always `
    -p 3000:3000 `
-   gomods/proxy:latest
+   gomods/athens:latest
 ```
 
 When we re-run our Go example, the Go cli will again download module from Athens. Athens, however, will not need to retrieve the module. It will be served from the Athens on-disk storage.

--- a/docs/content/walkthrough.md
+++ b/docs/content/walkthrough.md
@@ -101,7 +101,7 @@ docker run -d -v $ATHENS_STORAGE:/var/lib/athens \
    --name athens-proxy \
    --restart always \
    -p 3000:3000 \
-   gomods/proxy:latest
+   gomods/athens:latest
 ```
 
 **PowerShell**
@@ -114,7 +114,7 @@ docker run -d -v "$($env:ATHENS-STORAGE):/var/lib/athens" `
    --name athens-proxy `
    --restart always `
    -p 3000:3000 `
-   gomods/proxy:latest
+   gomods/athens:latest
 ```
 
 Next, you will need to enable the [Go Modules](https://github.com/golang/go/wiki/Modules)

--- a/init.ps1
+++ b/init.ps1
@@ -64,7 +64,7 @@ if ($build.IsPresent) {
 	finally {
 		Pop-Location
 	}
-	
+
 	finally {
 		Pop-Location
 	}
@@ -76,7 +76,7 @@ if ($run.IsPresent) {
 }
 
 if ($docs.IsPresent) {
-	Set-Location docs 
+	Set-Location docs
 	& hugo
 }
 
@@ -121,12 +121,12 @@ if ($test_e2e.IsPresent) {
 }
 
 if ($docker.IsPresent) {
-	& docker build -t gomods/proxy -f cmd/proxy/Dockerfile .
+	& docker build -t gomods/athens -f cmd/proxy/Dockerfile .
 }
 
 
 if ($proxy_docker.IsPresent) {
-	& docker build -t gomods/proxy -f cmd/proxy/Dockerfile .
+	& docker build -t gomods/athens -f cmd/proxy/Dockerfile .
 }
 
 if ($bench.IsPresent) {
@@ -136,4 +136,3 @@ if ($bench.IsPresent) {
 if ($down.IsPresent) {
 	& docker-compose -p athensdev down -v
 }
-

--- a/scripts/push-docker-images.sh
+++ b/scripts/push-docker-images.sh
@@ -18,11 +18,11 @@ else
     BRANCH=${BRANCH:-$(git symbolic-ref -q --short HEAD || echo "")}
 fi
 
-# MUTABLE_TAG is the docker image tag that we will reuse between pushes, it is not a stable tag like a commit hash or tag.
+# MUTABLE_TAG is the docker image tag that we will reuse between pushes, it is not an immutable tag like a commit hash or tag.
 if [[ "${MUTABLE_TAG:-}" == "" ]]; then
     # tagged builds
     if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-        MUTABLE_TAG="stable"
+        MUTABLE_TAG="latest"
     # master build
     elif [[ "$BRANCH" == "master" ]]; then
         MUTABLE_TAG="canary"


### PR DESCRIPTION
**What is the problem I am trying to address?**

We renamed the project to Athens but didn't rename the docker image.

**How is the fix applied?**

* I've manually retagged our docker image from `gomods/proxy` to `gomods/athens` for the release v0.2.0
* I've updated the CI to push using the new tag going forward.
* I've switched from using the stable tag to using latest, to fit our documentation and docker standards.
* I've updated the helm chart to match and also bumped the tag used in the chart with our latest release (v0.2.0).
* I've updated the documentation.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

N/A
