### PR TITLE
add support for a host in ensurePortFormat

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,16 +2,16 @@ package config
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path/filepath"
-	"runtime"
-
 	"github.com/BurntSushi/toml"
 	"github.com/gomods/athens/pkg/download/mode"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/kelseyhightower/envconfig"
-	validator "gopkg.in/go-playground/validator.v9"
+	"gopkg.in/go-playground/validator.v9"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 )
 
 const defaultConfigFile = "athens.toml"
@@ -188,10 +188,7 @@ func envOverride(config *Config) error {
 }
 
 func ensurePortFormat(s string) string {
-	if len(s) == 0 {
-		return ""
-	}
-	if s[0] != ':' {
+	if _, err := strconv.Atoi(s); err == nil {
 		return ":" + s
 	}
 	return s

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -143,6 +143,12 @@ func TestEnsurePortFormat(t *testing.T) {
 	if given != expected {
 		t.Fatalf("expected ensurePortFormat to not add a colon when it's present but got %v", given)
 	}
+	port = "127.0.0.1:3000"
+	expected = "127.0.0.1:3000"
+	given = ensurePortFormat(port)
+	if given != expected {
+		t.Fatalf("expected ensurePortFormat to not add a colon when it's present but got %v", given)
+	}
 }
 
 func TestStorageEnvOverrides(t *testing.T) {


### PR DESCRIPTION
using a host enables the ability to bind to a specific interface