### PR TITLE
Use sed to set proxy docker image to production mode

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -22,9 +22,9 @@ COPY --from=builder /usr/local/go/bin/go /bin/go
 
 # Add tini, see https://github.com/gomods/athens/issues/1155 for details.
 RUN apk add --update bzr git mercurial openssh-client subversion procps fossil tini && \
-	mkdir -p /usr/local/go
-
-ENV GO_ENV=production
+	mkdir -p /usr/local/go && \
+	sed -i -r -e 's/(GoEnv\s*=\s*)"development"/\1"production"/' /config/config.toml && \
+	chmod 600 /config/config.toml
 
 EXPOSE 3000
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

Because the proxy Dockerfile adds `GO_ENV=production`, there is no way to override the setting via the config.

This prevents the user from being able to use the config to fully manage their installation.

**How is the fix applied?**

Replaces the `ENV` directive within the proxy Dockerfile with a `sed` action to inject the `"production"` value into the config file.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Relates to #1435

I initially submitted PR #1431 which introduced a new proxy-docker-specific config file.  After some discussion, it was apparent that such a solution doesn't scale well.

I  mentioned in the referenced issue that another idea could be to use `sed` to set the config value to `"production"`

This PR is an example of what that would look like.



