### PR TITLE
Dockerfile: ensure right perms for production setting

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -24,6 +24,8 @@ COPY --from=builder /bin/athens-proxy /bin/athens-proxy
 COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/config.toml
 COPY --from=builder /usr/local/go/bin/go /bin/go
 
+RUN chmod 700 /config/config.toml
+
 # Add tini, see https://github.com/gomods/athens/issues/1155 for details.
 RUN apk add --update bzr git git-lfs mercurial openssh-client subversion procps fossil tini && \
 	mkdir -p /usr/local/go


### PR DESCRIPTION
Fixes https://github.com/gomods/athens/issues/1529

I believe will require a new patch release