### PR TITLE
drone: give more time for athens to boot up

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ steps:
   image: golang:1.13
   commands:
     # wait for services to be ready.
-    - sleep 5
+    - sleep 10
     - go mod download
     - go mod vendor # this is for when the Dockerfile gets built
   environment:


### PR DESCRIPTION
It looks like drone is taking longer to pull the image down for athens, checking if 10 seconds will be okay. However, we can probably write a small bash script to go in a loop and wait until the server is ready. 