### PR TITLE
build: switch to go1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 language: go
 install: false
 go:
-  - "1.11.x"
+  - "1.12.x"
 env:
   global:
     - PATH=${PATH}:./bin

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/docker-library/buildpack-deps/blob/1845b3f918f69b4c97912b0d4d68a5658458e84f/stretch/scm/Dockerfile
 # https://github.com/golang/go/blob/f082dbfd4f23b0c95ee1de5c2b091dad2ff6d930/src/cmd/go/internal/get/vcs.go#L90
 
-FROM golang:1.12-rc-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 WORKDIR $GOPATH/src/github.com/gomods/athens
 


### PR DESCRIPTION
Once go1.12 is up on Docker Hub, this can be merged so that we can release v0.3.0 ✌️ 