### PR TITLE
Replace limit with pagesize in docs for catalog endpoint

### DIFF
--- a/docs/content/design/proxy.md
+++ b/docs/content/design/proxy.md
@@ -69,9 +69,9 @@ The proxy provides a `/catalog` service endpoint to fetch all the modules and th
 
 A query is of the form
 
-`https://proxyurl/catalog?token=foo&limit=47`
+`https://proxyurl/catalog?token=foo&pagesize=47`
 
-Where token is an optional continuation token and limit is the desired size of the returned page.
+Where token is an optional continuation token and pagesize is the desired size of the returned page.
 The `token` parameter is not required for the first call and it's needed for handling paginated results.
 
 


### PR DESCRIPTION
## What is the problem I am trying to address?

The documentation at https://docs.gomods.io/design/proxy/#catalog-endpoint incorrectly gives the query parameter "format" instead of "pagesize".

## How is the fix applied?

Updated the markdown.

## What GitHub issue(s) does this PR fix or close?

none