### PR TITLE
Set build-args - VERSION

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -87,6 +87,9 @@ steps:
       - ${DRONE_TAG}
       - latest
     dockerfile: cmd/proxy/Dockerfile
+    build_args:
+      - VERSION=${DRONE_TAG}
+
   when:
     event:
       - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -69,6 +69,8 @@ steps:
     tags:
       - canary
     dockerfile: cmd/proxy/Dockerfile
+    build_args:
+      - VERSION=${DRONE_COMMIT}
   when:
     branch:
       - master


### PR DESCRIPTION
**What is the problem I am trying to address?**

#1253 mentions that the `athens-proxy -version` returns `unset`
This is bc we are not setting the VERSION build-arg in our CI

**How is the fix applied?**

http://plugins.drone.io/drone-plugins/drone-docker/ allows using build_arg
