### PR TITLE
Fixing pacmod command

### DIFF
--- a/docs/content/configuration/prefill-disk-cache.md
+++ b/docs/content/configuration/prefill-disk-cache.md
@@ -25,7 +25,7 @@ The `source.zip` file has a specific directory structure and the `$VERSION.info`
 To install the `pacmod` tool, run `go get` like this:
 
 ```console
-$ go get github.com/plexsystems/pacmod
+$ go get github.com/plexsystems/pacmod@v0.4.0
 ```
 
 This command will install the `pacmod` binary to your `$GOPATH/bin/pacmod` directory, so make sure that is in your `$PATH`.

--- a/docs/content/configuration/prefill-disk-cache.md
+++ b/docs/content/configuration/prefill-disk-cache.md
@@ -45,7 +45,7 @@ $ export VERSION="v1.0.0"
 Next, navigate to the top-level directory of the module source code, and run `pacmod` like this:
 
 ```console
-$ pacmod pack $VERSION .
+$ pacmod pack github.com/my/module $VERSION .
 ```
 
 Once this command is done, you'll notice three new files in the same same directory you ran the command from:


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

The `pacmod pack` command on the [pre-filling docs](https://docs.gomods.io/configuration/prefill-disk-cache/) was wrong

## How is the fix applied?

I fixed it

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any issues, that's ok. You can leave this blank.

    If it does, then use the below "Fixes #<issue number>" notation below
-->

Ref https://github.com/gomods/athens/issues/1416, because that issue is related to a problem related to using `pacmod` to "side-load" disk storage

<!-- 
example: Fixes #123
-->
