### PR TITLE
Add note that : should be prefixed for port

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -62,6 +62,7 @@ StorageType = "memory"
 
 # Port sets the port the proxy listens on
 # Env override: PORT
+# Note that PORT needs to be prefixed by :
 Port = ":3000"
 
 # The endpoint for a package registry in case of a proxy cache miss


### PR DESCRIPTION
**What is the problem I am trying to address?**

A question was asked about how to prefixing : in the PORT

**How is the fix applied?**

Make it clearer by adding docs for the users

