### PR TITLE
Fixing typo in storage compliance test harndess

### DIFF
--- a/pkg/storage/compliance/tests.go
+++ b/pkg/storage/compliance/tests.go
@@ -18,7 +18,7 @@ import (
 // against the interface.
 func RunTests(t *testing.T, b storage.Backend, clearBackend func() error) {
 	require.NoError(t, clearBackend(), "pre-clearing backend failed")
-	defer require.NoError(t, clearBackend(), "post-clearning backend failed")
+	defer require.NoError(t, clearBackend(), "post-clearing backend failed")
 	testNotFound(t, b)
 	testList(t, b)
 	testDelete(t, b)


### PR DESCRIPTION
**What is the problem I am trying to address?**

The storage test harness had a typo in the log message for the clearBackend() call

**How is the fix applied?**

I fixed the typo

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**