### PR TITLE
Add gitconfig support for helm chart

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.14
+version: 0.2.15
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -46,6 +46,7 @@ Available options:
 - [Ingress Resource](https://docs.gomods.io/install/install-on-kubernetes/#ingress-resource)
 - [Upstream module repository](https://docs.gomods.io/install/install-on-kubernetes/#upstream-module-repository)
 - [.netrc file support](https://docs.gomods.io/install/install-on-kubernetes/#netrc-file-support)
+- [gitconfig support](https://docs.gomods.io/install/install-on-kubernetes/#gitconfig-support)
 
 ### Pass extra configuration environment variables
 

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -170,6 +170,11 @@ spec:
         - name: ssh-keys
           mountPath: /ssh-keys
         {{- end }}
+        {{- if .Values.gitconfig.enabled }}
+        - name: gitconfig
+          mountPath: "/etc/gitconfig"
+          subPath: "gitconfig"
+        {{- end }}
       {{- with .Values.resources }}
         resources:
 {{ toYaml . | indent 10 }}
@@ -201,6 +206,14 @@ spec:
       - name: ssh-git-servers-secret
         secret:
           secretName: {{ template "fullname" . }}-ssh-git-servers
+      {{- end }}
+      {{- if .Values.gitconfig.enabled }}
+      - name: gitconfig
+        secret:
+          secretName: {{ .Values.gitconfig.secretName }}
+          items:
+          - key: {{ .Values.gitconfig.secretKey }}
+            path: "gitconfig"
       {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -71,6 +71,15 @@ netrc:
   enabled: false
   existingSecret: netrcsecret
 
+# gitconfig section provides a way to inject git config file to make athens able to fetch modules from private git repos.
+gitconfig:
+  # By default, gitconfig is disabled.
+  enabled: false
+  # Name of the kubernetes secret (in the same namespace as athens-proxy) that contains git config.
+  secretName: athens-proxy-gitconfig
+  # Key in the kubernetes secret that contains git config data.
+  secretKey: gitconfig
+
 upstreamProxy:
   # This is where you can set the URL for the upstream module repository.
   # If 'enabled' is set to true, Athens will try to download modules from the upstream when it doesn't find them in its own storage.

--- a/docs/content/install/install-on-kubernetes.md
+++ b/docs/content/install/install-on-kubernetes.md
@@ -257,3 +257,34 @@ In order to instruct athens to fetch and use the secret, `netrc.enabled` flag mu
 ```console
 helm install gomods/athens-proxy -n athens --namespace athens --set netrc.enabled=true
 ```
+
+### gitconfig support
+
+A [gitconfig](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration) file can be shared as a secret to allow
+the access to modules in private git repositories. For example, you can configure access to private repositories via HTTPS
+using personal access tokens on GitHub, GitLab and other git services.
+
+First of all, prepare your gitconfig file:
+
+```console
+cat << EOF > /tmp/gitconfig
+[url "https://user:token@git.example.com/"]
+    insteadOf = ssh://git@git.example.com/
+    insteadOf = https://git.example.com/
+EOF
+```
+
+Next, create the secret using the file created above:
+
+```console
+kubectl create secret generic athens-proxy-gitconfig --from-file=gitconfig=/tmp/gitconfig
+```
+
+In order to instruct athens to use the secret, set appropriate flags (or parameters in `values.yaml`):
+
+```console
+helm install gomods/athens-proxy --name athens --namespace athens \
+    --set gitconfig.enabled=true \
+    --set gitconfig.secretName=athens-proxy-gitconfig \
+    --set gitconfig.secretKey=gitconfig
+```


### PR DESCRIPTION
This commit adds support for gitconfig in the athens helm chart.

Reflects https://docs.gomods.io/configuration/authentication/#altassian-bitbucket-and-ssh-secured-git-vcs-s


**What is the problem I am trying to address?**

We deploy athens to Kubernetes using helm chart, and we want it to be able to access our private repositories with modules.

**How is the fix applied?**

This patch allows injecting any custom git config to the athens container. This is kind of similar to netrc support, but in our case gitconfig support would provide more flexible configuration options.

<!-- 
example: Fixes #123
-->
