### PR TITLE
pkg/config: make test failures output diff instead of %+v

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gobuffalo/httptest v1.0.4
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.5.1
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.6.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,7 +27,8 @@ func compareConfigs(parsedConf *Config, expConf *Config, t *testing.T) {
 	opts := cmpopts.IgnoreTypes(Storage{}, SingleFlight{}, Index{})
 	eq := cmp.Equal(parsedConf, expConf, opts)
 	if !eq {
-		t.Errorf("Parsed Example configuration did not match expected values. Expected: %+v. Actual: %+v", expConf, parsedConf)
+		diff := cmp.Diff(parsedConf, expConf, opts)
+		t.Errorf("Parsed Example configuration did not match expected values. diff:\n%s", diff)
 	}
 }
 
@@ -485,7 +486,8 @@ func TestDefaultConfigMatchesConfigFile(t *testing.T) {
 	ignoreGoEnvOpts := cmpopts.IgnoreFields(Config{}, "GoEnv")
 	eq := cmp.Equal(defConf, parsedConf, ignoreStorageOpts, ignoreGoEnvOpts)
 	if !eq {
-		t.Errorf("Default values from the config file: %v should equal to the default values returned in case the config file isn't provided %v", parsedConf, defConf)
+		diff := cmp.Diff(defConf, parsedConf, ignoreStorageOpts, ignoreGoEnvOpts)
+		t.Errorf("Default values from the config file should equal to the default values returned in case the config file isn't provided. Diff:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
This PR updates our go-cmp dependency to the latest version and also utilities the `Diff` functionality to output better test failures when the config is not what we expect them to be. 

Before: 

```
=== RUN   TestDefaultConfigMatchesConfigFile
    TestDefaultConfigMatchesConfigFile: /Users/marwansulaiman/marwan/athens/pkg/config/config_test.go:488: Default values from the config file: &{{300} development go direct [GOPROXY=direct] 10  30 debug none false :3001  http://localhost:14268  prometheus memory http://localhost:3001 :3000   false        [https://sum.golang.org] [] sync  memory robots.txt none 0xc00046cea0 0xc000451940 0xc00047a8f0} should equal to the default values returned in case the config file isn't provided &{{300} development go proxy.golang.org [GOPROXY=direct] 10  30 debug none false :3001  http://localhost:14268  prometheus memory http://localhost:3001 :3000   false        [https://sum.golang.org] [] sync  memory robots.txt none 0xc000486580 <nil> 0xc000494350}
```

After: 

```
=== RUN   TestDefaultConfigMatchesConfigFile
    TestDefaultConfigMatchesConfigFile: /Users/marwansulaiman/marwan/athens/pkg/config/config_test.go:490: Default values from the config file should equal to the default values returned in case the config file isn't provided. Diff:
          &config.Config{
          	... // 1 ignored and 1 identical fields
          	GoBinary:        "go",
        - 	GoProxy:         "proxy.golang.org",
        + 	GoProxy:         "direct",
          	GoBinaryEnvVars: {"GOPROXY=direct"},
          	GoGetWorkers:    10,
          	... // 2 ignored and 31 identical fields
          }
```