### PR TITLE
fix build argument issue in drone deployment

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -6,6 +6,8 @@
 # See project Makefile if using make.
 # See docker --build-arg if building directly.
 ARG GOLANG_VERSION=1.14
+ARG ALPINE_VERSION=3.11.5
+
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
 WORKDIR $GOPATH/src/github.com/gomods/athens
@@ -16,7 +18,6 @@ ARG VERSION="unset"
 
 RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && GO111MODULE=on CGO_ENABLED=0 GOPROXY="https://proxy.golang.org" go build -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE" -o /bin/athens-proxy ./cmd/proxy
 
-ARG ALPINE_VERSION=3.11.5
 FROM alpine:${ALPINE_VERSION}
 
 ENV GO111MODULE=on


### PR DESCRIPTION
## What is the problem I am trying to address?

In the recent change we added a build argument for the alpine version:
https://github.com/gomods/athens/blob/a8467661c219d5c31733ec1fc2ebb8fed1fb489a/cmd/proxy/Dockerfile#L19-L20

Due to it being a multistage build the argument is dropped before `FROM` so we need to set this globally.

You can see the issue manifested here https://cloud.drone.io/gomods/athens/1763/1/10

Unfortunatly this wasn't picked up during PR due to docker-build-latest only being called when branch is master and on push.

Edit to reference issue #1584 
