### PR TITLE
Allow full name override in helm chart

### DIFF
--- a/charts/athens-proxy/templates/_helpers.tpl
+++ b/charts/athens-proxy/templates/_helpers.tpl
@@ -1,6 +1,18 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
 {{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- define "readinessPath" -}}
 {{- if contains "v0.2.0" .Values.image.tag -}}/{{- else -}}/readyz{{- end -}}


### PR DESCRIPTION
**What is the problem I am trying to address?**

I have been trying to name my deployment something else than `athens-proxy`.

Currently it ends up something like: `go-mod-proxy-athens-proxy`

This adds support for `fullnameOverride` in the `fullname` templating helper.




