### PR TITLE
pkg/module: include SSH environments

### DIFF
--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -167,9 +167,23 @@ func PrepareEnv(gopath string) []string {
 	noProxy := fmt.Sprintf("NO_PROXY=%s", os.Getenv("NO_PROXY"))
 	gopathEnv := fmt.Sprintf("GOPATH=%s", gopath)
 	cacheEnv := fmt.Sprintf("GOCACHE=%s", filepath.Join(gopath, "cache"))
+	gitSSH := fmt.Sprintf("GIT_SSH=%s", os.Getenv("GIT_SSH"))
+	gitSSHCmd := fmt.Sprintf("GIT_SSH_COMMAND=%s", os.Getenv("GIT_SSH_COMMAND"))
 	disableCgo := "CGO_ENABLED=0"
 	enableGoModules := "GO111MODULE=on"
-	cmdEnv := []string{pathEnv, homeEnv, gopathEnv, cacheEnv, disableCgo, enableGoModules, httpProxy, httpsProxy, noProxy}
+	cmdEnv := []string{
+		pathEnv,
+		homeEnv,
+		gopathEnv,
+		cacheEnv,
+		disableCgo,
+		enableGoModules,
+		httpProxy,
+		httpsProxy,
+		noProxy,
+		gitSSH,
+		gitSSHCmd,
+	}
 
 	// add Windows specific ENV VARS
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
I noticed that Go treats SSH env vars in special case here: https://github.com/golang/go/blob/master/src/cmd/go/internal/get/get.go#L156

So we should be passing those environment variables. 