### PR TITLE
Added configurations for k8s livenessProbs thresholds

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.3.5
+version: 0.3.6
 appVersion: 0.6.1
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -47,9 +47,13 @@ spec:
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         livenessProbe:
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           httpGet:
             path: "/healthz"
             port: 3000
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             {{- if .Values.basicAuth.enabled }}
             httpHeaders:
               - name: Authorization

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -10,6 +10,13 @@ image:
   ##
   pullPolicy: IfNotPresent
 
+
+livenessProbe:
+  failureThreshold: 3
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
 service:
   ## Additional annotations to apply to the service
   annotations: {}


### PR DESCRIPTION
**What is the problem I am trying to address?**

Apparently Athens brakes with long k8s cluster upgrade (downtime is longer as default thresholds with livenessprobs)

**How is the fix applied?**

Make livenessProbs thresholds configurable so we can extend health check times

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

No issue
