### PR TITLE
Fix Mongo initialization to use environment variables for db/coll names

### DIFF
--- a/docs/content/configuration/storage.md
+++ b/docs/content/configuration/storage.md
@@ -80,6 +80,10 @@ This driver uses a [Mongo](https://www.mongodb.com/) server as data storage. On 
             # Env override: ATHENS_MONGO_DEFAULT_DATABASE
             DefaultDBName = athens
 
+            # Not required parameter
+            # Allows for use of custom collection 
+            # Env override: ATHENS_MONGO_DEFAULT_COLLECTION
+            DefaultCollectionName = modules
 ## Google Cloud Storage
 
 This driver uses [Google Cloud Storage](https://cloud.google.com/storage/) and assumes that you already have an `account` and `bucket` in it.

--- a/docs/content/configuration/storage.md
+++ b/docs/content/configuration/storage.md
@@ -75,6 +75,11 @@ This driver uses a [Mongo](https://www.mongodb.com/) server as data storage. On 
             # Env override: ATHENS_MONGO_INSECURE
             Insecure = false
 
+            # Not required parameter
+            # Allows for use of custom database 
+            # Env override: ATHENS_MONGO_DEFAULT_DATABASE
+            DefaultDBName = athens
+
 ## Google Cloud Storage
 
 This driver uses [Google Cloud Storage](https://cloud.google.com/storage/) and assumes that you already have an `account` and `bucket` in it.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -163,9 +163,10 @@ func TestStorageEnvOverrides(t *testing.T) {
 			Region:    "us-west-1",
 		},
 		Mongo: &MongoConfig{
-			URL:           "mongoURL",
-			CertPath:      "/test/path",
-			DefaultDBName: "test",
+			URL:                   "mongoURL",
+			CertPath:              "/test/path",
+			DefaultDBName:         "test",
+			DefaultCollectionName: "testModules",
 		},
 		S3: &S3Config{
 			Region: "s3Region",
@@ -233,10 +234,11 @@ func TestParseExampleConfig(t *testing.T) {
 			Bucket:    "gomods",
 		},
 		Mongo: &MongoConfig{
-			URL:           "mongodb://127.0.0.1:27017",
-			CertPath:      "",
-			InsecureConn:  false,
-			DefaultDBName: "athens",
+			URL:                   "mongodb://127.0.0.1:27017",
+			CertPath:              "",
+			InsecureConn:          false,
+			DefaultDBName:         "athens",
+			DefaultCollectionName: "modules",
 		},
 		S3: &S3Config{
 			Region: "MY_AWS_REGION",
@@ -337,6 +339,8 @@ func getEnvMap(config *Config) map[string]string {
 			envVars["ATHENS_MONGO_CERT_PATH"] = storage.Mongo.CertPath
 			envVars["ATHENS_MONGO_INSECURE"] = strconv.FormatBool(storage.Mongo.InsecureConn)
 			envVars["ATHENS_MONGO_DEFAULT_DATABASE"] = storage.Mongo.DefaultDBName
+			envVars["ATHENS_MONGO_DEFAULT_COLLECTION"] = storage.Mongo.DefaultCollectionName
+
 		}
 		if storage.S3 != nil {
 			envVars["AWS_REGION"] = storage.S3.Region

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -165,7 +165,7 @@ func TestStorageEnvOverrides(t *testing.T) {
 		Mongo: &MongoConfig{
 			URL:           "mongoURL",
 			CertPath:      "/test/path",
-			DefaultDBName: "athens",
+			DefaultDBName: "test",
 		},
 		S3: &S3Config{
 			Region: "s3Region",
@@ -233,9 +233,10 @@ func TestParseExampleConfig(t *testing.T) {
 			Bucket:    "gomods",
 		},
 		Mongo: &MongoConfig{
-			URL:          "mongodb://127.0.0.1:27017",
-			CertPath:     "",
-			InsecureConn: false,
+			URL:           "mongodb://127.0.0.1:27017",
+			CertPath:      "",
+			InsecureConn:  false,
+			DefaultDBName: "athens",
 		},
 		S3: &S3Config{
 			Region: "MY_AWS_REGION",
@@ -335,6 +336,7 @@ func getEnvMap(config *Config) map[string]string {
 			envVars["ATHENS_MONGO_STORAGE_URL"] = storage.Mongo.URL
 			envVars["ATHENS_MONGO_CERT_PATH"] = storage.Mongo.CertPath
 			envVars["ATHENS_MONGO_INSECURE"] = strconv.FormatBool(storage.Mongo.InsecureConn)
+			envVars["ATHENS_MONGO_DEFAULT_DATABASE"] = storage.Mongo.DefaultDBName
 		}
 		if storage.S3 != nil {
 			envVars["AWS_REGION"] = storage.S3.Region

--- a/pkg/config/mongo.go
+++ b/pkg/config/mongo.go
@@ -2,8 +2,9 @@ package config
 
 // MongoConfig specifies the properties required to use MongoDB as the storage backend
 type MongoConfig struct {
-	URL           string `validate:"required" envconfig:"ATHENS_MONGO_STORAGE_URL"`
-	DefaultDBName string `envconfig:"ATHENS_MONGO_DEFAULT_DATABASE" default:"athens"`
-	CertPath      string `envconfig:"ATHENS_MONGO_CERT_PATH"`
-	InsecureConn  bool   `envconfig:"ATHENS_MONGO_INSECURE"`
+	URL                   string `validate:"required" envconfig:"ATHENS_MONGO_STORAGE_URL"`
+	DefaultDBName         string `envconfig:"ATHENS_MONGO_DEFAULT_DATABASE" default:"athens"`
+	DefaultCollectionName string `envconfig:"ATHENS_MONGO_DEFAULT_COLLECTION" default:"modules"`
+	CertPath              string `envconfig:"ATHENS_MONGO_CERT_PATH"`
+	InsecureConn          bool   `envconfig:"ATHENS_MONGO_INSECURE"`
 }

--- a/pkg/storage/mongo/mongo.go
+++ b/pkg/storage/mongo/mongo.go
@@ -37,6 +37,7 @@ func NewStorage(conf *config.MongoConfig, timeout time.Duration) (*ModuleStore, 
 	client, err := ms.newClient(conf)
 	ms.client = client
 	ms.db = conf.DefaultDBName
+	ms.coll = conf.DefaultCollectionName
 
 	if err != nil {
 		return nil, errors.E(op, err)
@@ -68,7 +69,10 @@ func (m *ModuleStore) initDatabase() *mongo.Collection {
 	if m.db == "" {
 		m.db = "athens"
 	}
-	m.coll = "modules"
+
+	if m.coll == "" {
+		m.coll = "modules"
+	}
 
 	c := m.client.Database(m.db).Collection(m.coll)
 	indexView := c.Indexes()

--- a/pkg/storage/mongo/mongo.go
+++ b/pkg/storage/mongo/mongo.go
@@ -36,6 +36,7 @@ func NewStorage(conf *config.MongoConfig, timeout time.Duration) (*ModuleStore, 
 	ms := &ModuleStore{url: conf.URL, certPath: conf.CertPath, timeout: timeout, insecure: conf.InsecureConn}
 	client, err := ms.newClient(conf)
 	ms.client = client
+	ms.db = conf.DefaultDBName
 
 	if err != nil {
 		return nil, errors.E(op, err)
@@ -64,8 +65,9 @@ func (m *ModuleStore) connect(conf *config.MongoConfig) (*mongo.Collection, erro
 }
 
 func (m *ModuleStore) initDatabase() *mongo.Collection {
-	// TODO: database and collection as env vars, or params to New()? together with user/mongo
-	m.db = "athens"
+	if m.db == "" {
+		m.db = "athens"
+	}
 	m.coll = "modules"
 
 	c := m.client.Database(m.db).Collection(m.coll)

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -68,8 +68,9 @@ func TestNewStorageWithDefaultOverrides(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, test.expDbName, backend.db)
 			require.Equal(t, test.expCollName, backend.coll)
-	 })
- }
+	    })
+    }
+}
   
 func TestMongoConfigVerification(t *testing.T) {
 	testCases := []struct {

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -38,7 +38,7 @@ func getStorage(tb testing.TB) *ModuleStore {
 	return backend
 }
 
-func TestNewStorageWithNonDefaultDBName(t *testing.T) {
+func TestNewStorageWithDefaultOverrides(t *testing.T) {
 	url := os.Getenv("ATHENS_MONGO_STORAGE_URL")
 
 	if url == "" {
@@ -46,20 +46,28 @@ func TestNewStorageWithNonDefaultDBName(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		dbName    string
-		expDbName string
+		name        string
+		dbName      string
+		expDbName   string
+		collName    string
+		expCollName string
 	}{
-		{"Test Default 'Athens' DB Name", "athens", "athens"}, //Tests the default database name
-		{"Test Custom DB Name", "testAthens", "testAthens"},   //Tests a non-default database name
-		{"Test Blank DB Name", "", "athens"},                  //Tests the blank database name edge-case
+		{"Test Default 'Athens' DB Name", "athens", "athens", "modules", "modules"},          //Tests the default database name
+		{"Test Custom DB Name", "testAthens", "testAthens", "modules", "modules"},            //Tests a non-default database name
+		{"Test Blank DB Name", "", "athens", "modules", "modules"},                           //Tests the blank database name edge-case
+		{"Test Default 'Modules' Collection Name", "athens", "athens", "modules", "modules"}, //Tests the default collection name
+		{"Test Custom Collection Name", "athens", "athens", "testModules", "testModules"},    //Tests the non-default collection name
+		{"Test Blank Collection Name", "athens", "athens", "", "modules"},                    //Tests the blank collection name edge-case
+
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			backend, err := NewStorage(&config.MongoConfig{URL: url, DefaultDBName: test.dbName}, config.GetTimeoutDuration(300))
+			backend, err := NewStorage(&config.MongoConfig{URL: url, DefaultDBName: test.dbName, DefaultCollectionName: test.collName}, config.GetTimeoutDuration(300))
 			require.NoError(t, err)
 			require.Equal(t, test.expDbName, backend.db)
+			require.Equal(t, test.expCollName, backend.coll)
+
 		})
 	}
 }

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -38,7 +38,6 @@ func getStorage(tb testing.TB) *ModuleStore {
 	return backend
 }
 
-
 func TestNewStorageWithDefaultOverrides(t *testing.T) {
 	url := os.Getenv("ATHENS_MONGO_STORAGE_URL")
 
@@ -68,10 +67,10 @@ func TestNewStorageWithDefaultOverrides(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, test.expDbName, backend.db)
 			require.Equal(t, test.expCollName, backend.coll)
-	    })
-    }
+		})
+	}
 }
-  
+
 func TestMongoConfigVerification(t *testing.T) {
 	testCases := []struct {
 		testName     string


### PR DESCRIPTION
**What is the problem I am trying to address?**

The mongo database's initialization code uses hardcoded values for the database and collection names. An environment variable for the database name exists as ATHENS_MONGO_DEFAULT_DATABASE but is not used during the mongo initialization. There is no existing environment variable for the collection name. 

**How is the fix applied?**

Mongo will use the values set in the mongo storage configuration or will default to "athens" or "modules" during initialization. The environment variable, ATHENS_MONGO_DEFAULT_COLLECTION, is added to set the name of the collection. This will default to "modules" if not set. The value stored in the existing environment variable ATHENS_MONGO_DEFAULT_DATABASE is now used to set the mongo database name or will revert to the default of "athens" if not set. The configuration documentation was updated to reflect the environment variables. 

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes # N/A



