### PR TITLE
Going back to using the canary image in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -154,7 +154,7 @@ services:
   ports:
     - 6379
 - name: athens-proxy
-  image: gomods/athens-dev:canary
+  image: gomods/athens:canary
   pull: always
   ports:
     - 3000

--- a/.drone.yml
+++ b/.drone.yml
@@ -154,7 +154,7 @@ services:
   ports:
     - 6379
 - name: athens-proxy
-  image: gomods/athens-dev:221c451 # temporary to make the build pass, revert to gomods/athens:canary after merge.
+  image: gomods/athens-dev:canary
   pull: always
   ports:
     - 3000


### PR DESCRIPTION
**What is the problem I am trying to address?**

In #1480, we had to temporarily use a commit-specific athens image
to fix the build at the time. In that PR, we wrote a TODO to change
it back.

**How is the fix applied?**

I've changed the image we use in drone back to `canary`

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

This is a follow-up to the follow-on work described in 
https://github.com/gomods/athens/pull/1480#issue-349109197

<!-- 
example: Fixes #123
-->