### PR TITLE
Remove chart version from deployments and services selectors

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.4.3
+version: 0.4.4
 appVersion: 0.7.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "fullname" . }}
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
   template:
     metadata:

--- a/charts/athens-proxy/templates/jaeger-deploy.yaml
+++ b/charts/athens-proxy/templates/jaeger-deploy.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "fullname" . }}-jaeger
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
   template:
     metadata:

--- a/charts/athens-proxy/templates/jaeger-svc.yaml
+++ b/charts/athens-proxy/templates/jaeger-svc.yaml
@@ -37,6 +37,5 @@ spec:
       targetPort: 16686
   selector:
     app: {{ template "fullname" . }}-jaeger
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 {{- end -}}

--- a/charts/athens-proxy/templates/service.yaml
+++ b/charts/athens-proxy/templates/service.yaml
@@ -23,5 +23,4 @@ spec:
     {{- end }}
   selector:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"


### PR DESCRIPTION
Label selectors are immutable; having the chart version part of the label selectors means that upgrades require a full recreation of the deployments and services instead of a simple
update.
This branch removes the chart version from the selectors to allow smooth upgrades.

With the current code chart upgrades (without using `--force`) break with (this is an upgrade from 0.3.3 to 0.4.3):
```
Upgrading charts/vendor/athens-proxy
UPGRADE FAILED
ROLLING BACK
Error: Deployment.apps "athens-proxy-release" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"chart":"athens-proxy-0.4.3", "release":"athens-proxy-release", "app":"athens-proxy-release"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates for details.

See an example of a high-quality chart (prometheus): https://github.com/helm/charts/blob/master/stable/prometheus/templates/_helpers.tpl#L19-L22 / https://github.com/helm/charts/blob/master/stable/prometheus/templates/_helpers.tpl#L74-L77