### PR TITLE
File permissions on config files allow more restrictive setting

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,7 +147,7 @@ func checkFilePerms(files ...string) error {
 			}
 		} else {
 			// Assume unix based system (MacOS and Linux)
-			if fInfo.Mode() != 0640 {
+			if fInfo.Mode()&0137 != 0 {
 				return errors.E(op, f+" should have 0640 as permission")
 			}
 		}


### PR DESCRIPTION
**What is the problem I am trying to address?**

If you 0640 is allowed, then 0600 should be allowed as it is more restrictive.

**How is the fix applied?**

Apply a mask as suggested in #965 

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #965 

<!-- 
example: Fixes #123
-->
