### PR TITLE
Use go 1.12 in Dockerfile.test

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 RUN mkdir -p /athens/tests
 


### PR DESCRIPTION
We should use 1.12 in our tests
