### PR TITLE
Fixing the build failures from a missing GCS Key

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,9 @@ steps:
   - go test -v ./...
 
   # end to end test
-  - ./main & # run the just-built athens server
+  # First, run the just-built athens server
+  # TODO: check for startup failures and fail the build if so
+  - ./main &
   - sleep 3 # wait for it to spin up
   - mkdir -p ~/happy
   - mkdir -p ~/emptygopath # ensure the gopath has no modules cached.

--- a/.drone.yml
+++ b/.drone.yml
@@ -154,7 +154,7 @@ services:
   ports:
     - 6379
 - name: athens-proxy
-  image: gomods/athens:canary
+  image: gomods/athens-dev:221c451 # temporary to make the build pass, revert to gomods/athens:canary after merge.
   pull: always
   ports:
     - 3000

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,10 +31,9 @@ steps:
   - go test -v ./...
 
   # end to end test
-  # First, run the just-built athens server
-  # TODO: check for startup failures and fail the build if so
-  - ./main &
+  - ./main & # run the just-built athens server
   - sleep 3 # wait for it to spin up
+  - curl localhost:3000
   - mkdir -p ~/happy
   - mkdir -p ~/emptygopath # ensure the gopath has no modules cached.
   - cd ~/happy

--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.7.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
         - name: ATHENS_STORAGE_GCP_BUCKET
           value: {{ .Values.storage.gcp.bucket | quote }}
         {{- if .Values.storage.gcp.serviceAccount }}
-        - name: ATHENS_STORAGE_GCP_SERVICE_ACCOUNT
+        - name: ATHENS_STORAGE_GCP_JSON_KEY
           value: {{ .Values.storage.gcp.serviceAccount | b64enc | quote }}
         {{- end }}
         {{- else if eq .Values.storage.type "minio" }}

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -307,8 +307,22 @@ SingleFlightType = "memory"
         # running Athens inside GCP, you will most
         # likely not need this as GCP figures out
         # internal authentication between products for you.
-        # Env override: ATHENS_STORAGE_GCP_JSON_KEY
+        # Env override: ATHENS_STORAGE_GCP_SERVICE_ACCOUNT
         ServiceAccount = ""
+
+        # JSONKey is a base64 encoded service account 
+        # key that allows Athens to be run outside of GCP
+        # but still be able to access GCS. If you are
+        # running Athens inside GCP, you will most
+        # likely not need this as GCP figures out
+        # internal authentication between products for you.
+        # 
+        # NOTE: This config value is deprecated in favor of
+        # ServiceAccount above. Athens will check for it,
+        # but please do not rely on it being available forever.
+        #
+        # Env override: ATHENS_STORAGE_GCP_JSON_KEY
+        JSONKey = ""
 
     [Storage.Minio]
         # Endpoint for Minio storage

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -301,15 +301,6 @@ SingleFlightType = "memory"
         # Env override: ATHENS_STORAGE_GCP_BUCKET
         Bucket = "MY_GCP_BUCKET"
 
-        # ServiceAccount is a base64 encoded service account
-        # key that allows Athens to be run outside of GCP
-        # but still be able to access GCS. If you are
-        # running Athens inside GCP, you will most
-        # likely not need this as GCP figures out
-        # internal authentication between products for you.
-        # Env override: ATHENS_STORAGE_GCP_SERVICE_ACCOUNT
-        ServiceAccount = ""
-
         # JSONKey is a base64 encoded service account 
         # key that allows Athens to be run outside of GCP
         # but still be able to access GCS. If you are

--- a/pkg/config/gcp.go
+++ b/pkg/config/gcp.go
@@ -5,4 +5,8 @@ type GCPConfig struct {
 	ProjectID      string `envconfig:"GOOGLE_CLOUD_PROJECT"`
 	Bucket         string `validate:"required" envconfig:"ATHENS_STORAGE_GCP_BUCKET"`
 	ServiceAccount string `envconfig:"ATHENS_STORAGE_GCP_SERVICE_ACCOUNT"`
+	// NOTE: JSONKey is deprecated in favor of ServiceAccount above.
+	// We've left it here here for backward compatibility.
+	// If both ServiceAccount and JSONKey are set, ServiceAccount will take precedence
+	JSONKey string `envconfig:"ATHENS_STORAGE_GCP_JSON_KEY"`
 }

--- a/pkg/config/gcp.go
+++ b/pkg/config/gcp.go
@@ -2,11 +2,7 @@ package config
 
 // GCPConfig specifies the properties required to use GCP as the storage backend
 type GCPConfig struct {
-	ProjectID      string `envconfig:"GOOGLE_CLOUD_PROJECT"`
-	Bucket         string `validate:"required" envconfig:"ATHENS_STORAGE_GCP_BUCKET"`
-	ServiceAccount string `envconfig:"ATHENS_STORAGE_GCP_SERVICE_ACCOUNT"`
-	// NOTE: JSONKey is deprecated in favor of ServiceAccount above.
-	// We've left it here here for backward compatibility.
-	// If both ServiceAccount and JSONKey are set, ServiceAccount will take precedence
-	JSONKey string `envconfig:"ATHENS_STORAGE_GCP_JSON_KEY"`
+	ProjectID string `envconfig:"GOOGLE_CLOUD_PROJECT"`
+	Bucket    string `validate:"required" envconfig:"ATHENS_STORAGE_GCP_BUCKET"`
+	JSONKey   string `envconfig:"ATHENS_STORAGE_GCP_JSON_KEY"`
 }

--- a/pkg/stash/with_gcs_test.go
+++ b/pkg/stash/with_gcs_test.go
@@ -121,7 +121,7 @@ func getTestConfig() *config.GCPConfig {
 		return nil
 	}
 	return &config.GCPConfig{
-		Bucket:         "athens_drone_stash_bucket",
-		ServiceAccount: creds,
+		Bucket:  "athens_drone_stash_bucket",
+		JSONKey: creds,
 	}
 }

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -50,16 +50,7 @@ func newClient(ctx context.Context, gcpConf *config.GCPConfig, timeout time.Dura
 	const op errors.Op = "gcp.newClient"
 	opts := []option.ClientOption{}
 
-	// Get the GCS Key.
-	// First, try the ServiceAccount first. If it's not there,
-	// fall back to the deprecated JSONKey
-	var jsonKey string
-	if gcpConf.ServiceAccount != "" {
-		jsonKey = gcpConf.ServiceAccount
-	} else if gcpConf.JSONKey != "" {
-		jsonKey = gcpConf.JSONKey
-	}
-
+	jsonKey := gcpConf.JSONKey
 	key, err := base64.StdEncoding.DecodeString(jsonKey)
 	if err != nil {
 		return nil, errors.E(op, fmt.Errorf("could not decode base64 json key: %v", err))

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -50,7 +50,7 @@ func newClient(ctx context.Context, gcpConf *config.GCPConfig, timeout time.Dura
 	const op errors.Op = "gcp.newClient"
 	opts := []option.ClientOption{}
 	if gcpConf.JSONKey != "" {
-		key, err := base64.StdEncoding.DecodeString(gcpConf.ServiceAccount)
+		key, err := base64.StdEncoding.DecodeString(gcpConf.JSONKey)
 		if err != nil {
 			return nil, errors.E(op, fmt.Errorf("could not decode base64 json key: %v", err))
 		}

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -49,17 +49,17 @@ func New(ctx context.Context, gcpConf *config.GCPConfig, timeout time.Duration) 
 func newClient(ctx context.Context, gcpConf *config.GCPConfig, timeout time.Duration) (*Storage, error) {
 	const op errors.Op = "gcp.newClient"
 	opts := []option.ClientOption{}
-
-	jsonKey := gcpConf.JSONKey
-	key, err := base64.StdEncoding.DecodeString(jsonKey)
-	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("could not decode base64 json key: %v", err))
+	if gcpConf.JSONKey != "" {
+		key, err := base64.StdEncoding.DecodeString(gcpConf.ServiceAccount)
+		if err != nil {
+			return nil, errors.E(op, fmt.Errorf("could not decode base64 json key: %v", err))
+		}
+		creds, err := google.CredentialsFromJSON(ctx, key, storage.ScopeReadWrite)
+		if err != nil {
+			return nil, errors.E(op, fmt.Errorf("could not get GCS credentials: %v", err))
+		}
+		opts = append(opts, option.WithCredentials(creds))
 	}
-	creds, err := google.CredentialsFromJSON(ctx, key, storage.ScopeReadWrite)
-	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("could not get GCS credentials: %v", err))
-	}
-	opts = append(opts, option.WithCredentials(creds))
 	s, err := storage.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, errors.E(op, fmt.Errorf("could not create new storage client: %s", err))

--- a/pkg/storage/gcp/gcp_test.go
+++ b/pkg/storage/gcp/gcp_test.go
@@ -51,6 +51,9 @@ func getStorage(t testing.TB) *Storage {
 	bucketName := randomBucketName(os.Getenv("DRONE_PULL_REQUEST"))
 	cfg := getTestConfig(bucketName)
 	if cfg == nil {
+		// Don't fail if there's no test config, so that these tests don't
+		// fail when you run them locally
+		t.Log("No GCS Config found")
 		t.SkipNow()
 	}
 

--- a/pkg/storage/gcp/gcp_test.go
+++ b/pkg/storage/gcp/gcp_test.go
@@ -75,9 +75,9 @@ func getTestConfig(bucket string) *config.GCPConfig {
 		return nil
 	}
 	return &config.GCPConfig{
-		Bucket:         bucket,
-		ServiceAccount: creds,
-		ProjectID:      os.Getenv("GCS_PROJECT_ID"),
+		Bucket:    bucket,
+		JSONKey:   creds,
+		ProjectID: os.Getenv("GCS_PROJECT_ID"),
 	}
 }
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

When I merged https://github.com/gomods/athens/pull/1428,
I accidentally introduced a build failure where Athens couldn't find the GCS key,
and wouldn't start up. It silently failed though, because we start Athens up in
the background

**How is the fix applied?**

I have added backward compatibility to Athens, so that it falls back to the old
`ATHENS_STORAGE_GCP_SERVICE_ACCOUNT` env var if the new `ATHENS_STORAGE_GCP_SERVICE_ACCOUNT`
isn't found

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Closes #1479
Fixes https://github.com/gomods/athens/issues/1478

<!-- 
example: Fixes #123
-->

In a follow up to this PR, the `.drone.yml` needs to be updated so that the `athens-proxy` step uses the `gomods/athens:canary` image