### PR TITLE
pkg/module: set only present environment variables

### DIFF
--- a/pkg/module/prepare_env.go
+++ b/pkg/module/prepare_env.go
@@ -11,21 +11,19 @@ import (
 // environment variables for a Go Command to run
 // successfully (such as GOPATH, GOCACHE, PATH etc)
 func prepareEnv(gopath string, envVars []string) []string {
-	pathEnv := fmt.Sprintf("PATH=%s", os.Getenv("PATH"))
-	homeEnv := fmt.Sprintf("HOME=%s", os.Getenv("HOME"))
 	gopathEnv := fmt.Sprintf("GOPATH=%s", gopath)
 	cacheEnv := fmt.Sprintf("GOCACHE=%s", filepath.Join(gopath, "cache"))
 	disableCgo := "CGO_ENABLED=0"
 	enableGoModules := "GO111MODULE=on"
 	cmdEnv := []string{
-		pathEnv,
-		homeEnv,
 		gopathEnv,
 		cacheEnv,
 		disableCgo,
 		enableGoModules,
 	}
-	for _, key := range []string{
+	keys := []string{
+		"PATH",
+		"HOME",
 		"GIT_SSH",
 		"GIT_SSH_COMMAND",
 		"HTTP_PROXY",
@@ -35,7 +33,18 @@ func prepareEnv(gopath string, envVars []string) []string {
 		"http_proxy",
 		"https_proxy",
 		"no_proxy",
-	} {
+	}
+	if runtime.GOOS == "windows" {
+		windowsSpecificKeys := []string{
+			"USERPROFILE",
+			"SystemRoot",
+			"ALLUSERSPROFILE",
+			"HOMEDRIVE",
+			"HOMEPATH",
+		}
+		keys = append(keys, windowsSpecificKeys...)
+	}
+	for _, key := range keys {
 		// Prepend only if environment variable is present.
 		if v, ok := os.LookupEnv(key); ok {
 			cmdEnv = append(cmdEnv, fmt.Sprintf("%s=%s", key, v))
@@ -51,15 +60,5 @@ func prepareEnv(gopath string, envVars []string) []string {
 			cmdEnv = append(cmdEnv, sshAuthSock)
 		}
 	}
-
-	// add Windows specific ENV VARS
-	if runtime.GOOS == "windows" {
-		cmdEnv = append(cmdEnv, fmt.Sprintf("USERPROFILE=%s", os.Getenv("USERPROFILE")))
-		cmdEnv = append(cmdEnv, fmt.Sprintf("SystemRoot=%s", os.Getenv("SystemRoot")))
-		cmdEnv = append(cmdEnv, fmt.Sprintf("ALLUSERSPROFILE=%s", os.Getenv("ALLUSERSPROFILE")))
-		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEDRIVE=%s", os.Getenv("HOMEDRIVE")))
-		cmdEnv = append(cmdEnv, fmt.Sprintf("HOMEPATH=%s", os.Getenv("HOMEPATH")))
-	}
-
 	return cmdEnv
 }

--- a/pkg/module/prepare_env.go
+++ b/pkg/module/prepare_env.go
@@ -13,13 +13,8 @@ import (
 func prepareEnv(gopath string, envVars []string) []string {
 	pathEnv := fmt.Sprintf("PATH=%s", os.Getenv("PATH"))
 	homeEnv := fmt.Sprintf("HOME=%s", os.Getenv("HOME"))
-	httpProxy := fmt.Sprintf("HTTP_PROXY=%s", os.Getenv("HTTP_PROXY"))
-	httpsProxy := fmt.Sprintf("HTTPS_PROXY=%s", os.Getenv("HTTPS_PROXY"))
-	noProxy := fmt.Sprintf("NO_PROXY=%s", os.Getenv("NO_PROXY"))
 	gopathEnv := fmt.Sprintf("GOPATH=%s", gopath)
 	cacheEnv := fmt.Sprintf("GOCACHE=%s", filepath.Join(gopath, "cache"))
-	gitSSH := fmt.Sprintf("GIT_SSH=%s", os.Getenv("GIT_SSH"))
-	gitSSHCmd := fmt.Sprintf("GIT_SSH_COMMAND=%s", os.Getenv("GIT_SSH_COMMAND"))
 	disableCgo := "CGO_ENABLED=0"
 	enableGoModules := "GO111MODULE=on"
 	cmdEnv := []string{
@@ -29,24 +24,24 @@ func prepareEnv(gopath string, envVars []string) []string {
 		cacheEnv,
 		disableCgo,
 		enableGoModules,
-		httpProxy,
-		httpsProxy,
-		noProxy,
-		gitSSH,
-		gitSSHCmd,
+	}
+	for _, key := range []string{
+		"GIT_SSH",
+		"GIT_SSH_COMMAND",
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"NO_PROXY",
+		// Need to also check the lower case version of just these three env variables.
+		"http_proxy",
+		"https_proxy",
+		"no_proxy",
+	} {
+		// Prepend only if environment variable is present.
+		if v, ok := os.LookupEnv(key); ok {
+			cmdEnv = append(cmdEnv, fmt.Sprintf("%s=%s", key, v))
+		}
 	}
 	cmdEnv = append(cmdEnv, envVars...)
-
-	// need to also check the lower case version of just these three env variables
-	if httpProxyLower, exist := os.LookupEnv("http_proxy"); exist {
-		cmdEnv = append(cmdEnv, fmt.Sprintf("http_proxy=%s", httpProxyLower))
-	}
-	if httpsProxyLower, exist := os.LookupEnv("https_proxy"); exist {
-		cmdEnv = append(cmdEnv, fmt.Sprintf("https_proxy=%s", httpsProxyLower))
-	}
-	if noProxyLower, exist := os.LookupEnv("no_proxy"); exist {
-		cmdEnv = append(cmdEnv, fmt.Sprintf("no_proxy=%s", noProxyLower))
-	}
 
 	if sshAuthSockVal, hasSSHAuthSock := os.LookupEnv("SSH_AUTH_SOCK"); hasSSHAuthSock {
 		// Verify that the ssh agent unix socket exists and is a unix socket.


### PR DESCRIPTION
**What is the problem I am trying to address?**

For some arcane reasons go can't download private module if there is blank `GIT_SSH=` in environment.
I've tried to alter the way we construct the environment variables in `prepareEnv` so we don't set variables that are not present.

**How is the fix applied?**
I've introduced the ` os.LookupEnv(key)` call, and started to append variables only if boolean is true and variable is present.

Fixes #1398