### PR TITLE
CI/CD: replace buffalo build with go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION = "unset"
 DATE=$(shell date -u +%Y-%m-%d-%H:%M:%S-%Z)
 .PHONY: build
 build:
-	cd cmd/proxy && buffalo build
+	cd cmd/proxy && go build
 
 build-ver:
 	GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -ldflags "-X github.com/gomods/athens/pkg/build.version=$(VERSION) -X github.com/gomods/athens/pkg/build.buildDate=$(DATE)" -o athens ./cmd/proxy

--- a/init.ps1
+++ b/init.ps1
@@ -59,7 +59,7 @@ if ($setup_dev_env.IsPresent) {
 if ($build.IsPresent) {
 	try {
 		Push-Location $(Join-Path cmd proxy)
-		& buffalo build
+		& go build
 	}
 	finally {
 		Pop-Location


### PR DESCRIPTION
Replace `buffalo build` with `go build` since we don't have any assets to bundle 