### PR TITLE
Add "git clone" to command for checking out the code in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,7 +11,7 @@ See our [Contributing Guide](CONTRIBUTING.md) for tips on how to submit a pull r
 If you haven't done that, please do with the below command before you proceed:
 
 ```console
-$ https://github.com/gomods/athens.git
+$ git clone https://github.com/gomods/athens.git
 ```
 
 ### Go version


### PR DESCRIPTION
**What is the problem I am trying to address?**

I found `git clone` missing in the command for checking out Athens code in `DEVELOPMENT.md`.

**How is the fix applied?**

Just add it to the document.
