### PR TITLE
storage/gcp: allow json key to be used for GCS access

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -182,6 +182,16 @@ SingleFlightType = "memory"
         # Env override: ATHENS_STORAGE_GCP_BUCKET
         Bucket = "MY_GCP_BUCKET"
 
+        # JSONKey allows Athens to be run outside of GCP
+        # but still be able to access GCS. If you are 
+        # running Athens inside GCP, you will most 
+        # likely not need this as GCP figures out 
+        # internal authentication between products for you. 
+        # Pro tip: if you are pasting this as a JSON inside a string,
+        # make sure you escape "\n" by making it "\\n".
+        # Env override: ATHENS_STORAGE_GCP_JSON_KEY
+        JSONKey = "SERVICE_ACCOUNT_KEY"
+
     [Storage.Minio]
         # Endpoint for Minio storage
         # Env override: ATHENS_MINIO_ENDPOINT

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	go.opencensus.io v0.17.0
 	golang.org/x/crypto v0.0.0-20181029103014-dab2b1051b5d // indirect
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
-	golang.org/x/oauth2 v0.0.0-20180620175406-ef147856a6dd // indirect
+	golang.org/x/oauth2 v0.0.0-20180620175406-ef147856a6dd
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/sys v0.0.0-20181031143558-9b800f95dbbc // indirect
 	google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf

--- a/pkg/config/gcp.go
+++ b/pkg/config/gcp.go
@@ -4,4 +4,5 @@ package config
 type GCPConfig struct {
 	ProjectID string `envconfig:"GOOGLE_CLOUD_PROJECT"`
 	Bucket    string `validate:"required" envconfig:"ATHENS_STORAGE_GCP_BUCKET"`
+	JSONKey   string `envconfig:"ATHENS_STORAGE_GCP_JSON_KEY"`
 }


### PR DESCRIPTION
Fixes https://github.com/gomods/athens/issues/1087