### PR TITLE
Updating english docs to indicate the presence of hosted public proxies

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.6
+version: 0.2.7
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -53,7 +53,11 @@ netrc:
 upstreamProxy:
   # This is where you can set the URL for the upstream module repository.
   # If 'enabled' is set to true, Athens will try to download modules from the upstream when it doesn't find them in its own storage.
-  # You can use 'https://gocenter.io' to use JFrog's GoCenter as an upstream here, or you can also use another Athens server as well.
+  # Here's a non-exhaustive list of options you can set here:
+  #
+  # - https://gocenter.io
+  # - https://proxy.golang.org
+  # - another Athens server
   enabled: false
   url: "https://gocenter.io"
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -30,6 +30,8 @@ Athens is easy to run yourself. We give you a few options:
 
 We also run an experimental version of Athens so you can get started without even installing anything. To get started, set `GOPROXY="https://athens.azurefd.net"`.
 
+>This is not a production-ready proxy deployment, though. Please deploy your own Athens instance for your builds. _If you need a hosted proxy for public code, consider using either `https://gocenter.io` or `https://proxy.golang.org`_.
+
 **[Like what you hear? Try Athens Now!](/try-out)**
 
 

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -17,7 +17,7 @@ In Athens we support many storage options. In this section we'll describe how th
 
  - [Storage](/configuration/storage)
 
- ### Upstream proxy
+### Upstream proxy
  In this section we'll describe how the upstream proxy can be configured to fetch all modules from a Go Modules Repository such as [GoCenter](https://gocenter.io), [The Go Module Mirror](https://proxy.golang.org), or another Athens Server.
 
   - [Upstream](/configuration/upstream)

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -17,9 +17,8 @@ In Athens we support many storage options. In this section we'll describe how th
 
  - [Storage](/configuration/storage)
 
-
-### Upstream proxy
-In this section we'll describe how the upstream proxy can be configured to fetch all modules from a Go Modules Repository such as [GoCenter](https://gocenter.io) or another Athens Server.
+ ### Upstream proxy
+ In this section we'll describe how the upstream proxy can be configured to fetch all modules from a Go Modules Repository such as [GoCenter](https://gocenter.io), [The Go Module Mirror](https://proxy.golang.org), or another Athens Server.
 
   - [Upstream](/configuration/upstream)
 

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -18,7 +18,7 @@ In Athens we support many storage options. In this section we'll describe how th
  - [Storage](/configuration/storage)
 
 ### Upstream proxy
- In this section we'll describe how the upstream proxy can be configured to fetch all modules from a Go Modules Repository such as [GoCenter](https://gocenter.io), [The Go Module Mirror](https://proxy.golang.org), or another Athens Server.
+In this section we'll describe how the upstream proxy can be configured to fetch all modules from a Go Modules Repository such as [GoCenter](https://gocenter.io), [The Go Module Mirror](https://proxy.golang.org), or another Athens Server.
 
   - [Upstream](/configuration/upstream)
 

--- a/docs/content/configuration/upstream.md
+++ b/docs/content/configuration/upstream.md
@@ -19,6 +19,7 @@ Additionally in the current or new config file, set the following parameters as 
     FilterFile = "/usr/local/lib/FilterForGoCenter"
     GlobalEndpoint = "https://<url_to_uptream>"
     # To use GoCenter for example, replace <url_to_upstream> with gocenter.io
+    # You can also use https://proxy.golang.org to use the Go Module mirror
     ```
 1. Restart Athens specifying the updated current or new config file.
 

--- a/docs/content/install/install-on-kubernetes.md
+++ b/docs/content/install/install-on-kubernetes.md
@@ -187,7 +187,11 @@ helm install gomods/athens-proxy -n athens --namespace athens -f override-values
 
 You can set the `URL` for the [upstream module repository](https://docs.gomods.io/configuration/upstream/) then Athens will try to download modules from the upstream when it doesn't find them in its own storage.
 
-You can use `https://gocenter.io` to use JFrog's GoCenter as an upstream here, or you can also use another Athens server as well.
+You have a few good options for what you can set as an upstream:
+
+-  `https://gocenter.io` to use JFrog's GoCenter
+-  `https://proxy.golang.org` to use the Go Module Mirror
+-  The URL to any other Athens server
 
 The example below shows you how to set GoCenter up as upstream module repository:
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

Various docs don't mention public managed proxies like gocenter.io or proxy.golang.org

**How is the fix applied?**

I added that :)

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1235