### PR TITLE
Revert TraceExporter Default

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -131,7 +131,7 @@ HGRCPath = ""
 # TraceExporter is the service to which the data collected by OpenCensus can be exported to.
 # Possible values are: jaeger, datadog, and stackdriver.
 # Env overide: ATHENS_TRACE_EXPORTER
-TraceExporter = "jaeger"
+TraceExporter = ""
 
 # TraceExporterURL is the URL to which Athens populates distributed tracing
 # information such as Jaeger. In Stackdriver, use this as the GCP ProjectID.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -221,7 +221,6 @@ func TestParseExampleConfig(t *testing.T) {
 		BasicAuthPass:    "",
 		Storage:          expStorage,
 		TraceExporterURL: "http://localhost:14268",
-		TraceExporter:    "jaeger",
 		StatsExporter:    "prometheus",
 	}
 


### PR DESCRIPTION
Returned TraceExporter to be an empty string because when you have "jaeger" and Jaeger is not set up, we keep getting the following logs which is not good: 

`2018/12/21 17:28:23 Error when uploading spans to Jaeger: Post http://localhost:14268/api/traces?format=jaeger.thrift: dial tcp [::1]:14268: connect: connection refused`