### PR TITLE
add warning logs for situations where files are missing from a packag…

### DIFF
--- a/pkg/download/addons/with_pool.go
+++ b/pkg/download/addons/with_pool.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gomods/athens/pkg/download"
 	"github.com/gomods/athens/pkg/errors"
+	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/storage"
 )
 
@@ -64,13 +65,13 @@ func (p *withpool) List(ctx context.Context, mod string) ([]string, error) {
 	return vers, nil
 }
 
-func (p *withpool) Info(ctx context.Context, mod, ver string) ([]byte, error) {
+func (p *withpool) Info(ctx context.Context, mod, ver string, lggr log.Entry) ([]byte, error) {
 	const op errors.Op = "pool.Info"
 	var info []byte
 	var err error
 	done := make(chan struct{}, 1)
 	p.jobCh <- func() {
-		info, err = p.dp.Info(ctx, mod, ver)
+		info, err = p.dp.Info(ctx, mod, ver, lggr)
 		close(done)
 	}
 	<-done
@@ -96,13 +97,13 @@ func (p *withpool) Latest(ctx context.Context, mod string) (*storage.RevInfo, er
 	return info, nil
 }
 
-func (p *withpool) GoMod(ctx context.Context, mod, ver string) ([]byte, error) {
+func (p *withpool) GoMod(ctx context.Context, mod, ver string, lggr log.Entry) ([]byte, error) {
 	const op errors.Op = "pool.GoMod"
 	var goMod []byte
 	var err error
 	done := make(chan struct{}, 1)
 	p.jobCh <- func() {
-		goMod, err = p.dp.GoMod(ctx, mod, ver)
+		goMod, err = p.dp.GoMod(ctx, mod, ver, lggr)
 		close(done)
 	}
 	<-done
@@ -112,13 +113,13 @@ func (p *withpool) GoMod(ctx context.Context, mod, ver string) ([]byte, error) {
 	return goMod, nil
 }
 
-func (p *withpool) Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error) {
+func (p *withpool) Zip(ctx context.Context, mod, ver string, lggr log.Entry) (io.ReadCloser, error) {
 	const op errors.Op = "pool.Zip"
 	var zip io.ReadCloser
 	var err error
 	done := make(chan struct{}, 1)
 	p.jobCh <- func() {
-		zip, err = p.dp.Zip(ctx, mod, ver)
+		zip, err = p.dp.Zip(ctx, mod, ver, lggr)
 		close(done)
 	}
 	<-done

--- a/pkg/download/version_info.go
+++ b/pkg/download/version_info.go
@@ -20,7 +20,7 @@ func InfoHandler(dp Protocol, lggr log.Entry) http.Handler {
 			w.WriteHeader(errors.Kind(err))
 			return
 		}
-		info, err := dp.Info(r.Context(), mod, ver)
+		info, err := dp.Info(r.Context(), mod, ver, lggr)
 		if err != nil {
 			lggr.SystemErr(errors.E(op, err, errors.M(mod), errors.V(ver)))
 			w.WriteHeader(errors.Kind(err))

--- a/pkg/download/version_module.go
+++ b/pkg/download/version_module.go
@@ -20,7 +20,7 @@ func ModuleHandler(dp Protocol, lggr log.Entry) http.Handler {
 			w.WriteHeader(errors.Kind(err))
 			return
 		}
-		modBts, err := dp.GoMod(r.Context(), mod, ver)
+		modBts, err := dp.GoMod(r.Context(), mod, ver, lggr)
 		if err != nil {
 			err = errors.E(op, errors.M(mod), errors.V(ver), err)
 			lggr.SystemErr(err)

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -21,7 +21,7 @@ func ZipHandler(dp Protocol, lggr log.Entry) http.Handler {
 			w.WriteHeader(errors.Kind(err))
 			return
 		}
-		zip, err := dp.Zip(r.Context(), mod, ver)
+		zip, err := dp.Zip(r.Context(), mod, ver, lggr)
 		if err != nil {
 			lggr.SystemErr(err)
 			w.WriteHeader(errors.Kind(err))


### PR DESCRIPTION
…e in athens storage


**What is the problem I am trying to address?**

The file system storage currently checks for all three files (.mod, .zip, .info) exist and fails any one endpoint if they don't all exist. This results in the entire module being refreshed from vcs overwriting what ever is currently in Athens storage for this version of this module.

**How is the fix applied?**

The solution is to log a warning about what is happening when this one of these situations occurs.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1171

<!-- 
example: Fixes #123
-->
