### PR TITLE
Renamed redeploy annotations to fix duplicate key in yaml

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.3.8
+version: 0.3.9
 appVersion: 0.7.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config-upstream.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/config-ssh-git-servers.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret-ssh-git-servers.yaml") . | sha256sum }}
+        checksum/upstream: {{ include (print $.Template.BasePath "/config-upstream.yaml") . | sha256sum }}
+        checksum/ssh-config: {{ include (print $.Template.BasePath "/config-ssh-git-servers.yaml") . | sha256sum }}
+        checksum/ssh-secret: {{ include (print $.Template.BasePath "/secret-ssh-git-servers.yaml") . | sha256sum }}
     spec:
       {{- if .Values.sshGitServers }}
       initContainers:


### PR DESCRIPTION
**What is the problem I am trying to address?**

The chart creates a yaml that has duplicate keys. One key will be ignored by Kubernetes.

**How is the fix applied?**

Renamed the annotations to distinct names.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

The yaml becomes valid.