### PR TITLE
fix:  '/catalog' endpoint, which didn't allow fetch URL query parameters

### DIFF
--- a/cmd/proxy/actions/catalog.go
+++ b/cmd/proxy/actions/catalog.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/paths"
 	"github.com/gomods/athens/pkg/storage"
-	"github.com/gorilla/mux"
 )
 
 const defaultPageSize = 1000
@@ -28,10 +27,12 @@ func catalogHandler(s storage.Backend) http.HandlerFunc {
 			w.WriteHeader(errors.KindNotImplemented)
 			return
 		}
+
 		lggr := log.EntryFromContext(r.Context())
-		vars := mux.Vars(r)
-		token := vars["token"]
-		pageSize, err := getLimitFromParam(vars["pagesize"])
+		urlQuery := r.URL.Query()
+		token := urlQuery.Get("token")
+
+		pageSize, err := getLimitFromParam(urlQuery.Get("pagesize"))
 		if err != nil {
 			lggr.SystemErr(err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -53,6 +54,8 @@ func catalogHandler(s storage.Backend) http.HandlerFunc {
 	return http.HandlerFunc(f)
 }
 
+// getLimitFromParam converts a URL query parameter into an int
+// otherwise converts defaultPageSize constant
 func getLimitFromParam(param string) (int, error) {
 	if param == "" {
 		return defaultPageSize, nil

--- a/cmd/proxy/actions/catalog.go
+++ b/cmd/proxy/actions/catalog.go
@@ -29,10 +29,9 @@ func catalogHandler(s storage.Backend) http.HandlerFunc {
 		}
 
 		lggr := log.EntryFromContext(r.Context())
-		urlQuery := r.URL.Query()
-		token := urlQuery.Get("token")
+		token := r.FormValue("token")
 
-		pageSize, err := getLimitFromParam(urlQuery.Get("pagesize"))
+		pageSize, err := getLimitFromParam(r.FormValue("pagesize"))
 		if err != nil {
 			lggr.SystemErr(err)
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
**What is the problem I am trying to address?**
Fixed `/catalog` endpoint which didn't retrieve correctly `token `and `pagesize` parameters.

**How is the fix applied?**

In order to correctly fetch `pagesize` and `token` parameters, I had replaced to `r.Query()` values instead of `mux.Vars()`.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1236 