### PR TITLE
pkg/config: ensure port format

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,6 +168,7 @@ func envOverride(config *Config) error {
 	if config.Port == "" {
 		config.Port = defaultPort
 	}
+	config.Port = ensurePortFormat(config.Port)
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -123,8 +123,8 @@ func TestEnvOverridesPORT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Env override failed: %v", err)
 	}
-	if conf.Port != "5000" {
-		t.Fatalf("expected PORT env to be 5000 but got %v", conf.Port)
+	if conf.Port != ":5000" {
+		t.Fatalf("expected PORT env to be :5000 but got %v", conf.Port)
 	}
 }
 


### PR DESCRIPTION
Ensures that if the PORT doesn't have `:` it will add it. I added the logic and tests in a previous PR but this one makes the call now that it works well. 