### PR TITLE
Dockerfile: remove redundant call to apk update

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -20,8 +20,7 @@ COPY --from=builder /bin/athens-proxy /bin/athens-proxy
 COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/config.toml
 COPY --from=builder /usr/local/go/bin/go /bin/go
 
-RUN apk update &&  \
-	apk add --no-cache bzr git mercurial openssh-client subversion procps fossil && \
+RUN apk add --update bzr git mercurial openssh-client subversion procps fossil && \
 	mkdir -p /usr/local/go
 
 ENV GO_ENV=production


### PR DESCRIPTION
- ``apk update`` fetches the index and saves it locally
- ``apk add --update`` fetches the index and installs the requested
packages
