### PR TITLE
[helm-chart] Adding support for minio as storage-backend

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.11
+version: 0.2.12
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.12
+version: 0.2.13
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -91,6 +91,23 @@ spec:
         - name: AWS_SESSION_TOKEN
           value: {{ .Values.storage.s3.session_token | quote }}
         {{- end }}
+        {{- else if eq .Values.storage.type "minio" }}
+        {{- if .Values.storage.minio.endpoint }}
+        - name: ATHENS_MINIO_ENDPOINT
+          value: {{ .Values.storage.minio.endpoint | quote }}
+        {{- end }}
+        {{- if .Values.storage.minio.accessKey }}
+        - name: ATHENS_MINIO_ACCESS_KEY_ID
+          value: {{ .Values.storage.minio.accessKey | quote }}
+        {{- end }}
+        {{- if .Values.storage.minio.secretKey }}
+        - name: ATHENS_MINIO_SECRET_ACCESS_KEY
+          value: {{ .Values.storage.minio.secretKey | quote }}
+        {{- end }}
+        {{- if .Values.storage.minio.bucket }}
+        - name: ATHENS_MINIO_BUCKET_NAME
+          value: {{ .Values.storage.minio.bucket | quote }}
+        {{- end }}
         {{- end }}
         {{- if .Values.netrc.enabled }}
         - name: ATHENS_NETRC_PATH

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -32,7 +32,7 @@ ingress:
   tls:
 
 storage:
-  type: minio
+  type: disk
   disk:
     storageRoot: "/var/lib/athens"
     persistence:

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -32,7 +32,7 @@ ingress:
   tls:
 
 storage:
-  type: disk
+  type: minio
   disk:
     storageRoot: "/var/lib/athens"
     persistence:
@@ -49,6 +49,12 @@ storage:
     region: ""
     bucket: ""
     useDefaultConfiguration: true
+  minio:
+    # All these variables needs to be set when configuring athens to run with minio backend
+    endpoint: ""
+    accessKey: ""
+    secretKey: ""
+    bucket: ""
 
 # Extra environment variables to be passed
 # Commented lines below, show how to set username/password for basic auth

--- a/docs/content/install/install-on-kubernetes.md
+++ b/docs/content/install/install-on-kubernetes.md
@@ -152,6 +152,17 @@ variables, shared credentials files, and EC2 instance credentials. To manually s
 helm install gomods/athens-proxy -n athens --namespace athens --set storage.type=s3 --set storage.s3.region=<your-aws-region> --set storage.s3.bucket=<your-bucket>
 ```
 
+#### Minio Configuration
+
+To use S3 storage with Athens, set `storage.type` to `minio`. You need to set `storage.minio.endpoint` as the URL of your minio-installation.
+This URL can also be an kubernetes-internal one (e.g. something like `minio-service.default.svc`).
+You need to create a bucket inside your minio-installation or use an existing one. The bucket needs to be referenced in `storage.minio.bucket`.
+Last athens need authentication credentials for your minio in `storage.minio.accessKey` and `storage.minio.secretKey`.
+
+```
+helm install gomods/athens-proxy -n athens --namespace athens --set storage.type=minio --set storage.minio.endpoint=<your-minio-endpoint> --set storage.minio.bucket=<your-bucket> --set storage.minio.accessKey=<your-minio-access-key> --set storage.minio.secretKey=<your-minio-secret-key>
+```
+
 ### Kubernetes Service
 
 By default, a Kubernetes `ClusterIP` service is created for the Athens proxy. "ClusterIP" is sufficient in the case when the Athens proxy will be used from within the cluster. To expose Athens outside of the cluster, consider using a "NodePort" or "LoadBalancer" service. This can be changed by setting the `service.type` value when installing the chart. For example, to deploy Athens using a NodePort service, the following command could be used:


### PR DESCRIPTION
**What is the problem I am trying to address?**

In the current state of this helm-deployment there is no support for minio as storage-backend. Athens itself supports minio as storage backend, so the helm-chart should.

**How is the fix applied?**

I added some more variables inside the values.yaml file and implemented them into the deployment-template like the other storage-types did. Also, i added a new section explaining how to use minio as backend inside the docs.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

I did not find any issues regarding to this.
