### PR TITLE
pkg/stash: fix redis failing test

### DIFF
--- a/pkg/stash/with_redis_test.go
+++ b/pkg/stash/with_redis_test.go
@@ -102,8 +102,8 @@ func TestWithRedisLockWithWrongPassword(t *testing.T) {
 		t.Fatal("Expected Connection Error")
 	}
 
-	if err.Error() != "NOAUTH Authentication required." {
-		t.Fatalf("Wrong error was thrown %s\n", err.Error())
+	if !strings.Contains(err.Error(), "NOAUTH Authentication required.") {
+		t.Fatalf("Wrong error was thrown %q\n", err.Error())
 	}
 }
 


### PR DESCRIPTION
I noticed that the Redis test is failing due to some spacing issues in the error message. 

String matching when it comes to error handling is usually not great, but Redis doesn't provide us with error codes here so we should make the string matching a bit looser as there is no compatibility guarantee. 