### PR TITLE
storage/gcp: fix lister prefix

### DIFF
--- a/pkg/storage/compliance/tests.go
+++ b/pkg/storage/compliance/tests.go
@@ -21,6 +21,7 @@ func RunTests(t *testing.T, b storage.Backend, clearBackend func() error) {
 	defer require.NoError(t, clearBackend(), "post-clearing backend failed")
 	testNotFound(t, b)
 	testList(t, b)
+	testListSuffix(t, b)
 	testDelete(t, b)
 	testGet(t, b)
 	testExists(t, b)
@@ -53,6 +54,48 @@ func testNotFound(t *testing.T, b storage.Backend) {
 	_, err = b.Zip(ctx, mod, ver)
 	require.Error(t, err)
 	require.Equal(t, errors.KindNotFound, errors.Kind(err))
+}
+
+// testListPrefixes makes sure that if you have two modules, such as
+// github.com/one/two and github.com/one/two-suffix, then the versions
+// should not be mixed just because they share a similar prefix.
+func testListSuffix(t *testing.T, b storage.Backend) {
+	ctx := context.Background()
+
+	otherMod := "github.com/one/two-other"
+	mock := getMockModule()
+	err := b.Save(
+		ctx,
+		otherMod,
+		"v0.9.0",
+		mock.Mod,
+		mock.Zip,
+		mock.Info,
+	)
+	require.NoError(t, err, "Save for storage failed")
+	modname := "github.com/one/two"
+	versions := []string{"v1.1.0", "v1.2.0", "v1.3.0"}
+	for _, version := range versions {
+		mock := getMockModule()
+		err := b.Save(
+			ctx,
+			modname,
+			version,
+			mock.Mod,
+			mock.Zip,
+			mock.Info,
+		)
+		require.NoError(t, err, "Save for storage failed")
+	}
+	defer func() {
+		b.Delete(ctx, otherMod, "v0.9.0")
+		for _, ver := range versions {
+			b.Delete(ctx, modname, ver)
+		}
+	}()
+	retVersions, err := b.List(ctx, modname)
+	require.NoError(t, err)
+	require.Equal(t, versions, retVersions)
 }
 
 // testList tests that a storage Backend returns

--- a/pkg/storage/gcp/lister.go
+++ b/pkg/storage/gcp/lister.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -18,7 +17,7 @@ func (s *Storage) List(ctx context.Context, module string) ([]string, error) {
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
-	modulePrefix := filepath.Join(module, "/@v")
+	modulePrefix := strings.TrimSuffix(module, "/") + "/@v"
 	it := s.bucket.Objects(ctx, &storage.Query{Prefix: modulePrefix})
 	paths := []string{}
 	for {

--- a/pkg/storage/gcp/lister.go
+++ b/pkg/storage/gcp/lister.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -17,7 +18,8 @@ func (s *Storage) List(ctx context.Context, module string) ([]string, error) {
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
-	it := s.bucket.Objects(ctx, &storage.Query{Prefix: module})
+	modulePrefix := filepath.Join(module, "/@v")
+	it := s.bucket.Objects(ctx, &storage.Query{Prefix: modulePrefix})
 	paths := []string{}
 	for {
 		attrs, err := it.Next()

--- a/pkg/storage/s3/lister.go
+++ b/pkg/storage/s3/lister.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,7 +20,7 @@ func (s *Storage) List(ctx context.Context, module string) ([]string, error) {
 
 	lsParams := &s3.ListObjectsInput{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(module),
+		Prefix: aws.String(filepath.Join(module, "/")),
 	}
 
 	loo, err := s.s3API.ListObjectsWithContext(ctx, lsParams)

--- a/pkg/storage/s3/lister.go
+++ b/pkg/storage/s3/lister.go
@@ -20,7 +20,7 @@ func (s *Storage) List(ctx context.Context, module string) ([]string, error) {
 
 	lsParams := &s3.ListObjectsInput{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(filepath.Join(module, "/")),
+		Prefix: aws.String(filepath.Join(module, "/@v")),
 	}
 
 	loo, err := s.s3API.ListObjectsWithContext(ctx, lsParams)

--- a/pkg/storage/s3/lister.go
+++ b/pkg/storage/s3/lister.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,9 +17,10 @@ func (s *Storage) List(ctx context.Context, module string) ([]string, error) {
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
+	modulePrefix := strings.TrimSuffix(module, "/") + "/@v"
 	lsParams := &s3.ListObjectsInput{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(filepath.Join(module, "/@v")),
+		Prefix: aws.String(modulePrefix),
 	}
 
 	loo, err := s.s3API.ListObjectsWithContext(ctx, lsParams)


### PR DESCRIPTION
I noticed that our `/@v/list` endpoint was adding versions that didn't exist for `github.com/gobuffalo/buffalo` which turns out to be a bug in our GCP lister because it was considering all modules that had the previous prefx so it took version from other mods like `github.com/gobuffalo/buffalo-plugin` 

Most of our backend implementations have this correct, but I believe Azure/S3 might have this incorrect as well. We should hopefully add those implementations in our CI soon