### PR TITLE
Update tag of gomods/athens in chart

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: athens-proxy
-version: 0.3.4
-appVersion: 0.6.0
+version: 0.3.5
+appVersion: 0.6.1
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png
 keywords:

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 image:
   registry: docker.io
   repository: gomods/athens
-  tag: v0.6.0
+  tag: v0.6.1
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Fix an import bug: https://github.com/gomods/athens/issues/1390

Signed-off-by: jtcheng <jtcheng0616@gmail.com>


**What is the problem I am trying to address?**

There is an import bug  in v0.6.0 as description as https://github.com/gomods/athens/releases/tag/v0.6.1.

**How is the fix applied?**

Change the default tag from v0.6.0 to 0.6.1

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1390

**Confusion**
I dont know how to publish chart to `https://athens.blob.core.windows.net/charts`.
Do I need to deploy it  by hand ? 