### PR TITLE
[WIP] Speeding up Azure Pipelines CI runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,8 @@ jobs:
         Start-Process -NoNewWindow mongod.exe '--bind_ip_all --dbpath="C:\data\db"'
 - job: Tests
   displayName: "Run tests"
+  pool:
+    vmImage: 'vs2017-win2016'
   steps:
     - powershell: |
         go test -mod=vendor -race ./...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,48 +12,56 @@ variables:
   GO111MODULE: 'on'
   modulePath: '$(GOPATH)\src\github.com\$(build.repository.name)' # Path to the module's code
 
-steps:
-- powershell: |
-    mkdir "$env:GOBIN" | out-null
-    mkdir "$env:GOPATH\pkg" | out-null
-    mkdir "$env:modulePath" | out-null
-    robocopy "$env:system_defaultWorkingDirectory\" "$env:modulePath\" /E /Z /ZB /R:5 /W:5 /TBD /NP /V /XD "$env:GOPATH"
-    exit ($LastExitCode -band 24)
-  displayName: 'set up the Go workspace'
-
-- powershell: |
-    $downloadURL = "https://dl.minio.io/server/minio/release/windows-amd64/minio.exe"
-    Write-Host "download minio from $downloadURL - start"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest -Uri $downloadURL -OutFile "minio.exe"
-    Write-Host "download minio - end"
-    Start-Process -NoNewWindow minio.exe 'server --address ":9001" .'
+jobs:
+- job: WorkspaceSetup
+  displayName: "Set up the Go workspace"
+  steps:
+    - powershell: |
+        mkdir "$env:GOBIN" | out-null
+        mkdir "$env:GOPATH\pkg" | out-null
+        mkdir "$env:modulePath" | out-null
+        robocopy "$env:system_defaultWorkingDirectory\" "$env:modulePath\" /E /Z /ZB /R:5 /W:5 /TBD /NP /V /XD "$env:GOPATH"
+        exit ($LastExitCode -band 24)
+- job: Minio
+  displayName: "Download and start minio"
+  steps:
+    - powershell: |
+        $downloadURL = "https://dl.minio.io/server/minio/release/windows-amd64/minio.exe"
+        Write-Host "download minio from $downloadURL - start"
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $downloadURL -OutFile "minio.exe"
+        Write-Host "download minio - end"
+        Start-Process -NoNewWindow minio.exe 'server --address ":9001" .'
   env:
     MINIO_ACCESS_KEY: "minio"
     MINIO_SECRET_KEY: "minio123"
-  displayName: 'start minio'
-
-- powershell: |
-    $downloadURL = "https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.4-signed.msi"
-    Write-Host "download mongo from $downloadURL - start"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest -Uri $downloadURL -OutFile "mongo.msi"
-    Write-Host "download mongo - end"
-    Write-Host "install mongo - start"
-    Start-Process msiexec -Wait	-ArgumentList @('/i',	'mongo.msi', '/quiet', '/qn',	'INSTALLLOCATION=C:\mongodb',	'ADDLOCAL=all')
-    $env:PATH = 'C:\mongodb\bin;' + $env:PATH
-    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
-    mkdir C:\data\db | out-null
-    mkdir C:\data\configdb | out-null
-    Write-Host "install mongo - end"
-    Start-Process -NoNewWindow mongod.exe '--bind_ip_all --dbpath="C:\data\db"'
-  displayName: 'install & start mongo'
-
-- powershell: |
-    go test -mod=vendor -race ./...
+- job: Mongo
+  displayName: "Install & start mongo"
+  steps:
+    - powershell: |
+        $downloadURL = "https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.4-signed.msi"
+        Write-Host "download mongo from $downloadURL - start"
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $downloadURL -OutFile "mongo.msi"
+        Write-Host "download mongo - end"
+        Write-Host "install mongo - start"
+        Start-Process msiexec -Wait	-ArgumentList @('/i',	'mongo.msi', '/quiet', '/qn',	'INSTALLLOCATION=C:\mongodb',	'ADDLOCAL=all')
+        $env:PATH = 'C:\mongodb\bin;' + $env:PATH
+        [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+        mkdir C:\data\db | out-null
+        mkdir C:\data\configdb | out-null
+        Write-Host "install mongo - end"
+        Start-Process -NoNewWindow mongod.exe '--bind_ip_all --dbpath="C:\data\db"'
+- job: "Run tests"
+  steps:
+    - powershell: |
+        go test -mod=vendor -race ./...
   env:
     ATHENS_MINIO_ENDPOINT: "127.0.0.1:9001"
     ATHENS_MONGO_STORAGE_URL: "127.0.0.1:27017"
   workingDirectory: '$(modulePath)'
-  displayName: 'run tests'
+  dependsOn:
+    - WorkspaceSetup
+    - Minio
+    - Mongo
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,6 @@
 # Add steps that test, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/go
 
-pool:
-  vmImage: 'vs2017-win2016'
-
 variables:
   GOBIN:  '$(GOPATH)\bin' # Go binaries path
   GOPATH: '$(system.defaultWorkingDirectory)\gopath' # Go workspace path
@@ -14,6 +11,8 @@ variables:
 
 jobs:
 - job: WorkspaceSetup
+  pool:
+    vmImage: 'vs2017-win2016'
   displayName: "Set up the Go workspace"
   steps:
     - powershell: |
@@ -23,6 +22,8 @@ jobs:
         robocopy "$env:system_defaultWorkingDirectory\" "$env:modulePath\" /E /Z /ZB /R:5 /W:5 /TBD /NP /V /XD "$env:GOPATH"
         exit ($LastExitCode -band 24)
 - job: Minio
+  pool:
+    vmImage: 'vs2017-win2016'
   displayName: "Download and start minio"
   steps:
     - powershell: |
@@ -32,10 +33,12 @@ jobs:
         Invoke-WebRequest -Uri $downloadURL -OutFile "minio.exe"
         Write-Host "download minio - end"
         Start-Process -NoNewWindow minio.exe 'server --address ":9001" .'
-  env:
-    MINIO_ACCESS_KEY: "minio"
-    MINIO_SECRET_KEY: "minio123"
+      env:
+        MINIO_ACCESS_KEY: "minio"
+        MINIO_SECRET_KEY: "minio123"
 - job: Mongo
+  pool:
+    vmImage: 'vs2017-win2016'
   displayName: "Install & start mongo"
   steps:
     - powershell: |
@@ -52,14 +55,15 @@ jobs:
         mkdir C:\data\configdb | out-null
         Write-Host "install mongo - end"
         Start-Process -NoNewWindow mongod.exe '--bind_ip_all --dbpath="C:\data\db"'
-- job: "Run tests"
+- job: Tests
+  displayName: "Run tests"
   steps:
     - powershell: |
         go test -mod=vendor -race ./...
-  env:
-    ATHENS_MINIO_ENDPOINT: "127.0.0.1:9001"
-    ATHENS_MONGO_STORAGE_URL: "127.0.0.1:27017"
-  workingDirectory: '$(modulePath)'
+      env:
+        ATHENS_MINIO_ENDPOINT: "127.0.0.1:9001"
+        ATHENS_MONGO_STORAGE_URL: "127.0.0.1:27017"
+      workingDirectory: '$(modulePath)'
   dependsOn:
     - WorkspaceSetup
     - Minio

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,17 +10,6 @@ variables:
   modulePath: '$(GOPATH)\src\github.com\$(build.repository.name)' # Path to the module's code
 
 jobs:
-- job: WorkspaceSetup
-  pool:
-    vmImage: 'vs2017-win2016'
-  displayName: "Set up the Go workspace"
-  steps:
-    - powershell: |
-        mkdir "$env:GOBIN" | out-null
-        mkdir "$env:GOPATH\pkg" | out-null
-        mkdir "$env:modulePath" | out-null
-        robocopy "$env:system_defaultWorkingDirectory\" "$env:modulePath\" /E /Z /ZB /R:5 /W:5 /TBD /NP /V /XD "$env:GOPATH"
-        exit ($LastExitCode -band 24)
 - job: Minio
   pool:
     vmImage: 'vs2017-win2016'
@@ -61,13 +50,18 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
     - powershell: |
+        mkdir "$env:GOBIN" | out-null
+        mkdir "$env:GOPATH\pkg" | out-null
+        mkdir "$env:modulePath" | out-null
+        robocopy "$env:system_defaultWorkingDirectory\" "$env:modulePath\" /E /Z /ZB /R:5 /W:5 /TBD /NP /V /XD "$env:GOPATH"
+        exit ($LastExitCode -band 24)
+    - powershell: |
         go test -mod=vendor -race ./...
       env:
         ATHENS_MINIO_ENDPOINT: "127.0.0.1:9001"
         ATHENS_MONGO_STORAGE_URL: "127.0.0.1:27017"
       workingDirectory: '$(modulePath)'
   dependsOn:
-    - WorkspaceSetup
     - Minio
     - Mongo
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

Azure pipelines CI runs like [this one](https://dev.azure.com/gomods/athens/_build/results?buildId=514) take a long time to complete, compared to our Travis CI runs.

**How is the fix applied?**

I've added some [jobs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml) to the pipelines config to try and do the setup in parallel

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Ref https://github.com/gomods/athens/issues/1057 since that also deals with speeding up CI runs