### PR TITLE
s3 Use no. of objects for Exists check

### DIFF
--- a/pkg/storage/compliance/tests.go
+++ b/pkg/storage/compliance/tests.go
@@ -23,6 +23,7 @@ func RunTests(t *testing.T, b storage.Backend, clearBackend func() error) {
 	testList(t, b)
 	testDelete(t, b)
 	testGet(t, b)
+	testExists(t, b)
 	testCatalog(t, b)
 }
 
@@ -106,6 +107,20 @@ func testGet(t *testing.T, b storage.Backend) {
 	givenZipBts, err := ioutil.ReadAll(zip)
 	require.NoError(t, err)
 	require.Equal(t, zipBts, givenZipBts)
+}
+
+func testExists(t *testing.T, b storage.Backend) {
+	ctx := context.Background()
+	modname := "getTestModule"
+	ver := "v1.2.3"
+	mock := getMockModule()
+	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	b.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+	defer b.Delete(ctx, modname, ver)
+
+	exists, err := b.Exists(ctx, modname, ver)
+	require.NoError(t, err)
+	require.Equal(t, true, exists)
 }
 
 // testDelete tests that a module can be deleted from a

--- a/pkg/storage/s3/checker.go
+++ b/pkg/storage/s3/checker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
@@ -22,19 +21,15 @@ func (s *Storage) Exists(ctx context.Context, module, version string) (bool, err
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
-	pkgName := config.PackageVersionedName(module, version, "mod")
-	hoParams := &s3.HeadObjectInput{
+	lsParams := &s3.ListObjectsInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(pkgName),
+		Prefix: aws.String(config.PackageVersionedName(module, version, "")),
 	}
 
-	if _, err := s.s3API.HeadObjectWithContext(ctx, hoParams); err != nil {
-		if err.(awserr.Error).Code() == s3ErrorCodeNotFound {
-			return false, nil
-		}
-
-		return false, errors.E(op, err, errors.M(module))
+	loo, err := s.s3API.ListObjectsWithContext(ctx, lsParams)
+	if err != nil {
+		return false, errors.E(op, err, errors.M(module), errors.V(version))
 	}
 
-	return true, nil
+	return len(loo.Contents) == 3, nil
 }


### PR DESCRIPTION
**What is the problem I am trying to address?**
Currently our `storage.Exists` implementation checks only for the `mod` file. This can be problematic if i.e. `zip` or `info` uploads failed. 

**How is the fix applied?**

I'm checking if the len of objects equals 3 (zip, mod, info)

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Partially fixes #1032 
