### PR TITLE
Install git-lfs on proxy container

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/con
 COPY --from=builder /usr/local/go/bin/go /bin/go
 
 # Add tini, see https://github.com/gomods/athens/issues/1155 for details.
-RUN apk add --update bzr git mercurial openssh-client subversion procps fossil tini && \
+RUN apk add --update bzr git git-lfs mercurial openssh-client subversion procps fossil tini && \
 	mkdir -p /usr/local/go
 
 EXPOSE 3000


### PR DESCRIPTION
**What is the problem I am trying to address?**

For repositories that store files in git-lfs, the checksum will
differ for clients with and without git-lfs. Clients without git-lfs
will use the [git-lfs pointer](https://github.com/git-lfs/git-lfs/blob/master/docs/spec.md#the-pointer) for calculation, clients with will use
the real files.

**How is the fix applied?**

git-lfs is installed with the other utilities in the `cmd/proxy/Dockerfile`.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes #1448