### PR TITLE
Fixing the link to the download config docs from the deprecated filter docs

### DIFF
--- a/docs/content/configuration/filter.md
+++ b/docs/content/configuration/filter.md
@@ -4,7 +4,7 @@ description: Configuring modules that are stored on the proxy
 weight: 6
 ---
 
->Note: the filter file that this page documents is deprecated. Please instead see ["Filtering with the download mode file"](./download) for updated instructions on how to filter modules in Athens.
+>Note: the filter file that this page documents is deprecated. Please instead see ["Filtering with the download mode file"](/configuration/download) for updated instructions on how to filter modules in Athens.
 
 The proxy supports the following three use cases
 


### PR DESCRIPTION
**What is the problem I am trying to address?**

The filter docs (now deprecated) had a broken link to the download mode documentation

**How is the fix applied?**

I fixed the link

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

N/A

<!-- 
example: Fixes #123
-->