### PR TITLE
pkg/config: Update GoGetWorkers default/docs

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -15,8 +15,11 @@ GoEnv = "development"
 # GoGetWorkers specifies how many times you can concurrently
 # go mod download, this is so that low performance instances
 # can manage go get more sanely and not run out of disk or memory.
+# One way to think about is: the number of GoGetWorkers corresponds
+# directly to how many parallel "git clones" your underlying machine
+# can handle. 
 # Env override: ATHENS_GOGET_WORKERS
-GoGetWorkers = 30
+GoGetWorkers = 10
 
 # ProtocolWorkers specifies how many concurrent
 # requests can you handle at a time for all

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -206,7 +206,7 @@ func TestParseExampleConfig(t *testing.T) {
 		GoEnv:           "development",
 		LogLevel:        "debug",
 		GoBinary:        "go",
-		GoGetWorkers:    30,
+		GoGetWorkers:    10,
 		ProtocolWorkers: 30,
 		CloudRuntime:    "none",
 		TimeoutConf: TimeoutConf{


### PR DESCRIPTION
Update the GoGetWorkers documentation to be clear about what it does under the hood, I also lowered the number to a more sane default...doing 30 git clones at the same time will more likely run you out of resources. 