### PR TITLE
Fix link in deprecation note.

### DIFF
--- a/docs/content/configuration/upstream.md
+++ b/docs/content/configuration/upstream.md
@@ -4,7 +4,7 @@ description: How to Configure Athens to Fetch Missing Modules From an Upstream M
 weight: 7
 ---
 
->Note: the filter file that this page documents is deprecated. Please instead see ["Filtering with the download mode file"](./download) for updated instructions on how to set upstream repositories in Athens.
+>Note: the filter file that this page documents is deprecated. Please instead see ["Filtering with the download mode file"](/configuration/download) for updated instructions on how to set upstream repositories in Athens.
 
 By default, Athens fetches module code from an upstream version control system (VCS) like github.com, but this can be configured to use a Go modules repository like GoCenter or another Athens Server.
 


### PR DESCRIPTION
## What is the problem I am trying to address?

Broken link in documentation. Basically, same as #1524, just for another page.

## How is the fix applied?

I fixed the link.

## What GitHub issue(s) does this PR fix or close?

None.