### PR TITLE
Adding a note in the configuration section about the config.dev.toml

### DIFF
--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -7,6 +7,8 @@ weight: 3
 ## Configuring Athens
 Here we'll cover how to configure the Athens application utilizing various configuration scenarios.
 
+>This section covers some of the more commonly used configuration variables, but there are more! If you want to see all the configuration variables you can set, we've documented them all in [this configuration file](https://github.com/gomods/athens/blob/master/config.dev.toml).
+
 ### Authentication
 There are numerous version control systems available to us as developers.  In this section we'll outline how they can be used by supplying required credentials in various formats for the Athens project.
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

Only some of the configuration options are shown in https://docs.gomods.io/configuration/.

**How is the fix applied?**

For now, I've added a link to [`config.dev.toml`](https://github.com/gomods/athens/blob/master/config.dev.toml) so that at least a reader knows where the documentation lives for _all_ the configuration options.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes https://github.com/gomods/athens/issues/921

I am going to use this to close out #921. If the documentation in `config.dev.toml` is not enough, we can open a new issue and come up with a better solution.

cc/ @rogpeppe

<!-- 
example: Fixes #123
-->
