### PR TITLE
Add missing link to storage configuration docs

### DIFF
--- a/docs/content/install/shared-team-instance.md
+++ b/docs/content/install/shared-team-instance.md
@@ -10,7 +10,7 @@ We will use Docker to run the Athens proxy, so first make sure you have Docker [
 
 ## Selecting a Storage Provider
 
-Athens currently supports a number of storage drivers. For local use we recommend starting with the local disk provider. For other providers, please see the Storage Provider documentation [Coming Soon].
+Athens currently supports a number of storage drivers. For local use we recommend starting with the local disk provider. For other providers, please see [the Storage Provider documentation](/configuration/storage).
 
 ## Running Athens with Local Disk Storage
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

The docs for setting up a shared team instance doesn't point to the configuration page for the various storage providers. I might be wrong, but this looks like a TODO that has already been TODONE, it's just this link that's missing. Feel free to close the PR if these are not the docs it should point to.

**How is the fix applied?**

Adds a link to the storage configuration page.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Couldn't find an open issue for this. Apologies for not creating an issue; hopefully the change is pretty straight forward.