### PR TITLE
Move SingleFlight.Redis.Password back under SingleFlight.Redis in config

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -294,6 +294,9 @@ SingleFlightType = "memory"
         # TODO(marwan): enable multiple endpoints for redis clusters.
         # Env override: ATHENS_REDIS_ENDPOINT
         Endpoint = "127.0.0.1:6379"
+        # Password is the password for a redis SingleFlight lock.
+        # Env override: ATHENS_REDIS_PASSWORD
+        Password = ""
     [SingleFlight.RedisSentinel]
         # Endpoints is the redis sentinel endpoints to discover a redis 
         # master for a SingleFlight lock.
@@ -305,10 +308,6 @@ SingleFlightType = "memory"
         # SentinelPassword is an optional password for authenticating with
         # redis sentinel
         SentinelPassword = "sekret"
-
-        # Password is the password for a redis SingleFlight lock.
-        # Env override: ATHENS_REDIS_PASSWORD
-        Password = ""
 
 [Storage]
     # Only storage backends that are specified in Proxy.StorageType are required here


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

I goofed in #1545, this fixes that goof

## How is the fix applied?

Moved the Password field for `SingleFlight.Redis` back to where it was in the example config
