### PR TITLE
stasher/azure blob test: use - instead of _ for container name 

### DIFF
--- a/pkg/stash/with_azureblob_test.go
+++ b/pkg/stash/with_azureblob_test.go
@@ -105,7 +105,7 @@ func randomContainerName(prefix string) string {
 	// see https://github.com/technosophos/moniker for more details
 	namer := moniker.New()
 	if prefix != "" {
-		return fmt.Sprintf("%s_%s", prefix, namer.NameSep(""))
+		return fmt.Sprintf("%s-%s", prefix, namer.NameSep(""))
 	}
 	return namer.NameSep("")
 }


### PR DESCRIPTION
_ is an invalid char in container name so let's use - instead.