### PR TITLE
Changing high level arch. docs to indicate the right number of components

### DIFF
--- a/docs/content/intro/components.md
+++ b/docs/content/intro/components.md
@@ -4,7 +4,7 @@ date: 2018-02-11T16:57:56-05:00
 weight: 5
 ---
 
-From a very high-level view, we recognize 4 major components of the system.
+From a very high-level view, there are 3 major components of the system.
 
 ### Client
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

The docs indicated that there are 4 components in the high level architecture,
but only 3 are described.

**How is the fix applied?**

The right number is 3, so I've changed the docs from 4 to 3

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

cc/ @linuxsuren and @hihilary, since this was found in https://github.com/gomods/athens/pull/1128