### PR TITLE
Fix for issue #1192

### DIFF
--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -165,6 +165,10 @@ func PrepareEnv(gopath string) []string {
 	httpProxy := fmt.Sprintf("HTTP_PROXY=%s", os.Getenv("HTTP_PROXY"))
 	httpsProxy := fmt.Sprintf("HTTPS_PROXY=%s", os.Getenv("HTTPS_PROXY"))
 	noProxy := fmt.Sprintf("NO_PROXY=%s", os.Getenv("NO_PROXY"))
+	// need to also check the lower case version of just these three env variables
+	httpProxyLower := fmt.Sprintf("http_proxy=%s", os.Getenv("http_proxy"))
+	httpsProxyLower := fmt.Sprintf("https_proxy=%s", os.Getenv("https_proxy"))
+	noProxyLower := fmt.Sprintf("no_proxy=%s", os.Getenv("no_proxy"))
 	gopathEnv := fmt.Sprintf("GOPATH=%s", gopath)
 	cacheEnv := fmt.Sprintf("GOCACHE=%s", filepath.Join(gopath, "cache"))
 	gitSSH := fmt.Sprintf("GIT_SSH=%s", os.Getenv("GIT_SSH"))
@@ -181,6 +185,9 @@ func PrepareEnv(gopath string) []string {
 		httpProxy,
 		httpsProxy,
 		noProxy,
+		httpProxyLower,
+		httpsProxyLower,
+		noProxyLower,
 		gitSSH,
 		gitSSHCmd,
 	}
@@ -202,7 +209,6 @@ func PrepareEnv(gopath string) []string {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEDRIVE=%s", os.Getenv("HOMEDRIVE")))
 		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEPATH=%s", os.Getenv("HOMEPATH")))
 	}
-
 	return cmdEnv
 }
 

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -209,6 +209,7 @@ func PrepareEnv(gopath string) []string {
 		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEDRIVE=%s", os.Getenv("HOMEDRIVE")))
 		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEPATH=%s", os.Getenv("HOMEPATH")))
 	}
+
 	return cmdEnv
 }
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

This PR addresses #1192 and adds the lowercase version of unix Proxy environment variables. This makes Athens work the same way that the go binary does supporting both UPPER and lower case proxy environment variables.


