### PR TITLE
Fixes helm chart volumeMounts if only netrc is enabled

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.8
+version: 0.2.10
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         {{- end }}
         {{- if .Values.netrc.enabled }}
         - name: ATHENS_NETRC_PATH
-          value: "/etc/netrc/netrc"
+          value: "/etc/netrc/.netrc"
         {{- end }}
         {{- if .Values.upstreamProxy.enabled }}
         - name: ATHENS_FILTER_FILE
@@ -91,8 +91,10 @@ spec:
         {{- end }}
         ports:
         - containerPort: 3000
-        {{- if eq .Values.storage.type "disk" }}
+        {{- if or (eq .Values.storage.type "disk") .Values.upstreamProxy.enabled .Values.netrc.enabled }}
         volumeMounts:
+        {{- end }}
+        {{- if eq .Values.storage.type "disk" }}
         - name: storage-volume
           mountPath: {{ .Values.storage.disk.storageRoot | quote }}
         {{- end }}


### PR DESCRIPTION
Fixes a couple issues with the Helm chart regarding the netrc file.
* If only `netrc` is enabled but disk storage is disabled, previously the `volumeMounts` key of the deployment would not render causing the netrc mount to show up under the `ports` key.
* The documentation describes creating a Kubernetes secret with a key of `.netrc` but the chart was mounting the secret at `/etc/netrc/netrc` which is inconsistent with the docs.