### PR TITLE
Don't return an http error when a DownloadMode is invalid

### DIFF
--- a/pkg/download/mode/mode.go
+++ b/pkg/download/mode/mode.go
@@ -2,6 +2,7 @@ package mode
 
 import (
 	"encoding/base64"
+	e "errors"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -18,12 +19,16 @@ type Mode string
 
 // DownloadMode constants. For more information see config.dev.toml
 const (
-	Sync          Mode = "sync"
-	Async         Mode = "async"
-	Redirect      Mode = "redirect"
-	AsyncRedirect Mode = "async_redirect"
-	None          Mode = "none"
+	Sync           Mode = "sync"
+	Async          Mode = "async"
+	Redirect       Mode = "redirect"
+	AsyncRedirect  Mode = "async_redirect"
+	None           Mode = "none"
+	invalidModeErr      = "unrecognized download mode: %s"
 )
+
+// ErrNoDownloadMode is returned if the specified mode is empty string
+var ErrNoDownloadMode = e.New("download mode is not set")
 
 // DownloadFile represents a custom HCL format of
 // how to handle module@version requests that are
@@ -64,11 +69,16 @@ func NewFile(m Mode, downloadURL string) (*DownloadFile, error) {
 		}
 		return parseFile(bts)
 	}
+
+	if m == "" {
+		return nil, errors.E(op, ErrNoDownloadMode)
+	}
+
 	switch m {
 	case Sync, Async, Redirect, AsyncRedirect, None:
 		return &DownloadFile{Mode: m, DownloadURL: downloadURL}, nil
 	default:
-		return nil, errors.E(op, "unrecognized download mode: "+m, errors.KindBadRequest)
+		return nil, errors.E(op, fmt.Sprintf(invalidModeErr, m))
 	}
 }
 

--- a/pkg/download/mode/mode_test.go
+++ b/pkg/download/mode/mode_test.go
@@ -1,6 +1,7 @@
 package mode
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -90,6 +91,33 @@ func TestMode(t *testing.T) {
 			givenURL := tc.file.URL(tc.input)
 			if givenURL != tc.expectedURL {
 				t.Fatalf("expected matched DownloadURL to be %q but got %q", tc.expectedURL, givenURL)
+			}
+		})
+	}
+}
+
+func TestNewFile_err(t *testing.T) {
+	tc := []struct {
+		name     string
+		mode     Mode
+		expected string
+	}{
+		{
+			name:     "empty mode",
+			mode:     "",
+			expected: ErrNoDownloadMode.Error(),
+		},
+		{
+			name:     "invalid mode",
+			mode:     "invalidMode",
+			expected: fmt.Sprintf(invalidModeErr, "invalidMode"),
+		},
+	}
+	for _, c := range tc {
+		t.Run(c.name, func(subT *testing.T) {
+			_, err := NewFile(c.mode, "github.com/gomods/athens")
+			if err.Error() != c.expected {
+				t.Fatalf("expected error %s from NewFile, got %s", c.expected, err.Error())
 			}
 		})
 	}

--- a/pkg/download/mode/mode_test.go
+++ b/pkg/download/mode/mode_test.go
@@ -105,7 +105,7 @@ func TestNewFile_err(t *testing.T) {
 		{
 			name:     "empty mode",
 			mode:     "",
-			expected: ErrNoDownloadMode.Error(),
+			expected: downloadModeErr,
 		},
 		{
 			name:     "invalid mode",


### PR DESCRIPTION
**What is the problem I am trying to address?**

Right now `mode.NewFile()` returns an HTTP 400 error when `Config.DownloadMode` is not set. This doesn't make a lot of sense, because the consumer of the error is not an HTTP client, but an administrator attempting to configure Athens for the first time. 

**How is the fix applied?**

`mode.NewFile()` no longer returns HTTP errors, and instead returns either `mode.ErrDownloadMode` or a formatted error stating that the specified `DownloadMode` is not valid. This also adds some basic testing to ensure the function returns expected error values.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Refs #1336
