### PR TITLE
pkg/config: ensure env vars override defaults

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,8 @@ func Load(configFile string) (*Config, error) {
 
 	// Use default values
 	log.Println("Running dev mode with default settings, consult config when you're ready to run in production")
-	return defaultConfig(), nil
+	cfg := defaultConfig()
+	return cfg, envOverride(cfg)
 }
 
 func defaultConfig() *Config {


### PR DESCRIPTION
I noticed that when there's no Config file provided, the environment variables don't override any of the defaults. According to config.dev.toml, all environment variables have more priority so we should make sure they do override the hard coded configs. 