### PR TITLE
Add test when go mod download fails

### DIFF
--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -330,7 +330,7 @@ func TestDownloadProtocolWhenFetchFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mp := &NotFoundFetcher{}
+	mp := &notFoundFetcher{}
 	st := stash.New(mp, s)
 	dp := New(&Opts{s, st, nil})
 	ctx := context.Background()
@@ -340,9 +340,9 @@ func TestDownloadProtocolWhenFetchFails(t *testing.T) {
 	}
 }
 
-type NotFoundFetcher struct{}
+type notFoundFetcher struct{}
 
-func (m *NotFoundFetcher) Fetch(ctx context.Context, mod, ver string) (*storage.Version, error) {
+func (m *notFoundFetcher) Fetch(ctx context.Context, mod, ver string) (*storage.Version, error) {
 	const op errors.Op = "goGetFetcher.Fetch"
 	return nil, errors.E(op, "Fetcher error")
 }


### PR DESCRIPTION
**What is the problem I am trying to address?**

One of the core strengths of proxy is that when the download protocol fails, the storage should be immutable

**How is the fix applied?**

This adds a test to show that it is indeed immutable.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #946 

<!-- 
example: Fixes #123
-->
