### PR TITLE
pkg/module: include SSH_AUTH_SOCK in go get env

### DIFF
--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -185,9 +185,13 @@ func PrepareEnv(gopath string) []string {
 		gitSSHCmd,
 	}
 
-	if sshAuthSockVal, hasSSHAuthSock := os.Getenv("SSH_AUTH_SOCK"); hasSSHAuthSock {
-		sshAuthSock := fmt.Sprintf("SSH_AUTH_SOCK=%s", sshAuthSockVal)
-		cmdEnv = append(cmdEnv, sshAuthSock)
+	if sshAuthSockVal, hasSSHAuthSock := os.LookupEnv("SSH_AUTH_SOCK"); hasSSHAuthSock {
+		// Verify that the ssh agent unix socket exists and is a unix socket.
+		st, err := os.Stat(sshAuthSockVal)
+		if err == nil && st.Mode()&os.ModeSocket != 0 {
+			sshAuthSock := fmt.Sprintf("SSH_AUTH_SOCK=%s", sshAuthSockVal)
+			cmdEnv = append(cmdEnv, sshAuthSock)
+		}
 	}
 
 	// add Windows specific ENV VARS

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -185,6 +185,11 @@ func PrepareEnv(gopath string) []string {
 		gitSSHCmd,
 	}
 
+	if sshAuthSockVal, hasSSHAuthSock := os.Getenv("SSH_AUTH_SOCK"); hasSSHAuthSock {
+		sshAuthSock := fmt.Sprintf("SSH_AUTH_SOCK=%s", sshAuthSockVal)
+		cmdEnv = append(cmdEnv, sshAuthSock)
+	}
+
 	// add Windows specific ENV VARS
 	if runtime.GOOS == "windows" {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("USERPROFILE=%s", os.Getenv("USERPROFILE")))


### PR DESCRIPTION
When running locally, it's convenient to use a user's ssh-agent. For
that to work, we need to propagate SSH_AUTH_SOCK.

**What is the problem I am trying to address?**

Not all SSH keys are stored as files without passwords in `~/.ssh`. It is quite convenient to use `ssh-agent` (or `gpg-agent` in `ssh-agent` mode) to provide limited access to keys without having to enter the SSH key every time. (most notably when running on a workstation/laptop)

This is most useful when running `athens` as a docker container in the background.

**How is the fix applied?**

Mention briefly how you have applied the fix.

`openssh` generally handles the `SSH_AUTH_SOCK` environment variable automatically, so if it is present in the environment of `go mod download`, ssh-agent-based public key auth should just work.

I verified this locally on my machine with my company's github-enterprise setup.
