### PR TITLE
Document our docker tags

### DIFF
--- a/docs/content/install/_index.md
+++ b/docs/content/install/_index.md
@@ -13,6 +13,15 @@ We feel that Athens should keep the community federated and open, and nobody sho
 - Anyone can run their own full-featured mirror, public or private
 - Any organization can run their own private mirror, so they can manage their private code just as they would their public code
 
+## Release Scheme
+
+We follow [semver](https://semver.org). Our Docker images are tagged to indicate stability:
+
+* latest = the most recent stable release
+* canary = the most recent build of master
+
+We strongly recommend using a tagged release, e.g. `gomods/athens:v0.2.0`, instead of the latest or canary tags.
+
 ## Where to Go from Here
 
 To make sure it's easy to install, we try to provide as many ways as possible to install and run Athens:

--- a/docs/content/install/shared-team-instance.md
+++ b/docs/content/install/shared-team-instance.md
@@ -16,6 +16,9 @@ Athens currently supports a number of storage drivers. For local use we recommen
 
 In order to run Athens with disk storage, you will next need to identify where you would like to persist modules. In the example below, we will create a new directory named `athens-storage` in our current directory.  Now you are ready to run Athens with disk storage enabled. To enable disk storage, you need to set the `ATHENS_STORAGE_TYPE` and `ATHENS_DISK_STORAGE_ROOT` environment variables when you run the Docker container.
 
+The examples below use the `:latest` Docker tags for simplicity, however we strongly recommend that after your environment is up and running that you switch to using
+an explicit version (for example `:v0.2.0`).
+
 **Bash**
 ```bash
 export ATHENS_STORAGE=~/athens-storage

--- a/docs/content/install/shared-team-instance.md
+++ b/docs/content/install/shared-team-instance.md
@@ -189,5 +189,5 @@ Notice that the timestamps given have not changed.
 
 Next Steps:
 
-* Run the Athens Proxy on Kubernetes with Helm. [Coming Soon]
-* Explore best practices for running Athens in Production. [Coming Soon/Help Wanted](https://github.com/gomods/athens/issues/531)
+* [Run the Athens Proxy on Kubernetes with Helm](/install/install-on-kubernetes)
+* Explore best practices for running Athens in Production. [Coming Soon](https://github.com/gomods/athens/issues/531)


### PR DESCRIPTION
**What is the problem I am trying to address?**

Prevent confusion over which docker tags to use

**How is the fix applied?**

* I've documented the tags on our Install page
* Warned people to pick a specific version
* Updated our docker hub page to alert that [gomods/proxy is deprecated](https://hub.docker.com/r/gomods/proxy/), and again [explain the tags](https://hub.docker.com/r/gomods/athens/).

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

YOLO