### PR TITLE
Add client tracing to external storage requests

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -26,11 +26,6 @@ func App(conf *config.Config) (http.Handler, error) {
 	// ENV is used to help switch settings based on where the
 	// application is being run. Default is "development".
 	ENV := conf.GoEnv
-	store, err := GetStorage(conf.StorageType, conf.Storage, conf.TimeoutDuration())
-	if err != nil {
-		err = fmt.Errorf("error getting storage configuration (%s)", err)
-		return nil, err
-	}
 
 	if conf.GithubToken != "" {
 		if conf.NETRCPath != "" {
@@ -115,9 +110,21 @@ func App(conf *config.Config) (http.Handler, error) {
 		r.Use(mw.NewFilterMiddleware(mf, conf.GlobalEndpoint))
 	}
 
+	client := &http.Client{
+		Transport: &ochttp.Transport{
+			Base: http.DefaultTransport,
+		},
+	}
+
 	// Having the hook set means we want to use it
 	if vHook := conf.ValidatorHook; vHook != "" {
 		r.Use(mw.NewValidationMiddleware(vHook))
+	}
+
+	store, err := GetStorage(conf.StorageType, conf.Storage, conf.TimeoutDuration(), client)
+	if err != nil {
+		err = fmt.Errorf("error getting storage configuration (%s)", err)
+		return nil, err
 	}
 
 	proxyRouter := r

--- a/cmd/proxy/actions/storage.go
+++ b/cmd/proxy/actions/storage.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/gomods/athens/pkg/config"
@@ -20,7 +21,7 @@ import (
 )
 
 // GetStorage returns storage backend based on env configuration
-func GetStorage(storageType string, storageConfig *config.StorageConfig, timeout time.Duration) (storage.Backend, error) {
+func GetStorage(storageType string, storageConfig *config.StorageConfig, timeout time.Duration, client *http.Client) (storage.Backend, error) {
 	const op errors.Op = "actions.GetStorage"
 	switch storageType {
 	case "memory":
@@ -65,8 +66,7 @@ func GetStorage(storageType string, storageConfig *config.StorageConfig, timeout
 		if storageConfig.External == nil {
 			return nil, errors.E(op, "Invalid External Storage Configuration")
 		}
-		// TODO(marwan-at-work): add client tracing
-		return external.NewClient(storageConfig.External.URL, nil), nil
+		return external.NewClient(storageConfig.External.URL, client), nil
 	default:
 		return nil, fmt.Errorf("storage type %s is unknown", storageType)
 	}


### PR DESCRIPTION
This PR adds the ochttp Transport plugin into an http client in order to propagate tracing. 

Fixes https://github.com/gomods/athens/issues/1625