### PR TITLE
only check config perms in production

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,8 +90,10 @@ func ParseConfigFile(configFile string) (*Config, error) {
 	}
 
 	// Check file perms from config
-	if err := checkFilePerms(configFile, config.FilterFile); err != nil {
-		return nil, err
+	if config.GoEnv == "production" {
+		if err := checkFilePerms(configFile, config.FilterFile); err != nil {
+			return nil, err
+		}
 	}
 
 	// override values with environment variables if specified


### PR DESCRIPTION
@manugupt1 mentioned we can do this via git, but for now I'd love us to merge this because it's really annoying for the Developer Experience, especially if they're playing with Athens for the first time. 