### PR TITLE
Adds Github ribbon link to docs

### DIFF
--- a/docs/themes/hugo-theme-learn/layouts/partials/custom-footer.html
+++ b/docs/themes/hugo-theme-learn/layouts/partials/custom-footer.html
@@ -3,3 +3,6 @@
     console.log("running some javascript");
 </script>
 -->
+<a href="https://github.com/gomods/athens">
+  <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub">
+</a>


### PR DESCRIPTION
**What is the problem I am trying to address?**

Add better links from the docs back to the Github repo.

**How is the fix applied?**

Edited the docs template to include the ribbon

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Possible fix for #804 
