### PR TITLE
Removing gofmt vendor ignores

### DIFF
--- a/scripts/check_gofmt.sh
+++ b/scripts/check_gofmt.sh
@@ -4,5 +4,5 @@
 # Fail if a .go file hasn't been formatted with gofmt
 set -euo pipefail
 
-GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)   # All the .go files, excluding vendor/
+GO_FILES=$(find . -iname '*.go' -type f)   # All the .go files
 test -z $(gofmt -s -d $GO_FILES | tee /dev/stderr)

--- a/scripts/check_gofmt.sh
+++ b/scripts/check_gofmt.sh
@@ -5,4 +5,4 @@
 set -euo pipefail
 
 GO_FILES=$(find . -iname '*.go' -type f)   # All the .go files
-test -z $(gofmt -s -d $GO_FILES | tee /dev/stderr)
+test -z $(gofmt -s -d "$GO_FILES" | tee /dev/stderr)


### PR DESCRIPTION
We don't have a vendor directory anymore :smile: :tada:

**What is the problem I am trying to address?**

We have code in `./scripts/check_gofmt.sh` that ignores go code in the `vendor/` directory, but we don't have a `vendor` directory anymore

**How is the fix applied?**

I removed the check

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

<!-- 
example: Fixes #123
-->