### PR TITLE
charts: allow to set deployment update strategy

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.4.8
+version: 0.4.9
 appVersion: 0.8.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/master/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -9,6 +9,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.replicaCount }}
+{{- if .Values.strategy }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+  {{- if eq .Values.strategy.type "Recreate" }}
+  rollingUpdate: null
+  {{- end }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -17,6 +17,10 @@ livenessProbe:
   successThreshold: 1
   timeoutSeconds: 1
 
+## Server Deployment Strategy type
+# strategy:
+#   type: Recreate
+
 service:
   ## Additional annotations to apply to the service
   annotations: {}
@@ -46,6 +50,7 @@ storage:
     storageRoot: "/var/lib/athens"
     persistence:
       ## Note if you use disk.persistence.enabled, replicaCount should be set to 1 unless your access mode is ReadWriteMany
+      ## and strategy type must be Recreate
       enabled: false
       accessMode: ReadWriteOnce
       size: 4Gi


### PR DESCRIPTION
## What is the problem I am trying to address?

If [`storage.disk.persistence.enabled`](https://github.com/gomods/athens/blob/6b5b62c0fceb97e8c86816fcf82a93f730a330e3/charts/athens-proxy/values.yaml#L49) is set to `true` and the `accessMode` is not `ReadWriteMany`. the default strategy must be switched to `type: Recreate`. if not it will fail as the other pod is using the PVC.
