### PR TITLE
[helm-chart] Basic-Auth support without environment-variables

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.11
+version: 0.2.12
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -50,10 +50,20 @@ spec:
           httpGet:
             path: "/healthz"
             port: 3000
+            {{- if .Values.basicAuth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: "Basic {{ (printf "%s:%s" .Values.basicAuth.user .Values.basicAuth.password | b64enc) }}"
+            {{- end }}
         readinessProbe:
           httpGet:
             path: "{{ template "readinessPath" . }}"
             port: 3000
+            {{- if .Values.basicAuth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: "Basic {{ (printf "%s:%s" .Values.basicAuth.user .Values.basicAuth.password | b64enc) }}"
+            {{- end }}
         env:
         - name: ATHENS_GOGET_WORKERS
         {{- if .Values.goGetWorkers }}
@@ -107,6 +117,12 @@ spec:
           value: {{ .Values.jaeger.url | quote }}
         - name: ATHENS_TRACE_EXPORTER
           value: "jaeger"
+        {{- end }}
+        {{- if .Values.basicAuth.enabled }}
+        - name: BASIC_AUTH_USER
+          value: "{{ default "gomod" .Values.basicAuth.user | quote }}"
+        - name: BASIC_AUTH_PASS
+          value: "{{ default "gomod" .Values.basicAuth.password | quote }}"
         {{- end }}
         ports:
         - containerPort: 3000

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             {{- if .Values.basicAuth.enabled }}
             httpHeaders:
               - name: Authorization
-                value: "Basic {{ (printf "%s:%s" .Values.basicAuth.user .Values.basicAuth.password | b64enc) }}"
+                value: "Basic {{ (printf "%s:%s" (default "gomod" .Values.basicAuth.user) (default "gomod" .Values.basicAuth.password) | b64enc) }}"
             {{- end }}
         readinessProbe:
           httpGet:
@@ -62,7 +62,7 @@ spec:
             {{- if .Values.basicAuth.enabled }}
             httpHeaders:
               - name: Authorization
-                value: "Basic {{ (printf "%s:%s" .Values.basicAuth.user .Values.basicAuth.password | b64enc) }}"
+                value: "Basic {{ (printf "%s:%s" (default "gomod" .Values.basicAuth.user) (default "gomod" .Values.basicAuth.password) | b64enc) }}"
             {{- end }}
         env:
         - name: ATHENS_GOGET_WORKERS

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -56,7 +56,7 @@ configEnvVars: {}
 
 # HTTP basic auth
 basicAuth:
-  enabled: true
+  enabled: false
   user: "some_user"
   password: "some_password"
 

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -51,13 +51,14 @@ storage:
     useDefaultConfiguration: true
 
 # Extra environment variables to be passed
-# Commented lines below, show how to set username/password for basic auth
 # You can add any new ones at the bottom
 configEnvVars: {}
-#  - name: BASIC_AUTH_USER
-#    value: "some_user"
-#  - name: BASIC_AUTH_PASS
-#    value: "some_password"
+
+# HTTP basic auth
+basicAuth:
+  enabled: true
+  user: "some_user"
+  password: "some_password"
 
 netrc:
   # if enabled, it expects to find the content of a valid .netrc file imported as a secret named netrcsecret


### PR DESCRIPTION
**What is the problem I am trying to address?**

Whenever you enable basic auth in an application, your kubernetes ready- and liveness-checks needs to be configured to use a username and a password. Currently, just setting the environment-variables does not seems like a good approach, because you can't access the variable values directly inside helm. 

**How is the fix applied?**

This PR extracts basic-auth in a own configuration-entry instead of using the environment-variable based approach. When `basicAuth.enabled` is set to true, the respective environment variables will be filled with values from `basicAuth.user` and `basicAuth.password`. This is also the trigger to include basic-auth values into the HTTP-Headers for ready- and liveness-checks.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

I did not find any issue related to this.