### PR TITLE
Trying out appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+build: off
+
+clone_folder: c:\gopath\src\github.com\gomods\athens
+
+environment:
+  GOPATH: c:\gopath
+  GO111MODULE: on
+
+stack: go 1.12
+
+test_script:
+  - go test -mod=vendor ./...


### PR DESCRIPTION
**What is the problem I am trying to address?**

Azure pipelines VMs does not have go 1.12 and using docker is very slow (12 min).
Appveyor VM images contain go 1.12 and the build takes 1:30min.

**How is the fix applied?**
We can try out appveyor and see if it works for us.
