### PR TITLE
[s3] base uri is not used anywhere remove it

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"fmt"
 	"net/url"
 	"time"
 
@@ -34,10 +33,6 @@ type Storage struct {
 // New creates a new AWS S3 CDN saver
 func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Config)) (*Storage, error) {
 	const op errors.Op = "s3.New"
-	u, err := url.Parse(fmt.Sprintf("https://%s.s3.amazonaws.com", s3Conf.Bucket))
-	if err != nil {
-		return nil, errors.E(op, err)
-	}
 
 	creds := buildAWSCredentials(s3Conf)
 
@@ -61,7 +56,6 @@ func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Co
 		bucket:   s3Conf.Bucket,
 		uploader: uploader,
 		s3API:    uploader.S3,
-		baseURI:  u,
 		timeout:  timeout,
 	}, nil
 }

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -24,7 +23,6 @@ import (
 // For information how to get your keyId and access key turn to official aws docs: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/setting-up.html
 type Storage struct {
 	bucket   string
-	baseURI  *url.URL
 	uploader s3manageriface.UploaderAPI
 	s3API    s3iface.S3API
 	timeout  time.Duration


### PR DESCRIPTION
**What is the problem I am trying to address?**

Base URI is not required as it is not used anywhere in the code base and bucket names are provided.


**How is the fix applied?**

Remove the unneeded code.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

No issue

<!-- 
example: Fixes #123
-->
