### PR TITLE
Upgrade to Go 1.13

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: default
 
 steps:
 - name: download-dependencies
-  image: golang:1.12
+  image: golang:1.13
   commands:
     # wait for services to be ready.
     - sleep 5
@@ -19,7 +19,7 @@ steps:
 
 
 - name: build
-  image: golang:1.12
+  image: golang:1.13
   commands:
 
   # build

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/docker-library/buildpack-deps/blob/1845b3f918f69b4c97912b0d4d68a5658458e84f/stretch/scm/Dockerfile
 # https://github.com/golang/go/blob/f082dbfd4f23b0c95ee1de5c2b091dad2ff6d930/src/cmd/go/internal/get/vcs.go#L90
 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 WORKDIR $GOPATH/src/github.com/gomods/athens
 


### PR DESCRIPTION
Now that Go 1.13 is out, let's use it. 