### PR TITLE
Write tests for the new Mongo query function

### DIFF
--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -1,12 +1,17 @@
 package mongo
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/gomods/athens/pkg/config"
+	"github.com/gomods/athens/pkg/errors"
+	"github.com/gomods/athens/pkg/storage"
 	"github.com/gomods/athens/pkg/storage/compliance"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,4 +39,36 @@ func getStorage(tb testing.TB) *ModuleStore {
 	require.NoError(tb, err)
 
 	return backend
+}
+
+func TestGetterQueryModuleNotFoundError(t *testing.T) {
+	modname, ver := "xxx", "yyy"
+
+	ctx := context.Background()
+	backend := getStorage(t)
+
+	_, err := query(ctx, backend, modname, ver)
+	require.Error(t, err)
+	require.Equal(t, errors.KindNotFound, errors.Kind(err))
+}
+
+func TestGetterQueryModuleExists(t *testing.T) {
+	modname, ver := "getTestModule", "v1.2.3"
+	mock := &storage.Version{
+		Info: []byte("123"),
+		Mod:  []byte("456"),
+		Zip:  ioutil.NopCloser(bytes.NewReader([]byte("789"))),
+	}
+
+	ctx := context.Background()
+	backend := getStorage(t)
+
+	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+	defer backend.Delete(ctx, modname, ver)
+
+	info, err := query(ctx, backend, modname, ver)
+	require.NoError(t, err)
+	require.Equal(t, mock.Info, info.Info)
+	require.Equal(t, mock.Mod, info.Mod)
 }


### PR DESCRIPTION
**What is the problem I am trying to address?**

I am adding tests around the mongo query function. The query function contains common code that is used by both the Info and GoMod functions in getter.go. 

**How is the fix applied?**

I created two integration tests in mongo_test.go that test the function when there are modules in the database and when modules cannot be found. These tests are very similar to the existing tests in compliance.go that are used to test the Info and GoMod functions that in turn call query(). 

I am having trouble triggering unexpected type errors from within the mongo driver reliably. I would like to add tests for a non 'nil' queryResult error and KindUnexpected if possible (see snippet below).  

```
        if queryErr := queryResult.Err(); queryErr != nil {
		return nil, errors.E(op, queryErr, errors.M(module), errors.V(vsn))
	}

	if err := queryResult.Decode(result); err != nil {
		kind := errors.KindUnexpected
		if err == mongo.ErrNoDocuments {
			kind = errors.KindNotFound
		}
		return nil, errors.E(op, err, kind, errors.M(module), errors.V(vsn))
	}
```

I don't believe it is possible with a mock due to how the mongo driver is written and I am at a loss to a clean way to test it as part of an integration test. I really appreciate any comments, suggestions, or ideas!

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1301 