### PR TITLE
Add support for setting ATHENS_GONOSUM_PATTERNS in helm chart

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.6.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
         {{- if .Values.configEnvVars }}
 {{ toYaml .Values.configEnvVars | indent 8 }}
         {{- end }}
+        {{- if .Values.goNoSumPatterns }}
+        - name: ATHENS_GONOSUM_PATTERNS
+          value: {{ .Values.goNoSumPatterns | join "," }}
+        {{- end }}
         - name: ATHENS_STORAGE_TYPE
           value: {{ .Values.storage.type | quote }}
         {{- if eq .Values.storage.type "disk"}}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -116,6 +116,11 @@ sshGitServers: {}
     ## ssh port
   #  port: 22
 
+goNoSumPatterns: []
+  ## List of patterns for which not to issue checksum requests.
+  # - github.com/mycompany/*
+  # - github.com/mycompany2/*
+
 goGetWorkers: 3
 
 nodeSelector: {}


### PR DESCRIPTION
When using go 1.13, `go get` will by default issue checksum requests to sum.golang.org. When using athens inside an organization and deploying it via the helm chart, it's important to be able to set ATHENS_GONOSUM_PATTERNS in order to avoid leaking internal information to the outside world.