### PR TITLE
Adding a better error message for download mode

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/gomods/athens/pkg/config"
+	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/log"
 	mw "github.com/gomods/athens/pkg/middleware"
 	"github.com/gomods/athens/pkg/module"
@@ -132,6 +133,9 @@ func App(conf *config.Config) (http.Handler, error) {
 		lggr,
 		conf,
 	); err != nil {
+		if errors.IsConfigErr(err) {
+			return nil, err
+		}
 		err = fmt.Errorf("error adding proxy routes (%s)", err)
 		return nil, err
 	}

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gomods/athens/pkg/download"
 	"github.com/gomods/athens/pkg/download/addons"
 	"github.com/gomods/athens/pkg/download/mode"
+	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/module"
 	"github.com/gomods/athens/pkg/stash"
@@ -98,7 +99,10 @@ func addProxyRoutes(
 	}
 	st := stash.New(mf, s, stash.WithPool(c.GoGetWorkers), withSingleFlight)
 
-	df, err := mode.NewFile(c.DownloadMode, c.DownloadURL)
+	df, err := mode.NewFile(c.DownloadMode, c.DownloadURL, errors.ConfigError(
+		"DownloadMode",
+		"https://docs.gomods.io/configuration/download/",
+	))
 	if err != nil {
 		return err
 	}

--- a/pkg/download/mode/mode.go
+++ b/pkg/download/mode/mode.go
@@ -18,13 +18,11 @@ type Mode string
 
 // DownloadMode constants. For more information see config.dev.toml
 const (
-	Sync            Mode = "sync"
-	Async           Mode = "async"
-	Redirect        Mode = "redirect"
-	AsyncRedirect   Mode = "async_redirect"
-	None            Mode = "none"
-	downloadModeErr      = "download mode is not set"
-	invalidModeErr       = "unrecognized download mode: %s"
+	Sync          Mode = "sync"
+	Async         Mode = "async"
+	Redirect      Mode = "redirect"
+	AsyncRedirect Mode = "async_redirect"
+	None          Mode = "none"
 )
 
 // DownloadFile represents a custom HCL format of
@@ -50,11 +48,11 @@ type DownloadPath struct {
 // you can either point to a file path by passing
 // file:/path/to/file OR custom:<base64-encoded-hcl>
 // directly.
-func NewFile(m Mode, downloadURL string) (*DownloadFile, error) {
+func NewFile(m Mode, downloadURL string, errFn errors.ConfigErrFn) (*DownloadFile, error) {
 	const op errors.Op = "downloadMode.NewFile"
 
 	if m == "" {
-		return nil, errors.E(op, downloadModeErr)
+		return nil, errFn("You have to pass a value.")
 	}
 
 	if strings.HasPrefix(string(m), "file:") {
@@ -76,7 +74,7 @@ func NewFile(m Mode, downloadURL string) (*DownloadFile, error) {
 	case Sync, Async, Redirect, AsyncRedirect, None:
 		return &DownloadFile{Mode: m, DownloadURL: downloadURL}, nil
 	default:
-		return nil, errors.E(op, errors.KindBadRequest, fmt.Sprintf(invalidModeErr, m))
+		return nil, errFn(fmt.Sprintf("%s isn't a valid value.", m))
 	}
 }
 

--- a/pkg/download/mode/mode_test.go
+++ b/pkg/download/mode/mode_test.go
@@ -3,6 +3,8 @@ package mode
 import (
 	"fmt"
 	"testing"
+
+	"github.com/gomods/athens/pkg/errors"
 )
 
 var testCases = []struct {
@@ -119,6 +121,10 @@ func TestMode(t *testing.T) {
 }
 
 func TestNewFile_err(t *testing.T) {
+	dlModeErrFn := errors.ConfigError(
+		"DownloadMode",
+		"https://docs.gomods.io/configuration/download/",
+	)
 	tc := []struct {
 		name     string
 		mode     Mode
@@ -127,12 +133,12 @@ func TestNewFile_err(t *testing.T) {
 		{
 			name:     "empty mode",
 			mode:     "",
-			expected: downloadModeErr,
+			expected: dlModeErrFn("You have to pass a value.").Error(),
 		},
 		{
 			name:     "invalid mode",
 			mode:     "invalidMode",
-			expected: fmt.Sprintf(invalidModeErr, "invalidMode"),
+			expected: dlModeErrFn(fmt.Sprintf("%s isn't a valid value.", "invalidMode")).Error(),
 		},
 	}
 	for _, c := range tc {

--- a/pkg/errors/config.go
+++ b/pkg/errors/config.go
@@ -1,0 +1,41 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConfigErrFn is a function that can create a new configuration error. You pass it a
+// message specific to the error you found when you were validating configuration,
+// and it knows how to print out the actual configuration name and other helpful information.
+type ConfigErrFn func(string) error
+
+type configErr struct {
+	str string
+}
+
+func (c configErr) Error() string {
+	return c.str
+}
+
+// ConfigError returns a function that creates a configuration error to be printed
+// to the terminal. Call this function and pass its return value down the call stack to
+// functions that validate configuration fields.
+//
+// The function that ConfigError returns
+//
+// For example:
+//
+//	downloadModeFn := ConfigError("DownloadMode (ATHENS_DOWNLOAD_MODE)")
+//	err := doThingsWithDownloadMode(configStruct, downloadModeFn)
+func ConfigError(field string, url string) ConfigErrFn {
+	return func(helpText string) error {
+		slc := []string{
+			fmt.Sprintf("There was a configuration error with %s. %s", field, helpText),
+		}
+		if url != "" {
+			slc = append(slc, fmt.Sprintf("See %s for more information.", url))
+		}
+		return &configErr{str: strings.Join(slc, "\n")}
+	}
+}

--- a/pkg/errors/kinds.go
+++ b/pkg/errors/kinds.go
@@ -4,3 +4,9 @@ package errors
 func IsNotFoundErr(err error) bool {
 	return Kind(err) == KindNotFound
 }
+
+// IsConfigErr returns true if the given err is a configuration error
+func IsConfigErr(err error) bool {
+	_, ok := err.(*configErr)
+	return ok
+}


### PR DESCRIPTION
**What is the problem I am trying to address?**

There are a lot of configuration options and it's easy to forget something, misconfigure
Athens, and get stuck when you make a configuration mistake.

`DownloadMode` is a good example because it cannot be empty, and when it is, we just say
"it can't be empty" without any extra context.


See https://github.com/gomods/athens/issues/1491
and https://github.com/gomods/athens/issues/1336 for more discussion on `DownloadMode`

**How is the fix applied?**

I've added a nicer error message in cases where `DownloadMode` is empty, or it is set
to an invalid value.

If this code is acceptable, I'd like to apply it to a few other config values 
(in a follow-up PR) that are easy to get wrong.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

ref https://github.com/gomods/athens/issues/1491, since this checks existence and 
validates values for download mode, and also reports errors in a more human-friendly way.

cc/ @bluekeyes