### PR TITLE
Use Go 1.12rc for Docker Image

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/docker-library/buildpack-deps/blob/1845b3f918f69b4c97912b0d4d68a5658458e84f/stretch/scm/Dockerfile
 # https://github.com/golang/go/blob/f082dbfd4f23b0c95ee1de5c2b091dad2ff6d930/src/cmd/go/internal/get/vcs.go#L90
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12rc1-alpine AS builder
 
 WORKDIR $GOPATH/src/github.com/gomods/athens
 

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/docker-library/buildpack-deps/blob/1845b3f918f69b4c97912b0d4d68a5658458e84f/stretch/scm/Dockerfile
 # https://github.com/golang/go/blob/f082dbfd4f23b0c95ee1de5c2b091dad2ff6d930/src/cmd/go/internal/get/vcs.go#L90
 
-FROM golang:1.12rc1-alpine AS builder
+FROM golang:1.12-rc-alpine AS builder
 
 WORKDIR $GOPATH/src/github.com/gomods/athens
 


### PR DESCRIPTION
Now that the Release Candidate is out for 1.12, it's good that Canary users can test it out and so that they can catch any backwards-incompatible changes in Go Modules early on (i.e. the checksum mismatch issue) 