### PR TITLE
replace thrift to github.com/apache/thrift in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,3 +59,5 @@ require (
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.20.2
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tj
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmDlfhUrweEy1R1Fj1gu5iIM=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=


### PR DESCRIPTION
Signed-off-by: Wang Kirin <wangqilintech@gmail.com>


**What is the problem I am trying to address?**

issue #1376 

**How is the fix applied?**

`replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0`

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1376 