### PR TITLE
bump img version && remove GoProxy

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: athens-proxy
-version: 0.4.4
-appVersion: 0.7.0
+version: 0.4.5
+appVersion: 0.7.2
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png
 keywords:

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 image:
   registry: docker.io
   repository: gomods/athens
-  tag: v0.7.0
+  tag: v0.7.2
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -75,10 +75,6 @@ func addProxyRoutes(
 	// 4. The plain stash.New just takes a request from upstream and saves it into storage.
 	fs := afero.NewOsFs()
 
-	// TODO: remove before we release v0.7.0
-	if c.GoProxy != "direct" && c.GoProxy != "" {
-		l.Error("GoProxy is deprecated, please use GoBinaryEnvVars")
-	}
 	if !c.GoBinaryEnvVars.HasKey("GONOSUMDB") {
 		c.GoBinaryEnvVars.Add("GONOSUMDB", strings.Join(c.NoSumPatterns, ","))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,6 @@ type Config struct {
 	TimeoutConf
 	GoEnv            string    `validate:"required" envconfig:"GO_ENV"`
 	GoBinary         string    `validate:"required" envconfig:"GO_BINARY_PATH"`
-	GoProxy          string    `envconfig:"GOPROXY"`
 	GoBinaryEnvVars  EnvList   `envconfig:"ATHENS_GO_BINARY_ENV_VARS"`
 	GoGetWorkers     int       `validate:"required" envconfig:"ATHENS_GOGET_WORKERS"`
 	ProtocolWorkers  int       `validate:"required" envconfig:"ATHENS_PROTOCOL_WORKERS"`
@@ -142,7 +141,6 @@ func defaultConfig() *Config {
 		GoBinary:         "go",
 		GoBinaryEnvVars:  EnvList{"GOPROXY=direct"},
 		GoEnv:            "development",
-		GoProxy:          "direct",
 		GoGetWorkers:     10,
 		ProtocolWorkers:  30,
 		LogLevel:         "debug",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -74,7 +74,6 @@ func TestEnvOverrides(t *testing.T) {
 		ProtocolWorkers: 10,
 		LogLevel:        "info",
 		GoBinary:        "go11",
-		GoProxy:         "direct",
 		CloudRuntime:    "gcp",
 		TimeoutConf: TimeoutConf{
 			Timeout: 30,
@@ -264,7 +263,6 @@ func TestParseExampleConfig(t *testing.T) {
 		GoEnv:           "development",
 		LogLevel:        "debug",
 		GoBinary:        "go",
-		GoProxy:         "direct",
 		GoGetWorkers:    10,
 		ProtocolWorkers: 30,
 		CloudRuntime:    "none",
@@ -309,7 +307,6 @@ func getEnvMap(config *Config) map[string]string {
 	envVars := map[string]string{
 		"GO_ENV":                  config.GoEnv,
 		"GO_BINARY_PATH":          config.GoBinary,
-		"GOPROXY":                 config.GoProxy,
 		"ATHENS_GOGET_WORKERS":    strconv.Itoa(config.GoGetWorkers),
 		"ATHENS_PROTOCOL_WORKERS": strconv.Itoa(config.ProtocolWorkers),
 		"ATHENS_LOG_LEVEL":        config.LogLevel,


### PR DESCRIPTION
## What is the problem I am trying to address?

1. This should fix the issue #1560 which requires the release to be bumped in the chart.
2. Also removes some deprecated code that we don't need anymore since v0.7.0

## How is the fix applied?

Minor change to the `chart` folder and subsequent removals of wherever GoProxy environment was mentioned.

Have a quick peek through and make sure I've not done something stupid and if I need to alter any tests for move to `GoBinaryEnvVars` will y'.

I also gave it a quick test and it seems to workTM

## What GitHub issue(s) does this PR fix or close?

Fixes #1560 