### PR TITLE
changing the zoom link to a shortlink

### DIFF
--- a/docs/content/contributing/community/developer-meetings.md
+++ b/docs/content/contributing/community/developer-meetings.md
@@ -11,7 +11,7 @@ Absolutely everyone is invited to attend, suggest topics for the agenda, and par
 
 ### Meeting Details
 
-They're every Thursday at 11am to 12pm US Pacific Time and you can join the meeting here by following this link: https://zoom.us/j/193797787
+They're every Thursday at 11am to 12pm US Pacific Time and you can join the meeting here by following this link: [https://aka.ms/athensdevzoom](https://aka.ms/athensdevzoom)
 
 ### Agenda
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

The zoom URL has changed a few times and when it does, we have to update it on the docs site (and also on the [Athens agenda doc](https://docs.google.com/document/d/1xpvgmR1Fq4iy1j975Tb4H_XjeXUQUOAvn0FximUzvIk/edit#))

**How is the fix applied?**

I've created a [short link](https://aka.ms/athensdevzoom) and put it into the docs. Then, if the zoom link changes we can update the short link in one place.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**


<!-- 
example: Fixes #123
-->
