### PR TITLE
Add mod version decoding to fix branches with capital letters

### DIFF
--- a/pkg/paths/path.go
+++ b/pkg/paths/path.go
@@ -25,7 +25,7 @@ func GetVersion(r *http.Request) (string, error) {
 	if version == "" {
 		return "", errors.E(op, "missing version parameter")
 	}
-	return version, nil
+	return DecodePath(version)
 }
 
 // AllPathParams holds the module and version in the path of a ?go-get=1


### PR DESCRIPTION
**What is the problem I am trying to address?**

To properly handle module version (branches) with capital letters. 

**How is the fix applied?**

Added path decode for module version which caused issue for branches with capital letters. Used same function which is used to decode module names.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1292 

