### PR TITLE
skip test for chmod on windows

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -306,6 +307,7 @@ func invalidPerm() os.FileMode {
 
 func correctPerm() os.FileMode {
 	if runtime.GOOS == "windows" {
+		fmt.Println("select windows runtime")
 		return 0600
 	}
 	return 0640
@@ -323,15 +325,16 @@ func Test_checkFilePerms(t *testing.T) {
 	stat, lstatErr := os.Lstat(f1.Name())
 	t.Logf("f1 stat: %d, err %s", stat.Mode(), lstatErr)
 
-	stat, lstatErr = os.Lstat(f2.Name())
-	t.Logf("f2 stat: %d, err %s", stat.Mode(), lstatErr)
-
 	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")
 	if err != nil {
 		t.FailNow()
 	}
+
 	defer os.Remove(f2.Name())
 	err = os.Chmod(f2.Name(), correctPerm())
+
+	stat, lstatErr = os.Lstat(f2.Name())
+	t.Logf("f2 stat: %d, err %s", stat.Mode(), lstatErr)
 
 	type args struct {
 		files []string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -319,9 +319,12 @@ func Test_checkFilePerms(t *testing.T) {
 	defer os.Remove(f1.Name())
 	err = os.Chmod(f1.Name(), invalidPerm())
 
-	t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
+	// t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
 	stat, lstatErr := os.Lstat(f1.Name())
-	t.Logf("stat: %s, err %s", stat, lstatErr)
+	t.Logf("f1 stat: %d, err %s", stat.Mode(), lstatErr)
+
+	stat, lstatErr := os.Lstat(f2.Name())
+	t.Logf("f2 stat: %d, err %s", stat.Mode(), lstatErr)
 
 	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -320,6 +320,9 @@ func Test_checkFilePerms(t *testing.T) {
 	}
 	defer os.Remove(f1.Name())
 	err = os.Chmod(f1.Name(), invalidPerm())
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
 
 	// t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
 	stat, _ := os.Lstat(f1.Name())
@@ -332,6 +335,9 @@ func Test_checkFilePerms(t *testing.T) {
 
 	defer os.Remove(f2.Name())
 	err = os.Chmod(f2.Name(), correctPerm())
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
 
 	stat, _ = os.Lstat(f2.Name())
 	t.Logf("f2 stat: %d, err %s", stat.Mode(), stat.Mode())

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -326,7 +326,7 @@ func Test_checkFilePerms(t *testing.T) {
 
 	// t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
 	stat, _ := os.Lstat(f1.Name())
-	t.Logf("f1 stat: %d, err %s", stat.Mode(), stat.Mode())
+	t.Logf("f1 (%s) stat: %d, err %s", f1.Name(), stat.Mode(), stat.Mode())
 
 	f2, err := ioutil.TempFile(".", "prefix-")
 	if err != nil {
@@ -340,7 +340,7 @@ func Test_checkFilePerms(t *testing.T) {
 	}
 
 	stat, _ = os.Lstat(f2.Name())
-	t.Logf("f2 stat: %d, err %s", stat.Mode(), stat.Mode())
+	t.Logf("f2 (%s) stat: %d, err %s", f2.Name(), stat.Mode(), stat.Mode())
 
 	type args struct {
 		files []string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -314,7 +314,7 @@ func correctPerm() os.FileMode {
 }
 
 func Test_checkFilePerms(t *testing.T) {
-	f1, err := ioutil.TempFile(os.TempDir(), "prefix-")
+	f1, err := ioutil.TempFile(".", "prefix-")
 	if err != nil {
 		t.FailNow()
 	}
@@ -328,7 +328,7 @@ func Test_checkFilePerms(t *testing.T) {
 	stat, _ := os.Lstat(f1.Name())
 	t.Logf("f1 stat: %d, err %s", stat.Mode(), stat.Mode())
 
-	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")
+	f2, err := ioutil.TempFile(".", "prefix-")
 	if err != nil {
 		t.FailNow()
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -322,7 +322,7 @@ func Test_checkFilePerms(t *testing.T) {
 	err = os.Chmod(f1.Name(), invalidPerm())
 
 	// t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
-	stat, lstatErr := os.Lstat(f1.Name())
+	stat, _ := os.Lstat(f1.Name())
 	t.Logf("f1 stat: %d, err %s", stat.Mode(), stat.Mode())
 
 	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")
@@ -333,7 +333,7 @@ func Test_checkFilePerms(t *testing.T) {
 	defer os.Remove(f2.Name())
 	err = os.Chmod(f2.Name(), correctPerm())
 
-	stat, lstatErr = os.Lstat(f2.Name())
+	stat, _ = os.Lstat(f2.Name())
 	t.Logf("f2 stat: %d, err %s", stat.Mode(), stat.Mode())
 
 	type args struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -323,7 +323,7 @@ func Test_checkFilePerms(t *testing.T) {
 	stat, lstatErr := os.Lstat(f1.Name())
 	t.Logf("f1 stat: %d, err %s", stat.Mode(), lstatErr)
 
-	stat, lstatErr := os.Lstat(f2.Name())
+	stat, lstatErr = os.Lstat(f2.Name())
 	t.Logf("f2 stat: %d, err %s", stat.Mode(), lstatErr)
 
 	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -298,29 +297,18 @@ func restoreEnv(envVars map[string]string) {
 	}
 }
 
-func invalidPerm() os.FileMode {
-	if runtime.GOOS == "windows" {
-		fmt.Println("select windows runtime on invalid Perm")
-		return 0200
-	}
-	return 0777
-}
-
-func correctPerm() os.FileMode {
-	if runtime.GOOS == "windows" {
-		fmt.Println("select windows runtime on Valid Perm")
-		return 0600
-	}
-	return 0640
-}
-
 func Test_checkFilePerms(t *testing.T) {
+
+	if runtime.GOOS == "windows" {
+		t.Skipf("Chmod is not supported in windows, so not possible to test. Ref: https://github.com/golang/go/blob/master/src/os/os_test.go#L1031\n")
+	}
+
 	f1, err := ioutil.TempFile(".", "prefix-")
 	if err != nil {
 		t.FailNow()
 	}
 	defer os.Remove(f1.Name())
-	err = os.Chmod(f1.Name(), invalidPerm())
+	err = os.Chmod(f1.Name(), 0700)
 	if err != nil {
 		t.Fatalf("%s\n", err)
 	}
@@ -335,7 +323,7 @@ func Test_checkFilePerms(t *testing.T) {
 	}
 
 	defer os.Remove(f2.Name())
-	err = os.Chmod(f2.Name(), correctPerm())
+	err = os.Chmod(f2.Name(), 0640)
 	if err != nil {
 		t.Fatalf("%s\n", err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -300,6 +300,7 @@ func restoreEnv(envVars map[string]string) {
 
 func invalidPerm() os.FileMode {
 	if runtime.GOOS == "windows" {
+		fmt.Println("select windows runtime on invalid Perm")
 		return 0200
 	}
 	return 0777
@@ -307,7 +308,7 @@ func invalidPerm() os.FileMode {
 
 func correctPerm() os.FileMode {
 	if runtime.GOOS == "windows" {
-		fmt.Println("select windows runtime")
+		fmt.Println("select windows runtime on Valid Perm")
 		return 0600
 	}
 	return 0640

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -319,6 +319,10 @@ func Test_checkFilePerms(t *testing.T) {
 	defer os.Remove(f1.Name())
 	err = os.Chmod(f1.Name(), invalidPerm())
 
+	t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
+	stat, lstatErr := os.Lstat(f1.Name())
+	t.Logf("stat: %s, err %s", stat, lstatErr)
+
 	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")
 	if err != nil {
 		t.FailNow()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -323,7 +323,7 @@ func Test_checkFilePerms(t *testing.T) {
 
 	// t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
 	stat, lstatErr := os.Lstat(f1.Name())
-	t.Logf("f1 stat: %d, err %s", stat.Mode(), lstatErr)
+	t.Logf("f1 stat: %d, err %s", stat.Mode(), stat.Mode())
 
 	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")
 	if err != nil {
@@ -334,7 +334,7 @@ func Test_checkFilePerms(t *testing.T) {
 	err = os.Chmod(f2.Name(), correctPerm())
 
 	stat, lstatErr = os.Lstat(f2.Name())
-	t.Logf("f2 stat: %d, err %s", stat.Mode(), lstatErr)
+	t.Logf("f2 stat: %d, err %s", stat.Mode(), stat.Mode())
 
 	type args struct {
 		files []string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -303,7 +303,7 @@ func Test_checkFilePerms(t *testing.T) {
 		t.Skipf("Chmod is not supported in windows, so not possible to test. Ref: https://github.com/golang/go/blob/master/src/os/os_test.go#L1031\n")
 	}
 
-	f1, err := ioutil.TempFile(".", "prefix-")
+	f1, err := ioutil.TempFile(os.TempDir(), "prefix-")
 	if err != nil {
 		t.FailNow()
 	}
@@ -313,11 +313,7 @@ func Test_checkFilePerms(t *testing.T) {
 		t.Fatalf("%s\n", err)
 	}
 
-	// t.Logf("for windows invalidPerm for f1 is %s is %d and error is %s\n", f1.Name(), invalidPerm(), err)
-	stat, _ := os.Lstat(f1.Name())
-	t.Logf("f1 (%s) stat: %d, err %s", f1.Name(), stat.Mode(), stat.Mode())
-
-	f2, err := ioutil.TempFile(".", "prefix-")
+	f2, err := ioutil.TempFile(os.TempDir(), "prefix-")
 	if err != nil {
 		t.FailNow()
 	}
@@ -327,9 +323,6 @@ func Test_checkFilePerms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s\n", err)
 	}
-
-	stat, _ = os.Lstat(f2.Name())
-	t.Logf("f2 (%s) stat: %d, err %s", f2.Name(), stat.Mode(), stat.Mode())
 
 	type args struct {
 		files []string


### PR DESCRIPTION
os.Chmod on windows is not supported which led to CI failure. Ref: https://github.com/golang/go/blob/master/src/os/os_test.go#L1031

Skip test for windows as done by the go source code as well so that CI does not fail