### PR TITLE
ZipHandler set content type

### DIFF
--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -29,6 +29,7 @@ func ZipHandler(dp Protocol, lggr log.Entry) http.Handler {
 		}
 		defer zip.Close()
 
+		w.Header().Set("Content-Type", "application/zip")
 		_, err = io.Copy(w, zip)
 		if err != nil {
 			lggr.SystemErr(errors.E(op, errors.M(mod), errors.V(ver), err))


### PR DESCRIPTION
**What is the problem I am trying to address?**

I run athens behind reverse proxy. Athens set content type `application/json` for .zip file.
So the reverse proxy will compress the .zip file to gzip/br (because it think that file is json) depends on client's accept-encoding.

**How is the fix applied?**

Set content type to `application/zip` before send zip data.
