### PR TITLE
Revert "Add GCS to helm chart (#1428)"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -153,7 +153,7 @@ services:
   ports:
     - 6379
 - name: athens-proxy
-  image: gomods/athens:canary
+  image: gomods/athens-dev:221c451 # temporary to make the build pass, revert to gomods/athens:canary after merge.
   pull: always
   ports:
     - 3000

--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.7.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -95,15 +95,6 @@ spec:
         - name: AWS_SESSION_TOKEN
           value: {{ .Values.storage.s3.session_token | quote }}
         {{- end }}
-        {{- else if eq .Values.storage.type "gcp"}}
-        - name: GOOGLE_CLOUD_PROJECT
-          value: {{ .Values.storage.gcp.projectID | quote }}
-        - name: ATHENS_STORAGE_GCP_BUCKET
-          value: {{ .Values.storage.gcp.bucket | quote }}
-        {{- if .Values.storage.gcp.serviceAccount }}
-        - name: ATHENS_STORAGE_GCP_SERVICE_ACCOUNT
-          value: {{ .Values.storage.gcp.serviceAccount | b64enc | quote }}
-        {{- end }}
         {{- else if eq .Values.storage.type "minio" }}
         {{- if .Values.storage.minio.endpoint }}
         - name: ATHENS_MINIO_ENDPOINT

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -64,16 +64,6 @@ storage:
     accessKey: ""
     secretKey: ""
     bucket: ""
-  gcp:
-  # For more information, see:
-  # https://docs.gomods.io/install/install-on-kubernetes/#google-cloud-storage
-    # you must set gcp projectID and bucket when running 'helm install'
-    projectID: ""
-    bucket: ""
-    # set serviceAccount to a key which has read/write access to the GCS bucket.
-    # If you are running Athens inside GCP, you will most likely not need this
-    # as GCP figures out internal authentication between products for you.
-    serviceAccount: ""
 
 # Extra environment variables to be passed
 # You can add any new ones at the bottom

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -23,16 +23,16 @@ GoEnv = "development"
 # Env override: GOPROXY
 GoProxy = "direct"
 
-# GoBinaryEnvVars are environment variables that you'd like
-# to pass directly to the Go command that Athens runs under the
-# hood. Athens primarily runs two Go commands:
+# GoBinaryEnvVars are environment variables that you'd like 
+# to pass directly to the Go command that Athens runs under the 
+# hood. Athens primarily runs two Go commands: 
 # 1. `go mod download -json <module>@<version>`
 # 2. `go list -m -json <module>@latest`
-# The go command accepts multiple environment variables that
-# can affect the two processes above such as GONOSUMDB and GOPROXY.
+# The go command accepts multiple environment variables that 
+# can affect the two processes above such as GONOSUMDB and GOPROXY. 
 # Note that athens passes the NoSumPatterns to the two commands above,
 # but the existence of GONOSUMDB in this configuration takes precedence.
-# Although you can pass any key=value to the Go command here, you can see
+# Although you can pass any key=value to the Go command here, you can see 
 # the list of possible env vars by running `go env`.
 # Env override: ATHENS_GO_BINARY_ENV_VARS
 GoBinaryEnvVars = ["GOPROXY=direct"]
@@ -42,7 +42,7 @@ GoBinaryEnvVars = ["GOPROXY=direct"]
 # can manage go get more sanely and not run out of disk or memory.
 # One way to think about is: the number of GoGetWorkers corresponds
 # directly to how many parallel "git clones" your underlying machine
-# can handle.
+# can handle. 
 # Env override: ATHENS_GOGET_WORKERS
 GoGetWorkers = 10
 
@@ -78,7 +78,7 @@ PprofPort = ":3001"
 #
 # To point Athens to an upstream proxy to fetch modules,
 # set GlobalEndpoint to "https://<url_to_upstream>"
-# and also ensure that FilterFile is  set to a fully qualified file name
+# and also ensure that FilterFile is  set to a fully qualified file name 
 # that contains the letter `D` (for "Direct Access") in the first line.
 FilterFile = ""
 
@@ -119,15 +119,15 @@ Port = ":3000"
 #
 # To point Athens to an upstream proxy to fetch modules,
 # set GlobalEndpoint to "https://<url_to_upstream>"
-# and also ensure that FilterFile is set to a fully qualified file name
+# and also ensure that FilterFile is set to a fully qualified file name 
 # that contains the letter `D` (for "Direct Access") in the first line.
 GlobalEndpoint = "http://localhost:3001"
 
-# BASIC AUTH OPTIONS
+# BASIC AUTH OPTIONS 
 # ==================
-# PLASE NOTE THAT THIS IS A BAD HACK AROUND
-# THE FACT THAT GO DOES NOT SUPPORT PROPER AUTHENTICATION
-# YET! YOUR BASIC AUTH CREDENTIALS CAN EASILY LEAK
+# PLASE NOTE THAT THIS IS A BAD HACK AROUND 
+# THE FACT THAT GO DOES NOT SUPPORT PROPER AUTHENTICATION 
+# YET! YOUR BASIC AUTH CREDENTIALS CAN EASILY LEAK 
 # IN ATHENS LOGS AS WELL AS GO COMMAND LOGS.
 # THIS WILL BE ADDRESSED IN 1.13.
 # SEE https://github.com/golang/go/issues/30610
@@ -200,15 +200,15 @@ TraceExporterURL = "http://localhost:14268"
 # Env override: ATHENS_STATS_EXPORTER
 StatsExporter = "prometheus"
 
-# SumDBs specifies a list of fully qualified URLs that Athens will proxy
+# SumDBs specifies a list of fully qualified URLs that Athens will proxy 
 # so that the go command can use as a checksum verifier.
-# See NoSumDB for enforcing the go command to use
+# See NoSumDB for enforcing the go command to use 
 # GONOSUMDB.
 # Env override: ATHENS_SUM_DBS
 SumDBs = ["https://sum.golang.org"]
 
-# NoSumPatterns specifies a list of patterns that will make the
-# Sum DB proxy return a 403 if any of those patterns match.
+# NoSumPatterns specifies a list of patterns that will make the 
+# Sum DB proxy return a 403 if any of those patterns match. 
 # This will enforce the client to run GONOSUMDB
 # Example pattern: NoSumPatterns = ["github.com/mycompany/*"]
 # Env override: ATHENS_GONOSUM_PATTERNS
@@ -227,37 +227,37 @@ NoSumPatterns = []
 # 5. "none": return 404 if a module is not found and do nothing.
 # 6. "file:<path>": will point to an HCL file that specifies
 # any of the 5 options above based on different import paths.
-# 7. "custom:<base64-encoded-hcl>" is the same as option 6
-# but the file is fully encoded in the option. This is
-# useful for using an environment variable in serverless
+# 7. "custom:<base64-encoded-hcl>" is the same as option 6 
+# but the file is fully encoded in the option. This is 
+# useful for using an environment variable in serverless 
 # deployments.
 # Env override: ATHENS_DOWNLOAD_MODE
 DownloadMode = "sync"
 
-# DownloadURL is the URL that will be used if
-# DownloadMode is set to "redirect"
+# DownloadURL is the URL that will be used if 
+# DownloadMode is set to "redirect" 
 # Env override: ATHENS_DOWNLOAD_URL
 DownloadURL = ""
 
-# SingleFlightType determines what mechanism Athens uses
-# to manage concurrency flowing into the Athens Backend.
-# This is important for the following scenario: if two concurrent requests
-# were made to Athens that wanted to store the same module at the same time,
-# we want to make sure only the first request gets to store the module,
-# and the second request will wait for the first one to finish so that
-# it doesn't override the storage.
+# SingleFlightType determines what mechanism Athens uses 
+# to manage concurrency flowing into the Athens Backend. 
+# This is important for the following scenario: if two concurrent requests 
+# were made to Athens that wanted to store the same module at the same time, 
+# we want to make sure only the first request gets to store the module, 
+# and the second request will wait for the first one to finish so that 
+# it doesn't override the storage. 
 
 # Options are ["memory", "etcd", "redis", "gcp", "azureblob"]
 
-# The default option is "memory" which means that only one instance of Athens
+# The default option is "memory" which means that only one instance of Athens 
 # should be used.
-# The "gcp" single flight will assume that you have a "gcp" StorageType
-# and therefore it will use its strong-consistency features to ensure
-# that only one module is ever written even when concurrent saves happen
+# The "gcp" single flight will assume that you have a "gcp" StorageType 
+# and therefore it will use its strong-consistency features to ensure 
+# that only one module is ever written even when concurrent saves happen 
 # at the same time.
-# The "azureblob" single flight will assume that you have a "azureblob" StorageType
-# and therefore it will use its strong-consistency features to ensure
-# that only one module is ever written even when concurrent saves happen
+# The "azureblob" single flight will assume that you have a "azureblob" StorageType 
+# and therefore it will use its strong-consistency features to ensure 
+# that only one module is ever written even when concurrent saves happen 
 # at the same time.
 # Env override: ATHENS_SINGLE_FLIGHT_TYPE
 SingleFlightType = "memory"
@@ -265,7 +265,7 @@ SingleFlightType = "memory"
 [SingleFlight]
     [SingleFlight.Etcd]
         # Endpoints are comma separated URLs that determine all distributed etcd servers.
-        # It defaults to what we have in our docker-compose file. It is by default ignored
+        # It defaults to what we have in our docker-compose file. It is by default ignored 
         # as the SingleFlightType field above determines whether Etcd is used or not.
         # Env override: ATHENS_ETCD_ENDPOINTS
         Endpoints = "localhost:2379,localhost:22379,localhost:32379"
@@ -301,14 +301,14 @@ SingleFlightType = "memory"
         # Env override: ATHENS_STORAGE_GCP_BUCKET
         Bucket = "MY_GCP_BUCKET"
 
-        # ServiceAccount is a base64 encoded service account
+        # JSONKey is a base64 encoded service account 
         # key that allows Athens to be run outside of GCP
-        # but still be able to access GCS. If you are
+        # but still be able to access GCS. If you are 
         # running Athens inside GCP, you will most
-        # likely not need this as GCP figures out
-        # internal authentication between products for you.
+        # likely not need this as GCP figures out 
+        # internal authentication between products for you. 
         # Env override: ATHENS_STORAGE_GCP_JSON_KEY
-        ServiceAccount = ""
+        JSONKey = ""
 
     [Storage.Minio]
         # Endpoint for Minio storage
@@ -368,7 +368,7 @@ SingleFlightType = "memory"
         # and
         # https://godoc.org/github.com/aws/aws-sdk-go/aws/session#hdr-Environment_Variables
         # for environment variables that will affect the aws configuration.
-        # Setting UseDefaultConfiguration would only use default configuration. It will be deprecated in future releases
+        # Setting UseDefaultConfiguration would only use default configuration. It will be deprecated in future releases 
         # and is recommended not to use it.
 
         # Region for S3 storage

--- a/docs/content/install/install-on-kubernetes.md
+++ b/docs/content/install/install-on-kubernetes.md
@@ -177,18 +177,6 @@ Last athens need authentication credentials for your minio in `storage.minio.acc
 helm install gomods/athens-proxy -n athens --namespace athens --set storage.type=minio --set storage.minio.endpoint=<your-minio-endpoint> --set storage.minio.bucket=<your-bucket> --set storage.minio.accessKey=<your-minio-access-key> --set storage.minio.secretKey=<your-minio-secret-key>
 ```
 
-#### Google Cloud Storage
-
- To use Google Cloud Storage storage with Athens, set `storage.type` to `gcp`. You need to set `storage.gcp.projectID` and `storage.gcp.bucket` to the
- desired GCP project and bucket name, respectively.
-
- Depending on your deployment environment you will also need to set `storage.gcp.serviceAccount` to a key which has read/write access to
- the GCS bucket. If you are running Athens inside GCP, you will most likely not need this as GCP figures out internal authentication between products for you.
-
- ```
- helm install gomods/athens-proxy -n athens --namespace athens --set storage.type=gcp --set storage.gcp.projectID=<your-gcp-project> --set storage.gcp.bucket=<your-bucket>
- ```
-
 ### Kubernetes Service
 
 By default, a Kubernetes `ClusterIP` service is created for the Athens proxy. "ClusterIP" is sufficient in the case when the Athens proxy will be used from within the cluster. To expose Athens outside of the cluster, consider using a "NodePort" or "LoadBalancer" service. This can be changed by setting the `service.type` value when installing the chart. For example, to deploy Athens using a NodePort service, the following command could be used:

--- a/pkg/config/gcp.go
+++ b/pkg/config/gcp.go
@@ -2,7 +2,7 @@ package config
 
 // GCPConfig specifies the properties required to use GCP as the storage backend
 type GCPConfig struct {
-	ProjectID      string `envconfig:"GOOGLE_CLOUD_PROJECT"`
-	Bucket         string `validate:"required" envconfig:"ATHENS_STORAGE_GCP_BUCKET"`
-	ServiceAccount string `envconfig:"ATHENS_STORAGE_GCP_SERVICE_ACCOUNT"`
+	ProjectID string `envconfig:"GOOGLE_CLOUD_PROJECT"`
+	Bucket    string `validate:"required" envconfig:"ATHENS_STORAGE_GCP_BUCKET"`
+	JSONKey   string `envconfig:"ATHENS_STORAGE_GCP_JSON_KEY"`
 }

--- a/pkg/stash/with_gcs_test.go
+++ b/pkg/stash/with_gcs_test.go
@@ -121,7 +121,7 @@ func getTestConfig() *config.GCPConfig {
 		return nil
 	}
 	return &config.GCPConfig{
-		Bucket:         "athens_drone_stash_bucket",
-		ServiceAccount: creds,
+		Bucket:  "athens_drone_stash_bucket",
+		JSONKey: creds,
 	}
 }

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -49,8 +49,8 @@ func New(ctx context.Context, gcpConf *config.GCPConfig, timeout time.Duration) 
 func newClient(ctx context.Context, gcpConf *config.GCPConfig, timeout time.Duration) (*Storage, error) {
 	const op errors.Op = "gcp.newClient"
 	opts := []option.ClientOption{}
-	if gcpConf.ServiceAccount != "" {
-		key, err := base64.StdEncoding.DecodeString(gcpConf.ServiceAccount)
+	if gcpConf.JSONKey != "" {
+		key, err := base64.StdEncoding.DecodeString(gcpConf.JSONKey)
 		if err != nil {
 			return nil, errors.E(op, fmt.Errorf("could not decode base64 json key: %v", err))
 		}

--- a/pkg/storage/gcp/gcp_test.go
+++ b/pkg/storage/gcp/gcp_test.go
@@ -72,9 +72,9 @@ func getTestConfig(bucket string) *config.GCPConfig {
 		return nil
 	}
 	return &config.GCPConfig{
-		Bucket:         bucket,
-		ServiceAccount: creds,
-		ProjectID:      os.Getenv("GCS_PROJECT_ID"),
+		Bucket:    bucket,
+		JSONKey:   creds,
+		ProjectID: os.Getenv("GCS_PROJECT_ID"),
 	}
 }
 


### PR DESCRIPTION
This quickly reverts the last commit that caused a breaking change and our CI to fail

However, a nicer solution would be to only revert the breaking part since that PR had nice documentation as well as some Helm additions. 

That said, it's safer to revert this change then add the previous PR but only the parts that were non-breakable. 

If someone wants to open another PR that only fixes the breaking changes, I'm okay with that since we have tests that cover us (well only after we merged, but they covered us still) 

Fixes: https://github.com/gomods/athens/issues/1478