### PR TITLE
Making 'make build' not cd into the cmd/proxy directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 
 .PHONY: build
 build: ## build the athens proxy
-	cd cmd/proxy && go build
+	go build -o ./cmd/proxy/proxy ./cmd/proxy
 
 .PHONY: build-ver
 build-ver: ## build the athens proxy with version number


### PR DESCRIPTION
**What is the problem I am trying to address?**

`make build` runs `cd cmd/proxy` before doing the `go build`. That means that you end up in a different directory after you run this command.

**How is the fix applied?**

I've changed the `make build` from `cd cmd/proxy && go build` to `go build -o ./cmd/proxy/proxy ./cmd/proxy`, so that the exact same thing happens as before, except you stay in the directory you started at 

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

Fixes https://github.com/gomods/athens/issues/1495

