### PR TITLE
Version filtering

### DIFF
--- a/docs/content/configuration/filter.md
+++ b/docs/content/configuration/filter.md
@@ -36,7 +36,7 @@ It allows for `#` to add comments and new lines are skipped. Anything else would
 D golang.org/x/tools
 </pre>
 
-In the above example, `golang.org/x/tools` is fetched directly from the upstream proxy. All the modules from from `github.com/azure` are excluded except `github.com/azure/azure-sdk-for-go`
+In the above example, `golang.org/x/tools` is fetched directly from the upstream proxy. All the modules from `github.com/azure` are excluded except `github.com/azure/azure-sdk-for-go`
 
 ### Adding a default mode 
 
@@ -51,3 +51,20 @@ D
 </pre>
 
 In the above example, all the modules are fetched directly from the source. `github.com/manugupt1/athens` is excluded and `github.com/gomods/athens` is stored in the proxy storage.
+
+### Adding versions to the filter
+
+Using an "approved list" is a common practice that requires each minor or patch version to be approved before it is allowed in the codebase.  This is accomplished by adding a list of version patterns to the rule.  These version patterns are comma-separated and prefix-matching, so `v2` and `v2.3.*` both match the requested version `2.3.5`.
+
+An example version filter is 
+
+<pre>
+-
+# use internal github enterprise server directly
+D enterprise.github.com/company
+
+# external dependency approved list
++ github.com/gomods/athens v0.1,v0.2,v0.4.1
+</pre>
+
+In the above example, any module not in the rules will be excluded.  All modules from `enterprise.github.com/company` are fetched directly from the source.  The `github.com/gomods/athens` module will be stored in the proxy storage, but only for version `v0.4.1` and any patch versions under `v0.1` and `v0.2` minor versions.

--- a/pkg/middleware/filter.go
+++ b/pkg/middleware/filter.go
@@ -17,13 +17,17 @@ func NewFilterMiddleware(mf *module.Filter, upstreamEndpoint string) mux.Middlew
 	const op errors.Op = "actions.NewFilterMiddleware"
 	return func(h http.Handler) http.Handler {
 		f := func(w http.ResponseWriter, r *http.Request) {
-			mod, err := paths.GetAllParams(r)
+			mod, err := paths.GetModule(r)
 			if err != nil {
 				// if there is no module the path we are hitting is not one related to modules, like /
 				h.ServeHTTP(w, r)
 				return
 			}
-			rule := mf.Rule(mod.Module, mod.Version)
+			ver, err := paths.GetVersion(r)
+			if err != nil {
+				ver = ""
+			}
+			rule := mf.Rule(mod, ver)
 			switch rule {
 			case module.Exclude:
 				// Exclude: ignore request for this module

--- a/pkg/middleware/filter.go
+++ b/pkg/middleware/filter.go
@@ -17,13 +17,13 @@ func NewFilterMiddleware(mf *module.Filter, upstreamEndpoint string) mux.Middlew
 	const op errors.Op = "actions.NewFilterMiddleware"
 	return func(h http.Handler) http.Handler {
 		f := func(w http.ResponseWriter, r *http.Request) {
-			mod, err := paths.GetModule(r)
+			mod, err := paths.GetAllParams(r)
 			if err != nil {
 				// if there is no module the path we are hitting is not one related to modules, like /
 				h.ServeHTTP(w, r)
 				return
 			}
-			rule := mf.Rule(mod)
+			rule := mf.Rule(mod.Module, mod.Version)
 			switch rule {
 			case module.Exclude:
 				// Exclude: ignore request for this module

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -49,9 +49,9 @@ func newTestFilter(filterFile string) (*module.Filter, error) {
 	if err != nil {
 		return nil, err
 	}
-	f.AddRule("github.com/gomods/athens/", module.Direct)
-	f.AddRule("github.com/athens-artifacts/no-tags", module.Exclude)
-	f.AddRule("github.com/athens-artifacts", module.Include)
+	f.AddRule("github.com/gomods/athens/", nil, module.Direct)
+	f.AddRule("github.com/athens-artifacts/no-tags", nil, module.Exclude)
+	f.AddRule("github.com/athens-artifacts", nil, module.Include)
 	return f, nil
 }
 

--- a/pkg/module/filter.go
+++ b/pkg/module/filter.go
@@ -109,7 +109,7 @@ func (f *Filter) getAssociatedRule(version string, path ...string) FilterRule {
 				break
 			}
 		}
-		if match {
+		if match || version == "" {
 			rules = append(rules, rn.rule)
 		}
 	}

--- a/pkg/module/filter.go
+++ b/pkg/module/filter.go
@@ -42,7 +42,7 @@ func NewFilter(filterFilePath string) (*Filter, error) {
 }
 
 // AddRule adds rule for specified path
-func (f *Filter) AddRule(path string, rule FilterRule) {
+func (f *Filter) AddRule(path string, versions []string, rule FilterRule) {
 	f.ensurePath(path)
 
 	segments := getPathSegments(path)
@@ -62,13 +62,14 @@ func (f *Filter) AddRule(path string, rule FilterRule) {
 	last := segments[len(segments)-1]
 	rn := latest.next[last]
 	rn.rule = rule
+	rn.vers = versions
 	latest.next[last] = rn
 }
 
 // Rule returns the filter rule to be applied to the given path
-func (f *Filter) Rule(path string) FilterRule {
+func (f *Filter) Rule(path, version string) FilterRule {
 	segs := getPathSegments(path)
-	rule := f.getAssociatedRule(segs...)
+	rule := f.getAssociatedRule(version, segs...)
 	if rule == Default {
 		rule = Include
 	}
@@ -88,7 +89,7 @@ func (f *Filter) ensurePath(path string) {
 	}
 }
 
-func (f *Filter) getAssociatedRule(path ...string) FilterRule {
+func (f *Filter) getAssociatedRule(version string, path ...string) FilterRule {
 	if len(path) == 0 {
 		return f.root.rule
 	}
@@ -100,7 +101,17 @@ func (f *Filter) getAssociatedRule(path ...string) FilterRule {
 			break
 		}
 		rn = rn.next[p]
-		rules = append(rules, rn.rule)
+		// default to true if no version filter, false otherwise
+		match := len(rn.vers) == 0
+		for _, ver := range rn.vers {
+			if strings.HasPrefix(version, ver) {
+				match = true
+				break
+			}
+		}
+		if match {
+			rules = append(rules, rn.rule)
+		}
 	}
 
 	if len(rules) == 0 {
@@ -140,7 +151,7 @@ func initFromConfig(filePath string) (*Filter, error) {
 		}
 
 		split := strings.Split(line, " ")
-		if len(split) > 2 {
+		if len(split) > 3 {
 			return nil, errors.E(op, "Invalid configuration found in filter file at the line "+strconv.Itoa(idx+1))
 		}
 
@@ -158,12 +169,22 @@ func initFromConfig(filePath string) (*Filter, error) {
 		}
 		// is root config
 		if len(split) == 1 {
-			f.AddRule("", rule)
+			f.AddRule("", nil, rule)
 			continue
+		}
+		var vers []string
+		if len(split) == 3 {
+			vers = strings.Split(split[2], ",")
+			for i := range vers {
+				vers[i] = strings.TrimRight(vers[i], "*")
+				if vers[i][len(vers[i])-1] != '.' && strings.Count(vers[i], ".") < 2 {
+					vers[i] += "."
+				}
+			}
 		}
 
 		path := strings.TrimSpace(split[1])
-		f.AddRule(path, rule)
+		f.AddRule(path, vers, rule)
 	}
 	return f, nil
 }

--- a/pkg/module/filter_rule.go
+++ b/pkg/module/filter_rule.go
@@ -3,4 +3,5 @@ package module
 type ruleNode struct {
 	next map[string]ruleNode
 	rule FilterRule
+	vers []string
 }


### PR DESCRIPTION
**What is the problem I am trying to address?**

Increase the granularity of module filtering to include version matching.

**How is the fix applied?**

A comma-separated list of version filters is parsed from the filter rule, separated from the module by a space.  These version filters are applied using a prefix match, similar to the module filtering.  

Documentation has been updated, with an example filter file using version filtering.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1045 

