### PR TITLE
Azure Pipelines: use go1.12

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ variables:
 
 steps:
 - powershell: |
+    choco upgrade golang
     mkdir "$env:GOBIN" | out-null
     mkdir "$env:GOPATH\pkg" | out-null
     mkdir "$env:modulePath" | out-null


### PR DESCRIPTION
**What is the problem I am trying to address?**
Azure pipelines uses g1.11 but Athens requires 1.12
Using windows containers on Azure Pipelines is slow - it takes around ~12min (8min just to pull the image) ref: #1126 
This PR uses chocolatey to install go 1.12 on the VM
