### PR TITLE
Add check for mongo configuration errors.

### DIFF
--- a/pkg/storage/mongo/mongo.go
+++ b/pkg/storage/mongo/mongo.go
@@ -34,7 +34,7 @@ func NewStorage(conf *config.MongoConfig, timeout time.Duration) (*ModuleStore, 
 		return nil, errors.E(op, "No Mongo Configuration provided")
 	}
 	ms := &ModuleStore{url: conf.URL, certPath: conf.CertPath, timeout: timeout, insecure: conf.InsecureConn}
-	client, err := ms.newClient(conf)
+	client, err := ms.newClient()
 	ms.client = client
 
 	if err != nil {
@@ -80,11 +80,17 @@ func (m *ModuleStore) initDatabase() *mongo.Collection {
 	return c
 }
 
-func (m *ModuleStore) newClient(conf *config.MongoConfig) (*mongo.Client, error) {
+func (m *ModuleStore) newClient() (*mongo.Client, error) {
+	const op errors.Op = "mongo.newClient"
+
 	tlsConfig := &tls.Config{}
 	clientOptions := options.Client()
-	// Maybe check for error using Validate()?
 	clientOptions = clientOptions.ApplyURI(m.url)
+
+	err := clientOptions.Validate()
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
 
 	if m.certPath != "" {
 		// Sets only when the env var is setup in config.dev.toml
@@ -99,7 +105,7 @@ func (m *ModuleStore) newClient(conf *config.MongoConfig) (*mongo.Client, error)
 
 		cert, err := ioutil.ReadFile(m.certPath)
 		if err != nil {
-			return nil, err
+			return nil, errors.E(op, err)
 		}
 
 		if ok := roots.AppendCertsFromPEM(cert); !ok {
@@ -112,7 +118,7 @@ func (m *ModuleStore) newClient(conf *config.MongoConfig) (*mongo.Client, error)
 	clientOptions = clientOptions.SetConnectTimeout(m.timeout)
 	client, err := mongo.NewClient(clientOptions)
 	if err != nil {
-		return nil, err
+		return nil, errors.E(op, err)
 	}
 
 	return client, nil

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -35,3 +35,27 @@ func getStorage(tb testing.TB) *ModuleStore {
 
 	return backend
 }
+
+func TestMongoConfigVerification(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		url          string
+		requireError bool
+	}{
+		{"Test Invalid Configuration:Empty URL", "", true},                         // test mongo configuration without url
+		{"Test InValid Configuration:Misconfigured URL Scheme", "127.0.0.1", true}, // test mongo configuration with misconfigured url
+		{"Test Valid Configuration: Full URL", "mongodb://127.0.0.1", false},       // test mongo configuration with url
+	}
+
+	for _, test := range testCases {
+		t.Run(test.testName, func(t *testing.T) {
+			backend := &ModuleStore{url: test.url, timeout: config.GetTimeoutDuration(300)}
+			_, err := backend.newClient()
+			if test.requireError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What is the problem I am trying to address?**

When creating a new Mongo client, athens doesn't check for error messages returned when setting the database URL. This change checks for errors returned by the mongo ApplyURI function and wraps/returns the errors. 

**How is the fix applied?**

In the newClient function, the options.Validate is called after the options.ApplyURI function to check that that the supplied URI value didn't trigger an error with the mongo library. Also, the function signature for newClient was altered to remove the parameter since it is no longer used. 

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1328