### PR TITLE
Remove unnecessary service-account.yaml from Helm chart

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/service-account.yaml
+++ b/charts/athens-proxy/templates/service-account.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"


### PR DESCRIPTION
This file defined a duplicate (but empty) service. Fixes #1228.
