### PR TITLE
pkg/config: make sure envconfig doesn't override config values for port

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	StatsExporter    string `envconfig:"ATHENS_STATS_EXPORTER"`
 	StorageType      string `validate:"required" envconfig:"ATHENS_STORAGE_TYPE"`
 	GlobalEndpoint   string `envconfig:"ATHENS_GLOBAL_ENDPOINT"` // This feature is not yet implemented
-	Port             string `envconfig:"ATHENS_PORT" default:":3000"`
+	Port             string `envconfig:"ATHENS_PORT"`
 	BasicAuthUser    string `envconfig:"BASIC_AUTH_USER"`
 	BasicAuthPass    string `envconfig:"BASIC_AUTH_PASS"`
 	ForceSSL         bool   `envconfig:"PROXY_FORCE_SSL"`
@@ -137,7 +137,15 @@ func ParseConfigFile(configFile string) (*Config, error) {
 
 // envOverride uses Environment variables to override unspecified properties
 func envOverride(config *Config) error {
-	return envconfig.Process("athens", config)
+	const defaultPort = ":3000"
+	err := envconfig.Process("athens", config)
+	if err != nil {
+		return err
+	}
+	if config.Port == "" {
+		config.Port = defaultPort
+	}
+	return nil
 }
 
 func validateConfig(config Config) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,6 +64,7 @@ func TestPortDefaultsCorrectly(t *testing.T) {
 }
 
 func TestEnvOverrides(t *testing.T) {
+	os.Clearenv()
 	expConf := &Config{
 		GoEnv:           "production",
 		GoGetWorkers:    10,
@@ -88,10 +89,7 @@ func TestEnvOverrides(t *testing.T) {
 	}
 
 	envVars := getEnvMap(expConf)
-	envVarBackup := map[string]string{}
 	for k, v := range envVars {
-		oldVal := os.Getenv(k)
-		envVarBackup[k] = oldVal
 		os.Setenv(k, v)
 	}
 	conf := &Config{}
@@ -100,7 +98,19 @@ func TestEnvOverrides(t *testing.T) {
 		t.Fatalf("Env override failed: %v", err)
 	}
 	compareConfigs(conf, expConf, t)
-	restoreEnv(envVarBackup)
+}
+
+func TestEnvOverridesPreservingPort(t *testing.T) {
+	os.Clearenv()
+	const expPort = ":5000"
+	conf := &Config{Port: expPort}
+	err := envOverride(conf)
+	if err != nil {
+		t.Fatalf("Env override failed: %v", err)
+	}
+	if conf.Port != expPort {
+		t.Errorf("Port was incorrect. Got: %s, want: %s", conf.Port, expPort)
+	}
 }
 
 func TestStorageEnvOverrides(t *testing.T) {


### PR DESCRIPTION
Fixes #1037.

envconfig can't actually support that use case, and because athens was
using the `default:` tag only for the port field, handling this manually
is the easiest and functional solution.