### PR TITLE
Fix typo in protocol.md #978

### DIFF
--- a/docs/content/intro/protocol.md
+++ b/docs/content/intro/protocol.md
@@ -10,7 +10,7 @@ The original vgo research paper on Download protocol can be found here: https://
 
 Each of these endpoints sits on top of a module. Let's assume module `htp` authored by `acidburn`.
 
-So for each of endpoints mentioned bellow we will assume address `acidburn/htp/@v/{endpoint}` (e.g `acidburn/htp/@v/list`)
+So for each of endpoints mentioned below we will assume address `acidburn/htp/@v/{endpoint}` (e.g `acidburn/htp/@v/list`)
 
 In the examples below, `$HOST` and `$PORT` are placeholders for the host and port of your Athens server.
 


### PR DESCRIPTION
**What is the problem I am trying to 

#978 

**How is the fix applied?**

find typo words `bellow`
```
$ grep -rin bellow .
```
and
convert  with checking : `:%s/bellow/below/gc` in vim

Mention briefly how you have applied the fix.

Fixes #978 
