### PR TITLE
Support downloadURLs with paths

### DIFF
--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -3,6 +3,7 @@ package download
 import (
 	"net/http"
 	"net/url"
+	"path/filepath"
 
 	"github.com/gomods/athens/pkg/download/mode"
 	"github.com/gomods/athens/pkg/log"
@@ -60,6 +61,6 @@ func getRedirectURL(base, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	url.Path = path
+	url.Path = filepath.Join(url.Path, path)
 	return url.String(), nil
 }

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -3,7 +3,7 @@ package download
 import (
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 
 	"github.com/gomods/athens/pkg/download/mode"
 	"github.com/gomods/athens/pkg/log"
@@ -56,11 +56,11 @@ func RegisterHandlers(r *mux.Router, opts *HandlerOpts) {
 	r.Handle(PathVersionZip, LogEntryHandler(ZipHandler, opts)).Methods(http.MethodGet)
 }
 
-func getRedirectURL(base, path string) (string, error) {
+func getRedirectURL(base, downloadPath string) (string, error) {
 	url, err := url.Parse(base)
 	if err != nil {
 		return "", err
 	}
-	url.Path = filepath.Join(url.Path, path)
+	url.Path = path.Join(url.Path, downloadPath)
 	return url.String(), nil
 }

--- a/pkg/download/mode/mode_test.go
+++ b/pkg/download/mode/mode_test.go
@@ -26,6 +26,13 @@ var testCases = []struct {
 		expectedURL:  "gomods.io",
 	},
 	{
+		name:         "redirect with download url suffix",
+		file:         &DownloadFile{Mode: Redirect, DownloadURL: "internal.domain/repository/gonexus"},
+		input:        "github.com/gomods/athens",
+		expectedMode: Redirect,
+		expectedURL:  "internal.domain/repository/gonexus",
+	},
+	{
 		name: "pattern match",
 		file: &DownloadFile{
 			Mode: Sync,


### PR DESCRIPTION
## What is the problem I am trying to address?

If a downloadURL with a path such https://internal.domain/repository/gonexus is configured then this is truncated to https://internal.domain when redirecting to the upstream proxy, resulting in failures.

## How is the fix applied?

In getRedirectURL append the path to the downloadURL path rather than replacing it.

## What GitHub issue(s) does this PR fix or close?

Fixes #1639   

Signed-off-by: Keith Burdis <keith.burdis@gs.com>
