### PR TITLE
Updating helm chart image version to latest

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: athens-proxy
-version: 0.4.4
-appVersion: 0.7.0
+version: 0.4.8
+appVersion: 0.8.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png
 keywords:

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 image:
   registry: docker.io
   repository: gomods/athens
-  tag: v0.7.0
+  tag: v0.8.0
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

The [latest release](https://github.com/gomods/athens/releases/tag/v0.8.0) helm chart is pointing to an old image version, v0.7.0

## How is the fix applied?

I updated the image version to v0.8.0

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any issues, that's ok. You can leave this blank.

    If it does, then use the below "Fixes #<issue number>" notation below
-->

Fixes #

<!-- 
example: Fixes #123
-->
