### PR TITLE
ignoring vscode local settings dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tmp
 cmd/proxy/bin
 .idea
 .DS_Store
+.vscode
 
 
 # prod config file


### PR DESCRIPTION
**What is the problem I am trying to address?**

If you run Visual Studio Code, your editor might create a `.vscode` directory under this repository. It has settings specific to your preferences and it's better that we keep our editor preferences our own, and not have this project impose them on you 😄 

**How is the fix applied?**

I added `.vscode` to the `.gitignore` file

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

None