### PR TITLE
Add .git to .dockerignore, bringing docker build context from 71MB to 16MB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **/node_modules/
 **/bin/
+**/.git


### PR DESCRIPTION
**What is the problem I am trying to address?**

While playing around locally with the athens project, I realize pretty much the entire folder is being included in the docker build context of images.

**How is the fix applied?**

I have updated the .dockerignore file.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

No existing issue to reference.

I have simply added `**/.git` to the .dockerignore file.

This brings the size of the docker build context from ~71MB down to ~16mb

