### PR TITLE
pkg/download/addons: fix test error msg in TestPoolLogic.

### DIFF
--- a/pkg/download/addons/with_pool_test.go
+++ b/pkg/download/addons/with_pool_test.go
@@ -20,15 +20,16 @@ import (
 // at one time.
 func TestPoolLogic(t *testing.T) {
 	m := &mockPool{}
-	dp := WithPool(5)(m)
+	workers := 5
+	dp := WithPool(workers)(m)
 	ctx := context.Background()
 	m.ch = make(chan struct{})
 	for i := 0; i < 10; i++ {
 		go dp.List(ctx, "")
 	}
 	<-m.ch
-	if m.num != 5 {
-		t.Fatalf("expected 4 workers but got %v", m.num)
+	if m.num != workers {
+		t.Fatalf("expected %d workers but got %v", workers, m.num)
 	}
 }
 


### PR DESCRIPTION
Wrong number printed in error message in with_pool_test.go.
Fixes the problem by introducing a new variable.