### PR TITLE
minio : Use no. of objects for Exists check

### DIFF
--- a/pkg/storage/minio/checker.go
+++ b/pkg/storage/minio/checker.go
@@ -19,15 +19,25 @@ func (v *storageImpl) Exists(ctx context.Context, module, version string) (bool,
 	defer span.End()
 	versionedPath := v.versionLocation(module, version)
 	modPath := fmt.Sprintf("%s/go.mod", versionedPath)
-	_, err := v.minioClient.StatObject(v.bucketName, modPath, minio.StatObjectOptions{})
+	infoPath := fmt.Sprintf("%s/%s.info", versionedPath, version)
+	zipPath := fmt.Sprintf("%s/source.zip", versionedPath)
 
-	if minio.ToErrorResponse(err).Code == minioErrorCodeNoSuchKey {
-		return false, nil
+	var count int
+	objectCh, _ := l.minioCore.ListObjectsV2(l.bucketName, versionedPath, "", false, "", 0, "")
+	for _, object := range objectCh.Contents {
+		if object.Err != nil {
+			return false, errors.E(op, object.Err, errors.M(module), , errors.V(version))
+		}
+		
+		switch object.Key {
+		case infoPath:
+			count++
+		case modPath:
+			count++
+		case zipPath:
+			count++
+		}
 	}
 
-	if err != nil {
-		return false, errors.E(op, err, errors.M(module), errors.V(version))
-	}
-
-	return true, nil
+	return count == 3, nil
 }

--- a/pkg/storage/minio/checker.go
+++ b/pkg/storage/minio/checker.go
@@ -22,7 +22,10 @@ func (v *storageImpl) Exists(ctx context.Context, module, version string) (bool,
 	zipPath := fmt.Sprintf("%s/source.zip", versionedPath)
 
 	var count int
-	objectCh, _ := v.minioCore.ListObjectsV2(v.bucketName, versionedPath, "", false, "", 0, "")
+	objectCh, err := v.minioCore.ListObjectsV2(v.bucketName, versionedPath, "", false, "", 0, "")
+	if err != nil {
+		return false, errors.E(op, err, errors.M(module), errors.V(version))
+	}
 	for _, object := range objectCh.Contents {
 		if object.Err != nil {
 			return false, errors.E(op, object.Err, errors.M(module), errors.V(version))

--- a/pkg/storage/minio/checker.go
+++ b/pkg/storage/minio/checker.go
@@ -22,7 +22,7 @@ func (v *storageImpl) Exists(ctx context.Context, module, version string) (bool,
 	zipPath := fmt.Sprintf("%s/source.zip", versionedPath)
 
 	var count int
-	objectCh, _ := v.minioCore.ListObjectsV2(l.bucketName, versionedPath, "", false, "", 0, "")
+	objectCh, _ := v.minioCore.ListObjectsV2(v.bucketName, versionedPath, "", false, "", 0, "")
 	for _, object := range objectCh.Contents {
 		if object.Err != nil {
 			return false, errors.E(op, object.Err, errors.M(module), errors.V(version))

--- a/pkg/storage/minio/checker.go
+++ b/pkg/storage/minio/checker.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/observ"
-	minio "github.com/minio/minio-go"
 )
 
 const (
@@ -23,12 +22,12 @@ func (v *storageImpl) Exists(ctx context.Context, module, version string) (bool,
 	zipPath := fmt.Sprintf("%s/source.zip", versionedPath)
 
 	var count int
-	objectCh, _ := l.minioCore.ListObjectsV2(l.bucketName, versionedPath, "", false, "", 0, "")
+	objectCh, _ := v.minioCore.ListObjectsV2(l.bucketName, versionedPath, "", false, "", 0, "")
 	for _, object := range objectCh.Contents {
 		if object.Err != nil {
-			return false, errors.E(op, object.Err, errors.M(module), , errors.V(version))
+			return false, errors.E(op, object.Err, errors.M(module), errors.V(version))
 		}
-		
+
 		switch object.Key {
 		case infoPath:
 			count++

--- a/pkg/storage/minio/lister.go
+++ b/pkg/storage/minio/lister.go
@@ -18,8 +18,11 @@ func (l *storageImpl) List(ctx context.Context, module string) ([]string, error)
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 	searchPrefix := module + "/"
-	objectCh, _ := l.minioCore.ListObjectsV2(l.bucketName, searchPrefix, "", false, "", 0, "")
+	objectCh, err := l.minioCore.ListObjectsV2(l.bucketName, searchPrefix, "", false, "", 0, "")
 
+	if err != nil {
+		return nil, errors.E(op, err, errors.M(module))
+	}
 	for _, object := range objectCh.Contents {
 		if object.Err != nil {
 			return nil, errors.E(op, object.Err, errors.M(module))


### PR DESCRIPTION
What is the problem I am trying to address?
Currently our storage.Exists implementation checks only for the mod file. This can be problematic if i.e. zip or info uploads failed.

How is the fix applied?

I'm checking if the len of objects equals 3 (zip, mod, info)