### PR TITLE
pkg/config: make StatsExporter consistent with config.toml

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ func createDefault() *Config {
 		ProtocolWorkers: 30,
 		LogLevel:        "debug",
 		CloudRuntime:    "none",
+		StatsExporter:   "prometheus",
 		TimeoutConf:     TimeoutConf{Timeout: 300},
 		StorageType:     "memory",
 		Port:            ":3000",


### PR DESCRIPTION
Same as a previous PR: https://github.com/gomods/athens/pull/1062

Will make sure that using and not using a config file have no side effects