### PR TITLE
pkg/middleware: add tracing to ValidationHook

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -118,7 +118,7 @@ func App(conf *config.Config) (http.Handler, error) {
 
 	// Having the hook set means we want to use it
 	if vHook := conf.ValidatorHook; vHook != "" {
-		r.Use(mw.NewValidationMiddleware(vHook))
+		r.Use(mw.NewValidationMiddleware(client, vHook))
 	}
 
 	store, err := GetStorage(conf.StorageType, conf.Storage, conf.TimeoutDuration(), client)

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -95,7 +95,7 @@ func Test_FilterMiddleware(t *testing.T) {
 func hookFilterApp(hook string) *mux.Router {
 	h := func(w http.ResponseWriter, r *http.Request) {}
 	r := mux.NewRouter()
-	r.Use(NewValidationMiddleware(hook))
+	r.Use(NewValidationMiddleware(http.DefaultClient, hook))
 
 	r.HandleFunc(pathList, h)
 	r.HandleFunc(pathVersionInfo, h)


### PR DESCRIPTION
I noticed that our ValidationHook does not trace outgoing client calls. This PR does two things: 

1. It adds client tracing to outgoing Validation calls
2. It propagates the request context so that if a request is cancelled, the ValidationHook also gets cancelled 