### PR TITLE
Updates to mongo getter to reduce duplicate code

### DIFF
--- a/pkg/storage/mongo/getter.go
+++ b/pkg/storage/mongo/getter.go
@@ -16,26 +16,11 @@ import (
 // Info implements storage.Getter
 func (s *ModuleStore) Info(ctx context.Context, module, vsn string) ([]byte, error) {
 	const op errors.Op = "mongo.Info"
-	ctx, span := observ.StartSpan(ctx, op.String())
-	defer span.End()
-	c := s.client.Database(s.db).Collection(s.coll)
 
-	result := &storage.Module{}
+	result, err := Query(ctx, s, module, vsn, op)
 
-	tctx, cancel := context.WithTimeout(ctx, s.timeout)
-	defer cancel()
-
-	queryResult := c.FindOne(tctx, bson.M{"module": module, "version": vsn})
-	if queryErr := queryResult.Err(); queryErr != nil {
-		return nil, errors.E(op, queryErr, errors.M(module), errors.V(vsn))
-	}
-
-	if err := queryResult.Decode(&result); err != nil {
-		kind := errors.KindUnexpected
-		if err == mongo.ErrNoDocuments {
-			kind = errors.KindNotFound
-		}
-		return nil, errors.E(op, err, kind, errors.M(module), errors.V(vsn))
+	if err != nil {
+		return nil, errors.E(op, err)
 	}
 
 	return result.Info, nil
@@ -44,24 +29,11 @@ func (s *ModuleStore) Info(ctx context.Context, module, vsn string) ([]byte, err
 // GoMod implements storage.Getter
 func (s *ModuleStore) GoMod(ctx context.Context, module, vsn string) ([]byte, error) {
 	const op errors.Op = "mongo.GoMod"
-	ctx, span := observ.StartSpan(ctx, op.String())
-	defer span.End()
-	c := s.client.Database(s.db).Collection(s.coll)
-	result := &storage.Module{}
-	tctx, cancel := context.WithTimeout(ctx, s.timeout)
-	defer cancel()
 
-	queryResult := c.FindOne(tctx, bson.M{"module": module, "version": vsn})
-	if queryErr := queryResult.Err(); queryErr != nil {
-		return nil, errors.E(op, queryErr, errors.M(module), errors.V(vsn))
-	}
+	result, err := Query(ctx, s, module, vsn, op)
 
-	if err := queryResult.Decode(result); err != nil {
-		kind := errors.KindUnexpected
-		if err == mongo.ErrNoDocuments {
-			kind = errors.KindNotFound
-		}
-		return nil, errors.E(op, err, kind, errors.M(module), errors.V(vsn))
+	if err != nil {
+		return nil, errors.E(op, err)
 	}
 
 	return result.Mod, nil
@@ -90,4 +62,31 @@ func (s *ModuleStore) Zip(ctx context.Context, module, vsn string) (io.ReadClose
 	}
 
 	return dStream, nil
+}
+
+// Query connects and queries storage module
+func Query(ctx context.Context, s *ModuleStore, module, vsn string, op errors.Op) (*storage.Module, error) {
+	ctx, span := observ.StartSpan(ctx, op.String())
+	defer span.End()
+	c := s.client.Database(s.db).Collection(s.coll)
+
+	result := &storage.Module{}
+
+	tctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	queryResult := c.FindOne(tctx, bson.M{"module": module, "version": vsn})
+	if queryErr := queryResult.Err(); queryErr != nil {
+		return nil, errors.E(op, queryErr, errors.M(module), errors.V(vsn))
+	}
+
+	if err := queryResult.Decode(result); err != nil {
+		kind := errors.KindUnexpected
+		if err == mongo.ErrNoDocuments {
+			kind = errors.KindNotFound
+		}
+		return nil, errors.E(op, err, kind, errors.M(module), errors.V(vsn))
+	}
+
+	return result, nil
 }

--- a/pkg/storage/mongo/getter.go
+++ b/pkg/storage/mongo/getter.go
@@ -16,8 +16,10 @@ import (
 // Info implements storage.Getter
 func (s *ModuleStore) Info(ctx context.Context, module, vsn string) ([]byte, error) {
 	const op errors.Op = "mongo.Info"
+	ctx, span := observ.StartSpan(ctx, op.String())
+	defer span.End()
 
-	result, err := Query(ctx, s, module, vsn, op)
+	result, err := query(ctx, s, module, vsn)
 
 	if err != nil {
 		return nil, errors.E(op, err)
@@ -29,8 +31,10 @@ func (s *ModuleStore) Info(ctx context.Context, module, vsn string) ([]byte, err
 // GoMod implements storage.Getter
 func (s *ModuleStore) GoMod(ctx context.Context, module, vsn string) ([]byte, error) {
 	const op errors.Op = "mongo.GoMod"
+	ctx, span := observ.StartSpan(ctx, op.String())
+	defer span.End()
 
-	result, err := Query(ctx, s, module, vsn, op)
+	result, err := query(ctx, s, module, vsn)
 
 	if err != nil {
 		return nil, errors.E(op, err)
@@ -64,10 +68,12 @@ func (s *ModuleStore) Zip(ctx context.Context, module, vsn string) (io.ReadClose
 	return dStream, nil
 }
 
-// Query connects and queries storage module
-func Query(ctx context.Context, s *ModuleStore, module, vsn string, op errors.Op) (*storage.Module, error) {
+// Query connects to and queries storage module
+func query(ctx context.Context, s *ModuleStore, module, vsn string) (*storage.Module, error) {
+	const op errors.Op = "mongo.query"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
+
 	c := s.client.Database(s.db).Collection(s.coll)
 
 	result := &storage.Module{}


### PR DESCRIPTION
**What is the problem I am trying to address?**

In the mongo/getter implementation there is duplicated code in the Info and GoMod functions. The purpose of this PR is to reduce the duplicated code without any changes to the operation of either of the functions. 

There was also a difference between how the Info and GoMod functions passed the reference for the query result to the Decode function. The Info passed a pointer to the reference while the GoMod function just passed the reference. Mongo handles both so there was no error during run time but this refactor ensures that Info and GoMod call the mongo.Decode function the same way.

**How is the fix applied?**

The common/duplicated code from Info and GoMod functions has been moved into a new getter.Query function.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes # (No Existing Issue)

