### PR TITLE
Keep code defaults and config.toml defaults the same

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ func createDefault() *Config {
 	return &Config{
 		GoBinary:        "go",
 		GoEnv:           "development",
-		GoGetWorkers:    30,
+		GoGetWorkers:    10,
 		ProtocolWorkers: 30,
 		LogLevel:        "debug",
 		CloudRuntime:    "none",


### PR DESCRIPTION
Having Athens be okay to run without a config file makes the developer experience a little bit nicer since you can just run it as a standalone binary. 

Therefore, it's okay to make it the maintainers' responsibility to make sure that our two copies of the defaults are absolutely identical (the defaults in config.go vs the defaults in config.toml). 

We can potentially run a script to compare the two defaults and fail the pipeline on PRs, but for now manual checking is alright. 
