### PR TITLE
Fixed Minio NewStorage to return the correct error

### DIFF
--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -39,8 +39,9 @@ func NewStorage(conf *config.MinioConfig, timeout time.Duration) (storage.Backen
 	err = minioClient.MakeBucket(bucketName, region)
 	if err != nil {
 		// Check to see if we already own this bucket
-		exists, err := minioClient.BucketExists(bucketName)
-		if err == nil && !exists {
+		exists, _ := minioClient.BucketExists(bucketName)
+		if !exists {
+			// MakeBucket Error takes priority
 			return nil, errors.E(op, err)
 		}
 	}

--- a/pkg/storage/minio/minio_test.go
+++ b/pkg/storage/minio/minio_test.go
@@ -13,6 +13,66 @@ func TestBackend(t *testing.T) {
 	compliance.RunTests(t, backend, backend.clear)
 }
 
+// TestNewStorageExists tests the logic around MakeBucket and BucketExists
+func TestNewStorageExists(t *testing.T) {
+	url := os.Getenv("ATHENS_MINIO_ENDPOINT")
+	if url == "" {
+		t.SkipNow()
+	}
+
+	tests := []struct {
+		name         string
+		deleteBucket bool
+	}{
+		{"testbucket", false}, // test creation
+		{"testbucket", true},  // test exists
+	}
+
+	for _, test := range tests {
+		backend, err := NewStorage(&config.MinioConfig{
+			Endpoint: url,
+			Key:      "minio",
+			Secret:   "minio123",
+			Bucket:   test.name,
+		}, config.GetTimeoutDuration(300))
+		if err != nil {
+			t.Fatalf("TestNewStorageExists failed for bucketname:  %s, error: %v\n", test.name, err)
+		}
+
+		client, ok := backend.(*storageImpl)
+		if test.deleteBucket && ok {
+			client.minioClient.RemoveBucket(test.name)
+		}
+	}
+}
+
+// TestNewStorageError tests the logic around MakeBucket and BucketExists
+// MakeBucket uses a strict naming path in minio while BucketExists does not.
+// To ensure both paths are tested, there is a strict path error using the
+// "_" and a non strict error using less than 3 characters
+func TestNewStorageError(t *testing.T) {
+	url := os.Getenv("ATHENS_MINIO_ENDPOINT")
+	if url == "" {
+		t.SkipNow()
+	}
+
+	// "_" is not allowed in a bucket name
+	// bucket name must be bigger than 3
+	tests := []string{"test_bucket", "1"}
+
+	for _, bucketName := range tests {
+		_, err := NewStorage(&config.MinioConfig{
+			Endpoint: url,
+			Key:      "minio",
+			Secret:   "minio123",
+			Bucket:   bucketName,
+		}, config.GetTimeoutDuration(300))
+		if err == nil {
+			t.Fatalf("TestNewStorageError failed for bucketname:  %s\n", bucketName)
+		}
+	}
+}
+
 func BenchmarkBackend(b *testing.B) {
 	backend := getStorage(b)
 	compliance.RunBenchmarks(b, backend, backend.clear)


### PR DESCRIPTION
**What is the problem I am trying to address?**
The incorrect error was being bubbled up when using an "_" in the in Minio bucket name.  It was returning the BucketExists error which uses a less strict form of error checking.

**How is the fix applied?**
The fix simply ignores the BucketExists error (the execution path is already inside an error condition) when there is an error.  If the bucket does exist, it correctly returns a storage backend.   I added test cases locally to minio_test.go since they are specific to minio and not the overall compliance tests.  Let me know if this isn't ok but I felt it made more sense.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1295
