### PR TITLE
cmd/proxy: print port at server start

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -64,6 +64,7 @@ func main() {
 		close(idleConnsClosed)
 	}()
 
+	log.Printf("Starting application at port %v", conf.Port)
 	if cert != "" && key != "" {
 		err = srv.ListenAndServeTLS(conf.TLSCertFile, conf.TLSKeyFile)
 	} else {


### PR DESCRIPTION
Print a start up log that mentions the port Athens is running on. 