### PR TITLE
Maint resources

### DIFF
--- a/MAINTAINER_RESOURCES.md
+++ b/MAINTAINER_RESOURCES.md
@@ -1,0 +1,13 @@
+# Resources for Maintainers
+
+This document has resources that contributors and maintainers need access to. When we [add a new maintainer](https://docs.gomods.io/contributing/community/participating/), we should make sure they are added to this list and make sure they have access to everything here.
+
+| Maintainer | GitHub [Maintainers Team](https://github.com/orgs/gomods/teams/maintainers) | GitHub [Contributors Team](https://github.com/orgs/gomods/teams/contributors) | [github.com/athens-artifacts](https://github.com/athens-artifacts) | Netlify | YouTube Channel | Twitter Account | DockerHub | Azure Pipelines | Google Groups | Maintainers Slack |
+| - | - | - | - | - | - | - | - | - | - | - |
+| [carolynvs](https://github.com/carolynvs) | X | X |
+| [arschles](https://github.com/arschles) | X | X |
+| [manugupt1](https://github.com/manugupt1) | X | X |
+| [marpio](https://github.com/marpio) | X | X |
+| [marwan-at-work](https://github.com/marwan-at-work) | X | X |
+| [michalpristas](https://github.com/michalpristas) | X | X |
+| [robjloranger](https://github.com/robjloranger) | X | X |

--- a/MAINTAINER_RESOURCES.md
+++ b/MAINTAINER_RESOURCES.md
@@ -2,7 +2,7 @@
 
 This document has resources that contributors and maintainers need access to. When we [add a new maintainer](https://docs.gomods.io/contributing/community/participating/), we should make sure they are added to this list and make sure they have access to everything here.
 
-| Maintainer | GitHub [Maintainers Team](https://github.com/orgs/gomods/teams/maintainers) | GitHub [Contributors Team](https://github.com/orgs/gomods/teams/contributors) | [github.com/athens-artifacts](https://github.com/athens-artifacts) | Netlify | YouTube Channel | Twitter Account | DockerHub | Azure Pipelines | Google Groups | Maintainers Slack |
+| Maintainer | GitHub [Maintainers Team](https://github.com/orgs/gomods/teams/maintainers) | GitHub [Contributors Team](https://github.com/orgs/gomods/teams/contributors) | Github [athens-artifacts](https://github.com/athens-artifacts) Organization | Netlify | YouTube Channel | Twitter Account | DockerHub | Azure Pipelines | Google Groups | Maintainers Slack |
 | - | - | - | - | - | - | - | - | - | - | - |
 | [carolynvs](https://github.com/carolynvs) | X | X |
 | [arschles](https://github.com/arschles) | X | X |


### PR DESCRIPTION
**What is the problem I am trying to address?**

The maintainers group has been working to keep track of all the resources our community uses (i.e. Zoom for dev meetings, YouTube for weekly dev meeting recordings, Medium blog, and so on)

**How is the fix applied?**

I've created a markdown file with a table in it to keep track of all of our resources and the maintainers with access to each resource.

We'll first use this table to make sure each maintainer has access to everything.

Then, when we add new maintainers, we'll update the table and use it to ensure that the new person has access to everything they need.

Finally, if we add/remove a resource that the community uses, we'll edit the table as appropriate 😄 

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

<!-- 
example: Fixes #123
-->
