### PR TITLE
Use ambient aws credential provider for s3

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -219,6 +219,16 @@ StatsExporter = "prometheus"
         # S3 Bucket to use for storage
         # Env override: ATHENS_S3_BUCKET_NAME
         Bucket = "MY_S3_BUCKET_NAME"
+
+        # If true then the default aws configuration will be used. This will
+        # attempt to find credentials in the environment, in the shared
+        # configuration (~/.aws/credentials) and from ec2 instance role
+        # credentials. See
+        # https://godoc.org/github.com/aws/aws-sdk-go#hdr-Configuring_Credentials
+        # and
+        # https://godoc.org/github.com/aws/aws-sdk-go/aws/session#hdr-Environment_Variables
+        # for environment variables that will affect the aws configuration.
+        UseDefaultConfiguration = false
    [Storage.AzureBlob]
         # Storage Account name for Azure Blob
         # Env override: ATHENS_AZURE_ACCOUNT_NAME

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -2,10 +2,10 @@ package config
 
 // S3Config specifies the properties required to use S3 as the storage backend
 type S3Config struct {
-	Region                string `validate:"required" envconfig:"AWS_REGION"`
-	Key                   string `envconfig:"AWS_ACCESS_KEY_ID"`
-	Secret                string `envconfig:"AWS_SECRET_ACCESS_KEY"`
-	Token                 string `envconfig:"AWS_SESSION_TOKEN"`
-	Bucket                string `validate:"required" envconfig:"ATHENS_S3_BUCKET_NAME"`
-	UseAmbientCredentials bool   `envconfig:"AWS_USE_AMBIENT_CREDENTIALS"`
+	Region                  string `validate:"required" envconfig:"AWS_REGION"`
+	Key                     string `envconfig:"AWS_ACCESS_KEY_ID"`
+	Secret                  string `envconfig:"AWS_SECRET_ACCESS_KEY"`
+	Token                   string `envconfig:"AWS_SESSION_TOKEN"`
+	Bucket                  string `validate:"required" envconfig:"ATHENS_S3_BUCKET_NAME"`
+	UseDefaultConfiguration bool   `envconfig:"AWS_USE_DEFAULT_CONFIGURATION"`
 }

--- a/pkg/config/s3.go
+++ b/pkg/config/s3.go
@@ -2,9 +2,10 @@ package config
 
 // S3Config specifies the properties required to use S3 as the storage backend
 type S3Config struct {
-	Region string `validate:"required" envconfig:"AWS_REGION"`
-	Key    string `envconfig:"AWS_ACCESS_KEY_ID"`
-	Secret string `envconfig:"AWS_SECRET_ACCESS_KEY"`
-	Token  string `envconfig:"AWS_SESSION_TOKEN"`
-	Bucket string `validate:"required" envconfig:"ATHENS_S3_BUCKET_NAME"`
+	Region                string `validate:"required" envconfig:"AWS_REGION"`
+	Key                   string `envconfig:"AWS_ACCESS_KEY_ID"`
+	Secret                string `envconfig:"AWS_SECRET_ACCESS_KEY"`
+	Token                 string `envconfig:"AWS_SESSION_TOKEN"`
+	Bucket                string `validate:"required" envconfig:"ATHENS_S3_BUCKET_NAME"`
+	UseAmbientCredentials bool   `envconfig:"AWS_USE_AMBIENT_CREDENTIALS"`
 }

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -66,10 +66,18 @@ func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Co
 	}, nil
 }
 
-// buildAWSCredentials builds the credentials required to create a new AWS session.  It will prefer the access key ID and
-// secret access key if specified in the S3Config.  Otherwise it will look for credentials in the filesystem.
+// buildAWSCredentials builds the credentials required to create a new AWS
+// session.  It will prefer the access key ID and secret access key if specified
+// in the S3Config unless UseDefaultConfiguration is true. If the key ID and
+// secret access key are unspecified or UseDefaultConfiguration is true, then
+// the default aws configuration will be used. This will attempt to find
+// credentials in the environment, in the shared configuration
+// (~/.aws/credentials) and from ec2 instance role credentials. See
+// https://godoc.org/github.com/aws/aws-sdk-go#hdr-Configuring_Credentials and
+// https://godoc.org/github.com/aws/aws-sdk-go/aws/session#hdr-Environment_Variables
+// for environment variables that will affect the aws configuration.
 func buildAWSCredentials(s3Conf *config.S3Config) *credentials.Credentials {
-	if !s3Conf.UseAmbientCredentials && s3Conf.Key != "" && s3Conf.Secret != "" {
+	if !s3Conf.UseDefaultConfiguration && s3Conf.Key != "" && s3Conf.Secret != "" {
 		return credentials.NewStaticCredentials(s3Conf.Key, s3Conf.Secret, s3Conf.Token)
 	}
 

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -3,8 +3,6 @@ package s3
 import (
 	"fmt"
 	"net/url"
-	"os/user"
-	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -41,10 +39,7 @@ func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Co
 		return nil, errors.E(op, err)
 	}
 
-	creds, err := buildAWSCredentials(s3Conf)
-	if err != nil {
-		return nil, errors.E(op, "unable to build AWS credentials")
-	}
+	creds := buildAWSCredentials(s3Conf)
 
 	awsConfig := &aws.Config{
 		Credentials: creds,
@@ -73,18 +68,10 @@ func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Co
 
 // buildAWSCredentials builds the credentials required to create a new AWS session.  It will prefer the access key ID and
 // secret access key if specified in the S3Config.  Otherwise it will look for credentials in the filesystem.
-func buildAWSCredentials(s3Conf *config.S3Config) (*credentials.Credentials, error) {
-	if s3Conf.Key != "" && s3Conf.Secret != "" {
-		return credentials.NewStaticCredentials(s3Conf.Key, s3Conf.Secret, s3Conf.Token), nil
+func buildAWSCredentials(s3Conf *config.S3Config) *credentials.Credentials {
+	if !s3Conf.UseAmbientCredentials && s3Conf.Key != "" && s3Conf.Secret != "" {
+		return credentials.NewStaticCredentials(s3Conf.Key, s3Conf.Secret, s3Conf.Token)
 	}
 
-	u, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-
-	filename := filepath.Join(u.HomeDir, ".aws", "credentials")
-	sc := credentials.NewSharedCredentials(filename, "default")
-
-	return sc, nil
+	return nil
 }


### PR DESCRIPTION
**What is the problem I am trying to address?**

Athens does not pick up aws "ambient" role credentials when run in ec2, ecs or fargate containers.

**How is the fix applied?**

A new variable `UseAmbientCredentials` (or `$AWS_USE_AMBIENT_CREDENTIALS`) is added. If `false`, and `Key` and `Secret` are defined then the aws config is built as it was previously. If `true` then just a default `aws.Config` is used with Region provided. This will use ec2/ecs credentials (in addition to using the `~/.aws/credentials` that were previously used).

The reason the new variable is required is because ec2/ecs systems will also define `$AWS_ACCESS_KEY_ID` and `$AWS_SECRET_ACCESS_KEY`.