### PR TITLE
catalog: fix vet errors

### DIFF
--- a/pkg/storage/fs/cataloger.go
+++ b/pkg/storage/fs/cataloger.go
@@ -51,7 +51,7 @@ func (s *storageImpl) Catalog(ctx context.Context, token string, pageSize int) (
 				return nil
 			}
 
-			res = append(res, paths.AllPathParams{module, version})
+			res = append(res, paths.AllPathParams{Module: module, Version: version})
 			count--
 			if count == 0 {
 				resToken = tokenFromModVer(module, version)

--- a/pkg/storage/gcp/cataloger.go
+++ b/pkg/storage/gcp/cataloger.go
@@ -81,5 +81,5 @@ func parseGcpKey(p string) (paths.AllPathParams, error) {
 	if m == "" || v == "" {
 		return paths.AllPathParams{}, errors.E(op, fmt.Errorf("invalid object key format %s", p))
 	}
-	return paths.AllPathParams{m, v}, nil
+	return paths.AllPathParams{Module: m, Version: v}, nil
 }

--- a/pkg/storage/minio/cataloger.go
+++ b/pkg/storage/minio/cataloger.go
@@ -80,5 +80,5 @@ func parseMinioKey(o *minio.ObjectInfo) (paths.AllPathParams, error) {
 	if m == "" || v == "" {
 		return paths.AllPathParams{}, errors.E(op, fmt.Errorf("invalid object key format %s", o.Key))
 	}
-	return paths.AllPathParams{m, v}, nil
+	return paths.AllPathParams{Module: m, Version: v}, nil
 }

--- a/pkg/storage/s3/cataloger.go
+++ b/pkg/storage/s3/cataloger.go
@@ -81,5 +81,5 @@ func parseS3Key(o *s3.Object) (paths.AllPathParams, error) {
 	if m == "" || v == "" {
 		return paths.AllPathParams{}, errors.E(op, fmt.Errorf("invalid object key format %s", *o.Key))
 	}
-	return paths.AllPathParams{m, v}, nil
+	return paths.AllPathParams{mModule: , Version: v}, nil
 }

--- a/pkg/storage/s3/cataloger.go
+++ b/pkg/storage/s3/cataloger.go
@@ -81,5 +81,5 @@ func parseS3Key(o *s3.Object) (paths.AllPathParams, error) {
 	if m == "" || v == "" {
 		return paths.AllPathParams{}, errors.E(op, fmt.Errorf("invalid object key format %s", *o.Key))
 	}
-	return paths.AllPathParams{mModule: , Version: v}, nil
+	return paths.AllPathParams{Module: m, Version: v}, nil
 }


### PR DESCRIPTION
`go vet ./...` fails due to unkeyed values of similar types. This fixes it so that if/when we add `go vet` it should be happy. 