### PR TITLE
use minio docker img on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ env:
 before_script:
   - mkdir -p $ATHENS_DIR && rsync -azr . $ATHENS_DIR && cd $ATHENS_DIR
   - make setup-dev-env
-  - wget "https://dl.minio.io/server/minio/release/linux-amd64/minio"
-  # moving from the default port 9000 so it doesn't conflich with other services (i.e. vscode extensions server)
-  # we also need to change it in travis because the tests are using the config.dev.toml where port 9001 is used
-  - chmod +x minio && nohup ./minio server --address ":9001" . &
 
 script:
   - make verify test-unit test-e2e docker

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ alldeps:
 .PHONY: dev
 dev:
 	docker-compose -p athensdev up -d mongo
+	docker-compose -p athensdev up -d minio
 
 .PHONY: down
 down:

--- a/pkg/storage/gcp/gcp_test.go
+++ b/pkg/storage/gcp/gcp_test.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"bytes"
 	"context"
-
 	"io/ioutil"
 	"testing"
 	"time"


### PR DESCRIPTION
**What is the problem I am trying to address?**

In our CI we download and run the minio binary which takes time + we have to keep it in sync with docker-compose file

**How is the fix applied?**

Use docker-compose instead

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

No issue for that.
