### PR TITLE
Clear up language and remove duplicate content

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -74,5 +74,4 @@ To try out tracing with Jaeger, do the following:
 - Run the walkthrough tutorial
 - Open `http://localhost:16686/search`
 
-Observability is not a hard requirement for the Athens proxy. So, if the infrastructure is not properly set up, they will fail with an information log. For eg. if Jaeger is not running / if the wrong URL to the exporter is provided, proxy will continue to run. However, it will not collect any traces or metrics (when the exporter backend is unavailable).
-
+Observability is not a hard requirement for the Athens proxy. So, if the infrastructure is not properly set up, it will fail with an information log. For example, if Jaeger is not running or if the wrong URL to the exporter is provided, the proxy will continue to run. However, it will not collect any traces or metrics while the exporter backend is unavailable.

--- a/docs/content/install/install-on-kubernetes.md
+++ b/docs/content/install/install-on-kubernetes.md
@@ -94,12 +94,6 @@ $ helm install gomods/athens-proxy -n athens --namespace athens
 
 This will deploy a single Athens instance in the `default` namespace with `disk` storage enabled. Additionally, a `ClusterIP` service will be created.
 
-By default, the chart will install Athens with a replica count of 1. To change this, change the `replicaCount` value:
-
-```console
-helm install gomods/athens-proxy -n athens --namespace athens --set replicaCount=3
-```
-
 ## Advanced Configuration
 
 ### Replicas


### PR DESCRIPTION
**What is the problem I am trying to address?**

Describe the issue you have been trying to solve.

> There were some sentences in the "Is there support for monitoring and observability for Proxy?" FAQ that were written too informally.
> 
> Additionally, documentation for installing Athens on Kubernetes had duplicate directions.
<img width="1062" alt="Screen Shot 2019-04-29 at 6 16 24 PM" src="https://user-images.githubusercontent.com/7443383/56936211-f8a41c00-6aaa-11e9-9b95-59f5668c38d2.png">

**How is the fix applied?**

Mention briefly how you have applied the fix.

> I re-worded the sentences and removed the duplicate lines.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #

<!-- 
example: Fixes #123
-->

> There is no associated issue with this fix/pull request.
