### PR TITLE
fixing typo in protocol docs

### DIFF
--- a/docs/content/intro/protocol.md
+++ b/docs/content/intro/protocol.md
@@ -10,7 +10,7 @@ The original vgo research paper on Download protocol can be found here: https://
 
 Each of these endpoints sits on top of a module. Let's assume module `htp` authored by `acidburn`.
 
-So for each of endpoints mentioned below we will assume address `acidburn/htp/@v/{endpoint}` (e.g `acidburn/htp/@v/list`)
+So for each of the endpoints mentioned below we will assume address `acidburn/htp/@v/{endpoint}` (e.g `acidburn/htp/@v/list`)
 
 In the examples below, `$HOST` and `$PORT` are placeholders for the host and port of your Athens server.
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

We were missing a `the` in the protocol docs

**How is the fix applied?**

I added one 😄 

This is a follow-up from #987 

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

<!-- 
example: Fixes #123
-->
