### PR TITLE
Enable multiple access modes for PVC

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.4.8
+version: 0.4.9
 appVersion: 0.8.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/storage-pvc.yaml
+++ b/charts/athens-proxy/templates/storage-pvc.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   accessModes:
     - {{ .Values.storage.disk.persistence.accessMode | quote }}
+    {{- range .Values.storage.disk.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
   resources:
     requests:
       storage: {{ .Values.storage.disk.persistence.size | quote }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -48,6 +48,8 @@ storage:
       ## Note if you use disk.persistence.enabled, replicaCount should be set to 1 unless your access mode is ReadWriteMany
       enabled: false
       accessMode: ReadWriteOnce
+      ## Enable multiple access modes
+      accessModes: []
       size: 4Gi
   mongo:
     # you must set this on the command line when you run 'helm install'


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

For my particular setup, I want Athens to RW to the volume but enable CI workers to access the volumes in RO mode.
