### PR TITLE
[debug] allow to expose pprof via config

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -10,6 +10,8 @@ import (
 	"os/signal"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/gomods/athens/cmd/proxy/actions"
 	"github.com/gomods/athens/pkg/build"
 	"github.com/gomods/athens/pkg/config"
@@ -60,6 +62,15 @@ func main() {
 		}
 		close(idleConnsClosed)
 	}()
+
+	if conf.EnablePprof {
+		go func() {
+			// pprof to be exposed on a different port than the application for security matters, not to expose profiling data and avoid DoS attacks (profiling slows down the service)
+			// https://www.farsightsecurity.com/txt-record/2016/10/28/cmikk-go-remote-profiling/
+			log.Printf("Starting `pprof` at port %v", conf.PprofPort)
+			log.Fatal(http.ListenAndServe(conf.PprofPort, nil))
+		}()
+	}
 
 	log.Printf("Starting application at port %v", conf.Port)
 	if cert != "" && key != "" {

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -43,6 +43,14 @@ LogLevel = "debug"
 # Env override: ATHENS_CLOUD_RUNTIME
 CloudRuntime = "none"
 
+# EnablePprof specifies if the pprof endpoints should be exposed.
+# Note that this option is not meant to be activated forever on a server
+# and should be desactivated once not needed.
+EnablePprof = false
+
+# PprofPort specifies the port on which pprof will be exposed if activated.
+PprofPort = ":3001"
+
 # The filename for the include exclude filter.
 # Env override: ATHENS_FILTER_FILE
 #

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	ProtocolWorkers  int       `validate:"required" envconfig:"ATHENS_PROTOCOL_WORKERS"`
 	LogLevel         string    `validate:"required" envconfig:"ATHENS_LOG_LEVEL"`
 	CloudRuntime     string    `validate:"required" envconfig:"ATHENS_CLOUD_RUNTIME"`
+	EnablePprof      bool      `envconfig:"ATHENS_ENABLE_PPROF"`
+	PprofPort        string    `envconfig:"ATHENS_PPROF_PORT"`
 	FilterFile       string    `envconfig:"ATHENS_FILTER_FILE"`
 	TraceExporterURL string    `envconfig:"ATHENS_TRACE_EXPORTER_URL"`
 	TraceExporter    string    `envconfig:"ATHENS_TRACE_EXPORTER"`
@@ -78,6 +80,8 @@ func defaultConfig() *Config {
 		ProtocolWorkers:  30,
 		LogLevel:         "debug",
 		CloudRuntime:     "none",
+		EnablePprof:      false,
+		PprofPort:        ":3001",
 		StatsExporter:    "prometheus",
 		TimeoutConf:      TimeoutConf{Timeout: 300},
 		StorageType:      "memory",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -78,6 +78,8 @@ func TestEnvOverrides(t *testing.T) {
 		StorageType:    "minio",
 		GlobalEndpoint: "mytikas.gomods.io",
 		Port:           ":7000",
+		EnablePprof:    false,
+		PprofPort:      ":3001",
 		BasicAuthUser:  "testuser",
 		BasicAuthPass:  "testpass",
 		ForceSSL:       true,
@@ -256,6 +258,8 @@ func TestParseExampleConfig(t *testing.T) {
 		StorageType:      "memory",
 		GlobalEndpoint:   "http://localhost:3001",
 		Port:             ":3000",
+		EnablePprof:      false,
+		PprofPort:        ":3001",
 		BasicAuthUser:    "",
 		BasicAuthPass:    "",
 		Storage:          expStorage,
@@ -297,6 +301,8 @@ func getEnvMap(config *Config) map[string]string {
 	envVars["ATHENS_STORAGE_TYPE"] = config.StorageType
 	envVars["ATHENS_GLOBAL_ENDPOINT"] = config.GlobalEndpoint
 	envVars["ATHENS_PORT"] = config.Port
+	envVars["ATHENS_ENABLE_PPROF"] = strconv.FormatBool(config.EnablePprof)
+	envVars["ATHENS_PPROF_PORT"] = config.PprofPort
 	envVars["BASIC_AUTH_USER"] = config.BasicAuthUser
 	envVars["BASIC_AUTH_PASS"] = config.BasicAuthPass
 	envVars["PROXY_FORCE_SSL"] = strconv.FormatBool(config.ForceSSL)


### PR DESCRIPTION



**What is the problem I am trying to address?**

This CL allows to activate `pprof` when needed to investigate any potential performances issues and / or proceed to profilings.

**How is the fix applied?**

Introducing two new configuration params
allowing to activate pprof.
- `ATHENS_ACTIVATE_DEBUG_HANDLER`
- `ATHENS_DEBUG_HANDLER_PORT`

If `ATHENS_ACTIVATE_DEBUG_HANDLER` is set to `true` then `pprof` is started on the `ATHENS_DEBUG_HANDLER_PORT` port which is ideally different from the application port for security reasons as stated [here](https://mmcloughlin.com/posts/your-pprof-is-showing).

`pprof` won't be exposed by default.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1177
