### PR TITLE
Fix #1268: Launch tini as subreaper

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -28,6 +28,6 @@ ENV GO_ENV=production
 
 EXPOSE 3000
 
-ENTRYPOINT [ "/sbin/tini", "--" ]
+ENTRYPOINT [ "/sbin/tini", "-s", "--" ]
 
 CMD ["athens-proxy", "-config_file=/config/config.toml"]


### PR DESCRIPTION
Added the `-s` parameter to launch `tini` as subreaper by default.

Fixes #1268