### PR TITLE
Fixes indentation in documentation

### DIFF
--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -18,8 +18,8 @@ In Athens we support many storage options. In this section we'll describe how th
  - [Storage](/configuration/storage)
 
 
- ### Upstream proxy
- In this section we'll describe how the upstream proxy can be configured to fetch all modules from a Go Modules Repository such as [GoCenter](https://gocenter.io) or another Athens Server.
+### Upstream proxy
+In this section we'll describe how the upstream proxy can be configured to fetch all modules from a Go Modules Repository such as [GoCenter](https://gocenter.io) or another Athens Server.
 
   - [Upstream](/configuration/upstream)
 


### PR DESCRIPTION
Fixed indentention in docs/content/configuration/_index.md so the page
is correctly generated by Hugo.

**What is the problem I am trying to address?**

The documentation for the [configuration page](https://docs.gomods.io/configuration/) has a formatting issue:

![image](https://user-images.githubusercontent.com/158845/58419383-c1fdf900-808a-11e9-974e-b3c462291670.png)

**How is the fix applied?**

Removed whitespace before the title.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Removed whitespace before the title.
