### PR TITLE
Dockerfile: wrap athens with tini

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -12,6 +12,11 @@ ARG VERSION="unset"
 
 RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE" -o /bin/athens-proxy ./cmd/proxy
 
+# Add tini, see https://github.com/gomods/athens/issues/1155 for details.
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
+RUN chmod +x /tini
+
 FROM alpine
 
 ENV GO111MODULE=on
@@ -19,6 +24,7 @@ ENV GO111MODULE=on
 COPY --from=builder /bin/athens-proxy /bin/athens-proxy
 COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/config.toml
 COPY --from=builder /usr/local/go/bin/go /bin/go
+COPY --from=builder /tini /bin/tini
 
 RUN apk add --update bzr git mercurial openssh-client subversion procps fossil && \
 	mkdir -p /usr/local/go
@@ -26,5 +32,7 @@ RUN apk add --update bzr git mercurial openssh-client subversion procps fossil &
 ENV GO_ENV=production
 
 EXPOSE 3000
+
+ENTRYPOINT [ "tini", "--" ]
 
 CMD ["athens-proxy", "-config_file=/config/config.toml"]


### PR DESCRIPTION
Athens runs `go mod download` which internally runs different VCS binaries such as `git` and `bzr`. 

Therefore, Athens doesn't have control over those binaries leaving defunct processes behind. 

The user can run the Athens docker container with `--init`, but chances are high that our users will miss to put this flag when they run their containers. 

From looking around the tini repo, I don't see any significant overhead or side effects that we should be aware of. But, we should definitely keep an eye out for those. 

Fixes https://github.com/gomods/athens/issues/1155