### PR TITLE
basicauth: log warning on healthz

### DIFF
--- a/cmd/proxy/actions/basicauth.go
+++ b/cmd/proxy/actions/basicauth.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"crypto/subtle"
 	"net/http"
+	"strings"
 
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gorilla/mux"
@@ -18,7 +19,7 @@ func basicAuth(user, pass string) mux.MiddlewareFunc {
 				// if they forget to send auth headers
 				// kubernetes silently fails, so a log
 				// might help them.
-				if r.URL.Path == "/healthz" {
+				if strings.HasSuffix(r.URL.Path, "/healthz") {
 					lggr := log.EntryFromContext(r.Context())
 					lggr.Warnf(healthWarning)
 				}

--- a/cmd/proxy/actions/basicauth.go
+++ b/cmd/proxy/actions/basicauth.go
@@ -4,13 +4,24 @@ import (
 	"crypto/subtle"
 	"net/http"
 
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gorilla/mux"
 )
+
+const healthWarning = "/healthz received none or incorrect Basic-Auth headers"
 
 func basicAuth(user, pass string) mux.MiddlewareFunc {
 	return func(h http.Handler) http.Handler {
 		f := func(w http.ResponseWriter, r *http.Request) {
 			if !checkAuth(r, user, pass) {
+				// Helpful hint for Kubernetes users:
+				// if they forget to send auth headers
+				// kubernetes silently fails, so a log
+				// might help them.
+				if r.URL.Path == "/healthz" {
+					lggr := log.EntryFromContext(r.Context())
+					lggr.Warnf(healthWarning)
+				}
 				w.Header().Set("WWW-Authenticate", `Basic realm="basic auth required"`)
 				w.WriteHeader(http.StatusUnauthorized)
 				return


### PR DESCRIPTION
Kubernetes users have easily missed to pass auth headers to their livenessProbe and readinessProbe, and K8s doesn't really say much. We should log a warning if the user passes does not pass correct authentication to our /healthz endpoint to help such users figure out what is wrong. 