### PR TITLE
Fixing basic auth vars in the helm chart

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.2.15
+version: 0.2.16
 appVersion: 0.4.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -137,9 +137,9 @@ spec:
         {{- end }}
         {{- if .Values.basicAuth.enabled }}
         - name: BASIC_AUTH_USER
-          value: "{{ default "gomod" .Values.basicAuth.user | quote }}"
+          value: {{ default "gomod" .Values.basicAuth.user | quote }}
         - name: BASIC_AUTH_PASS
-          value: "{{ default "gomod" .Values.basicAuth.password | quote }}"
+          value: {{ default "gomod" .Values.basicAuth.password | quote }}
         {{- end }}
         ports:
         - containerPort: 3000


### PR DESCRIPTION
**What is the problem I am trying to address?**

The helm chart failed to deploy Athens properly when basic auth is turned on

**How is the fix applied?**

I removed the double-quote from the params

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1303


cc/ @qiuyuzhou