### PR TITLE
Fixing code like the go team printed version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The Athens project would not be possible without the amazing projects it builds 
 
 We all strive to write nice and readable code which can be understood by every person of the team. To achieve that we follow principles described in Brian's talk `Code like the Go team`.
 
-- [Printed version](https://learn-golang.com/en/goteam/)
+- [Printed version](https://www.brianketelsen.com/slides/gcru18-best/#1)
 - [Gophercon RU talk](https://www.youtube.com/watch?v=MzTcsI6tn-0)
 
 # Code of Conduct


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

The "Code like the go team" link to the printed version goes to a broken link

## How is the fix applied?

I fixed the link. It points to https://www.brianketelsen.com/slides/gcru18-best/#1 now.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any issues, that's ok. You can leave this blank.

    If it does, then use the below "Fixes #<issue number>" notation below
-->

Fixes https://github.com/gomods/athens/issues/1565

<!-- 
example: Fixes #123
-->
