### PR TITLE
Read basic auth credentials from a secret.

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.3.9
+version: 0.4.0
 appVersion: 0.7.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -54,20 +54,10 @@ spec:
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            {{- if .Values.basicAuth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: "Basic {{ (printf "%s:%s" (default "gomod" .Values.basicAuth.user) (default "gomod" .Values.basicAuth.password) | b64enc) }}"
-            {{- end }}
         readinessProbe:
           httpGet:
             path: "{{ template "readinessPath" . }}"
             port: 3000
-            {{- if .Values.basicAuth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: "Basic {{ (printf "%s:%s" (default "gomod" .Values.basicAuth.user) (default "gomod" .Values.basicAuth.password) | b64enc) }}"
-            {{- end }}
         env:
         - name: ATHENS_GOGET_WORKERS
         {{- if .Values.goGetWorkers }}
@@ -141,9 +131,15 @@ spec:
         {{- end }}
         {{- if .Values.basicAuth.enabled }}
         - name: BASIC_AUTH_USER
-          value: {{ default "gomod" .Values.basicAuth.user | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ default "athens-proxy-basic-auth" .Values.basicAuth.secretName | quote }}
+              key: {{ default "username" .Values.basicAuth.usernameSecretKey | quote }}
         - name: BASIC_AUTH_PASS
-          value: {{ default "gomod" .Values.basicAuth.password | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ default "athens-proxy-basic-auth" .Values.basicAuth.secretName | quote }}
+              key: {{ default "password" .Values.basicAuth.passwordSecretKey | quote }}
         {{- end }}
         ports:
         - containerPort: 3000

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -72,8 +72,9 @@ configEnvVars: {}
 # HTTP basic auth
 basicAuth:
   enabled: false
-  user: "some_user"
-  password: "some_password"
+  secretName: athens-proxy-basic-auth
+  passwordSecretKey: password
+  usernameSecretKey: username
 
 netrc:
   # if enabled, it expects to find the content of a valid .netrc file imported as a secret named netrcsecret

--- a/cmd/proxy/actions/basicauth_test.go
+++ b/cmd/proxy/actions/basicauth_test.go
@@ -49,8 +49,16 @@ var basicAuthTests = [...]struct {
 		user:           "wrongUser",
 		pass:           "wrongPassword",
 		path:           "/healthz",
-		logs:           healthWarning,
-		expectedStatus: 401,
+		logs:           "",
+		expectedStatus: 200,
+	},
+	{
+		name:           "log_on_readyz",
+		user:           "wrongUser",
+		pass:           "wrongPassword",
+		path:           "/readyz",
+		logs:           "",
+		expectedStatus: 200,
 	},
 }
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

Currently, the Helm chart requires the HTTP basic authentication credentials (if any) to be defined  in the `values.yaml` file or via the CLI. Both of these approaches are cumbersome when working with [Flux](https://fluxcd.io/) and the [Helm operator](https://github.com/fluxcd/helm-operator), as that would require these credentials to be checked (as plain text) into source control. This PR updates the Helm chart in order to make it possible to reference a secret instead. This secret can then be managed using [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) or bby some other process. 

**How is the fix applied?**

* Replace `basicAuth.username` and `basicAuth.password` with `basicAuth.secretName`, `basicAuth.usernameSecretKey` and `basicAuth.passwordSecretKey`.
* Remove the need for authentication from `/healthz` and `/readyz` and adapt the liveness and readiness probes accordingly.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Closes #1316.

---
_Note from @arschles :
Fixes #1307
Since #1316 also fixes #1307_