### PR TITLE
Add ability to annotate the proxy Service via Helm

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.6.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/service.yaml
+++ b/charts/athens-proxy/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "fullname" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -11,6 +11,8 @@ image:
   pullPolicy: IfNotPresent
 
 service:
+  ## Additional annotations to apply to the service
+  annotations: {}
   ## Port as exposed by the service
   servicePort: 80
   ## Type of service; valid values are "ClusterIP", "LoadBalancer", and


### PR DESCRIPTION
It is often use to add custom annotations to a Service deployed
through Helm, so this PR adds the ability for a user to specify
annotations in their values file. For such use case we have seen
is when working in conjunction with external-dns, we want to assign
DNS properties of the Service, but currently cannot because this
Helm chart does not support it.

**What is the problem I am trying to address?**

We are trying to apply custom annotations to the Athens k8s Service to make it work with our usage of external-dns.

**How is the fix applied?**

I implemented a pattern seen in several other helm charts.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

(See above)