### PR TITLE
index: gracefully handle duplicate module indexes

### DIFF
--- a/pkg/index/mem/mem.go
+++ b/pkg/index/mem/mem.go
@@ -2,6 +2,7 @@ package mem
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -22,12 +23,17 @@ type indexer struct {
 func (i *indexer) Index(ctx context.Context, mod, ver string) error {
 	const op errors.Op = "mem.Index"
 	i.mu.Lock()
+	defer i.mu.Unlock()
+	for _, l := range i.lines {
+		if l.Path == mod && l.Version == ver {
+			return errors.E(op, fmt.Sprintf("%s@%s already indexed", mod, ver), errors.KindAlreadyExists)
+		}
+	}
 	i.lines = append(i.lines, &index.Line{
 		Path:      mod,
 		Version:   ver,
 		Timestamp: time.Now(),
 	})
-	i.mu.Unlock()
 	return nil
 }
 

--- a/pkg/stash/stasher.go
+++ b/pkg/stash/stasher.go
@@ -74,7 +74,7 @@ func (s *stasher) Stash(ctx context.Context, mod, ver string) (string, error) {
 		return "", errors.E(op, err)
 	}
 	err = s.indexer.Index(ctx, mod, v.Semver)
-	if err != nil {
+	if err != nil && !errors.Is(err, errors.KindAlreadyExists) {
 		return "", errors.E(op, err)
 	}
 	return v.Semver, nil


### PR DESCRIPTION
If a Stasher calls Index on a backend, and that backend already has the given module@version, then the backend could (and should) return a DuplicateEntry error kind. 

If that happens, we should gracefully handle and ignore this error because we know our index already has this module@version. 

This scenario happens when a user switches backend storages but has not switched index storages. 

Updates https://github.com/gomods/athens/issues/1546