### PR TITLE
pkg/download: return 404 on list/latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/gomods/athens
 
+go 1.12
+
 require (
 	cloud.google.com/go v0.26.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.6.0

--- a/pkg/download/upstream_lister.go
+++ b/pkg/download/upstream_lister.go
@@ -66,7 +66,14 @@ func (l *vcsLister) List(ctx context.Context, mod string) (*storage.RevInfo, []s
 	err = cmd.Run()
 	if err != nil {
 		err = fmt.Errorf("%v: %s", err, stderr)
-		return nil, nil, errors.E(op, err)
+		// as of now, we can't recognize between a true NotFound
+		// and an unexpected error, so we choose the more
+		// hopeful path of NotFound. This way the Go command
+		// will not log en error and we still get to log
+		// what happened here if someone wants to dig in more.
+		// Once, https://github.com/golang/go/issues/30134 is
+		// resolved, we can hopefully differentiate.
+		return nil, nil, errors.E(op, err, errors.KindNotFound)
 	}
 
 	var lr listResp


### PR DESCRIPTION
In 1.13, the Go command deduces a "module root" from an "import path" concurrently which means all paths are tried for `github.com/pkg/errors` such as `github.com/pkg/errors`, `github.com/pkg` and `github.com`. 

However, if the proxy returns a non 404/410 on any of the above calls, then the Go command will log to the user the returned error which could confuse the user thinking the `go get` command failed even though it didn't. 

For now, all attempts for `go mod` commands should return 404/410 until the mentioned issue in this PR gets resolved. Will follow up with another PR for .info/.mod/.zip 