### PR TITLE
mongo: Use no. of objects for Exists check

### DIFF
--- a/pkg/storage/mongo/checker.go
+++ b/pkg/storage/mongo/checker.go
@@ -18,5 +18,5 @@ func (s *ModuleStore) Exists(ctx context.Context, module, vsn string) (bool, err
 	if err != nil {
 		return false, errors.E(op, errors.M(module), errors.V(vsn), err)
 	}
-	return count > 0, nil
+	return count == 3, nil
 }


### PR DESCRIPTION
**What is the problem I am trying to address?**

Currently our storage.Exists implementation checks only for the mod file. This can be problematic if i.e. zip or info uploads failed.

**How is the fix applied?**

I'm checking if the no. of objects equals 3 (zip, mod, info)

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Partially fixes #1032
