### PR TITLE
storage/gcp: use base64 for json key

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -182,15 +182,14 @@ SingleFlightType = "memory"
         # Env override: ATHENS_STORAGE_GCP_BUCKET
         Bucket = "MY_GCP_BUCKET"
 
-        # JSONKey allows Athens to be run outside of GCP
+        # JSONKey is a base64 encoded service account 
+        # key that allows Athens to be run outside of GCP
         # but still be able to access GCS. If you are 
-        # running Athens inside GCP, you will most 
+        # running Athens inside GCP, you will most
         # likely not need this as GCP figures out 
         # internal authentication between products for you. 
-        # Pro tip: if you are pasting this as a JSON inside a string,
-        # make sure you escape "\n" by making it "\\n".
         # Env override: ATHENS_STORAGE_GCP_JSON_KEY
-        JSONKey = "SERVICE_ACCOUNT_KEY"
+        JSONKey = ""
 
     [Storage.Minio]
         # Endpoint for Minio storage

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -31,7 +32,11 @@ func New(ctx context.Context, gcpConf *config.GCPConfig, timeout time.Duration) 
 
 	opts := []option.ClientOption{}
 	if gcpConf.JSONKey != "" {
-		creds, err := google.CredentialsFromJSON(ctx, []byte(gcpConf.JSONKey), storage.ScopeReadWrite)
+		key, err := base64.StdEncoding.DecodeString(gcpConf.JSONKey)
+		if err != nil {
+			return nil, errors.E(op, fmt.Errorf("could not decode base64 json key: %v", err))
+		}
+		creds, err := google.CredentialsFromJSON(ctx, key, storage.ScopeReadWrite)
 		if err != nil {
 			return nil, errors.E(op, fmt.Errorf("could not get GCS credentials: %v", err))
 		}


### PR DESCRIPTION
@leitzler suggested that we use base64 for a json inside a string to avoid any weird parsing errors. The only parsing hack I had to do was to escape new lines "\\n" -- however, it seems that some CIs give even weirder errors such as: `private key should be a PEM or plain PKSC1 or PKCS8; parse error: asn1: syntax error: sequence truncated` 

So to avoid all of these possibilities, we'll just have to let users encode their own json key in base64 which shouldn't be a huge hassle hopefully. 