### PR TITLE
Makefile: Add `make help` to display documented cmds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 VERSION = "unset"
 DATE=$(shell date -u +%Y-%m-%d-%H:%M:%S-%Z)
 .PHONY: build
-build:
+build: ## build the athens proxy
 	cd cmd/proxy && go build
 
-build-ver:
+build-ver: ## build the athens proxy with version number
 	GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -ldflags "-X github.com/gomods/athens/pkg/build.version=$(VERSION) -X github.com/gomods/athens/pkg/build.buildDate=$(DATE)" -o athens ./cmd/proxy
 
 # The build-image step creates a docker image that has all the tools required
@@ -14,7 +14,7 @@ build-image:
 	docker build -t athens-build ./scripts/build-image
 
 .PHONY: run
-run:
+run: ## run the athens proxy with dev configs
 	cd ./cmd/proxy && go run . -config_file ../../config.dev.toml
 
 .PHONY: run-docker
@@ -26,7 +26,7 @@ run-docker-teardown:
 	docker-compose -p athensdockerdev down
 
 .PHONY: docs
-docs:
+docs: ## build the docs docker image
 	docker build -t gomods/hugo -f docs/Dockerfile .
 
 .PHONY: setup-dev-env
@@ -35,18 +35,18 @@ setup-dev-env:
 	$(MAKE) dev
 
 .PHONY: verify
-verify:
+verify: ## verify athens codebase
 	./scripts/check_gofmt.sh
 	./scripts/check_golint.sh
 	./scripts/check_deps.sh
 	./scripts/check_conflicts.sh
 
 .PHONY: test-unit
-test-unit:
+test-unit: ## run unit tests with race detector and code coverage enabled
 	./scripts/test_unit.sh
 
 .PHONY: test-unit-docker
-test-unit-docker:
+test-unit-docker: ## run unit tests with docker
 	docker-compose -p athensunit up --exit-code-from=testunit --build testunit
 	docker-compose -p athensunit down
 
@@ -101,3 +101,7 @@ down:
 .PHONY: dev-teardown
 dev-teardown:
 	docker-compose -p athensdev down -v
+
+.PHONY: help
+help: ## display help page
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
**What is the problem I am trying to address?**
Add `make help` to display documented `make` cmds.
```
$ make help
build                          build the athens proxy
build-ver                      build the athens proxy with version number
docs                           build the docs docker image
help                           display help page
run                            run the athens proxy with dev configs
test-unit-docker               run unit tests with docker
test-unit                      run unit tests with race detector and code coverage enabled
verify                         verify athens codebase
```

**How is the fix applied?**

The help cmd is copied from Jess Frazelle's (jessfraz)
dotfile repo, see https://github.com/jessfraz/dotfiles/blob/master/Makefile#L68

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes no Issue.
Add help description by adding `## <cmd description>` after make cmd.
For example:
```
.PHONY: run
run: ## run the athens proxy with dev configs
[...]
```

**Note**
Undocumented cmds do not get displayed with `make help`.