### PR TITLE
helm chart: configure ssh-secured git servers

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.2.0
 description: The proxy server for Go modules
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: athens-proxy
 version: 0.2.1
-appVersion: 0.3.0
+appVersion: v0.3.1
 description: The proxy server for Go modules
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: athens-proxy
 version: 0.2.1
-appVersion: 0.2.0
+appVersion: 0.3.0
 description: The proxy server for Go modules
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/charts/athens-proxy/templates/configmap.yaml
+++ b/charts/athens-proxy/templates/configmap.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.sshGitServers }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-configmap
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  ssh_config: |
+    {{- range $server := .Values.sshGitServers }}
+    Host {{ $server.host }}
+      Hostname {{ $server.host }}
+      User {{ $server.user }}
+      Port {{ $server.port }}
+      StrictHostKeyChecking no
+      IdentityFile /ssh-keys/id_rsa-{{ $server.host }}
+    {{- end }}
+  git_config: |
+    {{- range $server := .Values.sshGitServers }}
+    [url "ssh://{{ $server.user }}@{{ $server.host }}:{{ $server.port}}"]
+      insteadOf = https://{{ $server.host }}
+    {{- end -}}
+{{- end -}}

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       volumes:
       containers:
       - name: {{ template "fullname" . }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         livenessProbe:
           httpGet:

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
@@ -16,7 +15,26 @@ spec:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
+      annotations:
+        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        - name: copy-key-files
+          image: alpine:3.6
+          command:
+            - sh
+            - -c
+          args: ["cp /root/.ssh/id_rsa* /ssh-keys && chmod 400 /ssh-keys/*"]
+          volumeMounts:
+          - name: ssh-keys
+            mountPath: /ssh-keys
+          {{- range $server := .Values.sshGitServers }}
+          - name: {{ template "fullname" $ }}-secret
+            mountPath: /root/.ssh/id_rsa-{{ $server.host }}
+            subPath: id_rsa-{{ $server.host }}
+          {{- end }}
+      volumes:
       containers:
       - name: {{ template "fullname" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -32,7 +50,7 @@ spec:
         env:
         - name: ATHENS_STORAGE_TYPE
           value: {{ .Values.storage.type | quote }}
-        {{- if eq .Values.storage.type "disk"}}
+        {{- if eq .Values.storage.type "disk" }}
         - name: ATHENS_DISK_STORAGE_ROOT
           value: {{ .Values.storage.disk.storageRoot | quote }}
         {{- else if eq .Values.storage.type "mongo"}}
@@ -61,10 +79,20 @@ spec:
           mountPath: "/etc/netrc"
           readOnly: true
         {{- end }}
+        - name: {{ template "fullname" . }}-configmap
+          mountPath: /root/.ssh/config
+          subPath: ssh_config
+        - name: {{ template "fullname" . }}-configmap
+          mountPath: /root/.gitconfig
+          subPath: git_config
+        - name: ssh-keys
+          mountPath: /ssh-keys
       volumes:
+      - name: ssh-keys
+        emptyDir: {}
       - name: storage-volume
       {{- if .Values.storage.disk.persistence.enabled }}
-        persistentVolumeClaim: 
+        persistentVolumeClaim:
           claimName: {{ template "fullname" . }}-storage
       {{- else }}
         emptyDir: {}
@@ -74,3 +102,9 @@ spec:
         secret:
           secretName: netrcsecret
       {{- end }}
+      - name: {{ template "fullname" . }}-configmap
+        configMap:
+          name: {{ template "fullname" . }}-configmap
+      - name: {{ template "fullname" . }}-secret
+        secret:
+          secretName: {{ template "fullname" . }}-secret

--- a/charts/athens-proxy/templates/secret.yaml
+++ b/charts/athens-proxy/templates/secret.yaml
@@ -1,0 +1,10 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-secret
+type: Opaque
+data:
+{{- range $server := .Values.sshGitServers }}
+  id_rsa-{{ $server.host }}: {{ $server.privateKey | b64enc | quote }}
+{{- end }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -58,3 +58,16 @@ jaeger:
   # you must set this on the command line when you run 'helm install'
   # for example, you need to run 'helm install --set jaeger.url=myurl ...'
   url: "SET THIS ON THE COMMAND LINE"
+
+# private git servers over ssh
+sshGitServers:
+  ## hostname of the git server
+  - host: git.example.com
+    ## ssh username
+    user: git
+    ## ssh private key for the user
+    privateKey: |
+      -----BEGIN RSA PRIVATE KEY-----
+      -----END RSA PRIVATE KEY-----
+    ## ssh port
+    port: 22

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 image:
   registry: docker.io
   repository: gomods/athens
-  tag: v0.3.0
+  tag: "{{ .Chart.AppVersion }}"
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**What is the problem I am trying to address?**

This PR adds support for working with private ssh-secured git servers in the helm chart. The idea is taken from here: https://docs.gomods.io/configuration/authentication/#altassian-bitbucket-and-ssh-secured-git-vcs-s

**How is the fix applied?**

One or many git servers are added to `sshGitServers`, and the corresponding config files (git config and ssh config) and ssh keys will be created. Athens then will use these configs and keys to download the source from the git servers.

```
sshGitServers:
  ## hostname of the git server
  - host: git.example.com
    ## ssh username
    user: git
    ## ssh private key for the user
    privateKey: |
      -----BEGIN RSA PRIVATE KEY-----
      -----END RSA PRIVATE KEY-----
    ## ssh port
    port: 22
```

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**


<!-- 
example: Fixes #123
-->
