### PR TITLE
ci/cd: remove bottlenecks from azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,38 +22,6 @@ steps:
   displayName: 'set up the Go workspace'
 
 - powershell: |
-    $downloadURL = "https://dl.minio.io/server/minio/release/windows-amd64/minio.exe"
-    Write-Host "download minio from $downloadURL - start"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest -Uri $downloadURL -OutFile "minio.exe"
-    Write-Host "download minio - end"
-    Start-Process -NoNewWindow minio.exe 'server --address ":9001" .'
-  env:
-    MINIO_ACCESS_KEY: "minio"
-    MINIO_SECRET_KEY: "minio123"
-  displayName: 'start minio'
-
-- powershell: |
-    $downloadURL = "https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.4-signed.msi"
-    Write-Host "download mongo from $downloadURL - start"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest -Uri $downloadURL -OutFile "mongo.msi"
-    Write-Host "download mongo - end"
-    Write-Host "install mongo - start"
-    Start-Process msiexec -Wait	-ArgumentList @('/i',	'mongo.msi', '/quiet', '/qn',	'INSTALLLOCATION=C:\mongodb',	'ADDLOCAL=all')
-    $env:PATH = 'C:\mongodb\bin;' + $env:PATH
-    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
-    mkdir C:\data\db | out-null
-    mkdir C:\data\configdb | out-null
-    Write-Host "install mongo - end"
-    Start-Process -NoNewWindow mongod.exe '--bind_ip_all --dbpath="C:\data\db"'
-  displayName: 'install & start mongo'
-
-- powershell: |
     go test -mod=vendor -race ./...
-  env:
-    ATHENS_MINIO_ENDPOINT: "127.0.0.1:9001"
-    ATHENS_MONGO_STORAGE_URL: "127.0.0.1:27017"
   workingDirectory: '$(modulePath)'
   displayName: 'run tests'
-


### PR DESCRIPTION
Since Drone is now in place and tests almost all of our storages, there's no need for Azure Pipelines to run the same tests. All we need it for is that it's Windows compatible, and the biggest difference between Windows/Linux is the FileSystem so we should insure the regular tests pass on Windows and I'd say that's a pretty confident sign that things are working properly. 

Fixes https://github.com/gomods/athens/issues/1111