### PR TITLE
Removing the line number from the config link

### DIFF
--- a/docs/content/install/install-on-kubernetes.md
+++ b/docs/content/install/install-on-kubernetes.md
@@ -97,7 +97,7 @@ This will deploy a single Athens instance in the `default` namespace with `disk`
 
 ### Give Athens access to private repositories via Github Token (Optional)
 1. Create a token at https://github.com/settings/tokens
-2. Provide the token to the Athens proxy either through the [config.toml](https://github.com/gomods/athens/blob/master/config.dev.toml#L111) file or by setting the `ATHENS_GITHUB_TOKEN` environment variable.
+2. Provide the token to the Athens proxy either through the [config.toml](https://github.com/gomods/athens/blob/master/config.dev.toml) file (the `GithubToken` field) or by setting the `ATHENS_GITHUB_TOKEN` environment variable.
 
 ### Storage Providers
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

There's a link to the config file in the Kubernetes install docs 
(https://docs.gomods.io/install/install-on-kubernetes/), and the link has a line
number in it. The code in the config file has changed and now the link points
to the wrong line

**How is the fix applied?**

I removed the line number in the link (so it points to just the file) and
instead just describes where the config field is.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes https://github.com/gomods/athens/issues/1157