### PR TITLE
Allow users to specify the module fetcher's temporary directory

### DIFF
--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -96,7 +96,7 @@ func addProxyRoutes(
 	if err := c.GoBinaryEnvVars.Validate(); err != nil {
 		return err
 	}
-	mf, err := module.NewGoGetFetcher(c.GoBinary, c.GoBinaryEnvVars, fs)
+	mf, err := module.NewGoGetFetcher(c.GoBinary, c.GoGetDir, c.GoBinaryEnvVars, fs)
 	if err != nil {
 		return err
 	}

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -62,6 +62,16 @@ GoBinaryEnvVars = ["GOPROXY=direct"]
 # Env override: ATHENS_GOGET_WORKERS
 GoGetWorkers = 10
 
+# GoGetDir specifies the temporary directory that Athens
+# will use to fetch modules from VCS prior to persisting
+# them to a storage backend. This is useful if you are in a
+# Kubernetes environment where a specific path is volumed into 
+# a directory that has larger disk resources. If the value is
+# empty, Athens will use the default OS temporary directory.
+# 
+# Env override: ATHENS_GOGOET_DIR
+GoGetDir = ""
+
 # ProtocolWorkers specifies how many concurrent
 # requests can you handle at a time for all
 # download protocol paths. This is different from

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	GoProxy          string    `envconfig:"GOPROXY"`
 	GoBinaryEnvVars  EnvList   `envconfig:"ATHENS_GO_BINARY_ENV_VARS"`
 	GoGetWorkers     int       `validate:"required" envconfig:"ATHENS_GOGET_WORKERS"`
+	GoGetDir         string    `envconfig:"ATHENS_GOGOET_DIR"`
 	ProtocolWorkers  int       `validate:"required" envconfig:"ATHENS_PROTOCOL_WORKERS"`
 	LogLevel         string    `validate:"required" envconfig:"ATHENS_LOG_LEVEL"`
 	CloudRuntime     string    `validate:"required" envconfig:"ATHENS_CLOUD_RUNTIME"`

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -37,7 +37,7 @@ func getDP(t *testing.T) Protocol {
 	}
 	goBin := conf.GoBinary
 	fs := afero.NewOsFs()
-	mf, err := module.NewGoGetFetcher(goBin, conf.GoBinaryEnvVars, fs)
+	mf, err := module.NewGoGetFetcher(goBin, conf.GoGetDir, conf.GoBinaryEnvVars, fs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -20,6 +20,7 @@ type goGetFetcher struct {
 	fs           afero.Fs
 	goBinaryName string
 	envVars      []string
+	gogetDir     string
 }
 
 type goModule struct {
@@ -35,7 +36,7 @@ type goModule struct {
 }
 
 // NewGoGetFetcher creates fetcher which uses go get tool to fetch modules
-func NewGoGetFetcher(goBinaryName string, envVars []string, fs afero.Fs) (Fetcher, error) {
+func NewGoGetFetcher(goBinaryName, gogetDir string, envVars []string, fs afero.Fs) (Fetcher, error) {
 	const op errors.Op = "module.NewGoGetFetcher"
 	if err := validGoBinary(goBinaryName); err != nil {
 		return nil, errors.E(op, err)
@@ -44,6 +45,7 @@ func NewGoGetFetcher(goBinaryName string, envVars []string, fs afero.Fs) (Fetche
 		fs:           fs,
 		goBinaryName: goBinaryName,
 		envVars:      envVars,
+		gogetDir:     gogetDir,
 	}, nil
 }
 
@@ -55,7 +57,7 @@ func (g *goGetFetcher) Fetch(ctx context.Context, mod, ver string) (*storage.Ver
 	defer span.End()
 
 	// setup the GOPATH
-	goPathRoot, err := afero.TempDir(g.fs, "", "athens")
+	goPathRoot, err := afero.TempDir(g.fs, g.gogetDir, "athens")
 	if err != nil {
 		return nil, errors.E(op, err)
 	}


### PR DESCRIPTION
This PR adds a new "GoGetDir" config that users can specify to be passed to the module.Fetcher to leverage K8s volumes as well as have a consistent place for where "go mod download" results are temporarily stored. 

Fixes https://github.com/gomods/athens/issues/1635