### PR TITLE
Implement an optional /config endpoint that outputs the used configuration.

### DIFF
--- a/cmd/proxy/actions/config.go
+++ b/cmd/proxy/actions/config.go
@@ -1,0 +1,19 @@
+package actions
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gomods/athens/pkg/config"
+)
+
+// ConfigHandler returns the current configuration as json when hitting the /config url
+func ConfigHandler(c *config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/config" {
+			w.WriteHeader(http.StatusForbidden)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(c)
+	}
+}

--- a/cmd/proxy/actions/config_test.go
+++ b/cmd/proxy/actions/config_test.go
@@ -1,0 +1,118 @@
+package actions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/gomods/athens/pkg/config"
+)
+
+var testStorage = &config.Storage{
+	Disk: &config.DiskConfig{
+		RootPath: "/path/on/disk",
+	},
+	GCP: &config.GCPConfig{
+		ProjectID: "MY_GCP_PROJECT_ID",
+		Bucket:    "MY_GCP_BUCKET",
+	},
+	Minio: &config.MinioConfig{
+		Endpoint:  "127.0.0.1:9001",
+		Key:       "minio",
+		Secret:    "minio123",
+		EnableSSL: false,
+		Bucket:    "gomods",
+	},
+	Mongo: &config.MongoConfig{
+		URL:                   "mongodb://127.0.0.1:27017",
+		CertPath:              "",
+		InsecureConn:          false,
+		DefaultDBName:         "athens",
+		DefaultCollectionName: "modules",
+	},
+	S3: &config.S3Config{
+		Region: "MY_AWS_REGION",
+		Key:    "MY_AWS_ACCESS_KEY_ID",
+		Secret: "MY_AWS_SECRET_ACCESS_KEY",
+		Token:  "",
+		Bucket: "MY_S3_BUCKET_NAME",
+	},
+}
+
+var testConfig = &config.Config{
+	GoEnv:           "development",
+	LogLevel:        "debug",
+	GoBinary:        "go",
+	GoProxy:         "direct",
+	GoGetWorkers:    10,
+	ProtocolWorkers: 30,
+	CloudRuntime:    "none",
+	TimeoutConf: config.TimeoutConf{
+		Timeout: 300,
+	},
+	StorageType:      "memory",
+	GlobalEndpoint:   "http://localhost:3001",
+	Port:             ":3000",
+	EnablePprof:      false,
+	PprofPort:        ":3001",
+	BasicAuthUser:    "",
+	BasicAuthPass:    "",
+	Storage:          testStorage,
+	TraceExporterURL: "http://localhost:14268",
+	TraceExporter:    "",
+	StatsExporter:    "prometheus",
+	SingleFlightType: "memory",
+	GoBinaryEnvVars:  []string{"GOPROXY=direct"},
+	SingleFlight:     &config.SingleFlight{},
+	SumDBs:           []string{"https://sum.golang.org"},
+	NoSumPatterns:    []string{},
+	DownloadMode:     "sync",
+	RobotsFile:       "robots.txt",
+}
+
+func TestConfigHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/config", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := ConfigHandler(testConfig)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	toCheck := &config.Config{}
+	if err := json.Unmarshal(rr.Body.Bytes(), toCheck); err != nil {
+		t.Error("Failed to unmarshal the reply")
+	}
+	if !cmp.Equal(toCheck, testConfig) {
+		diff := cmp.Diff(toCheck, testConfig)
+		t.Errorf("Returned config different from original. Diff: %s", diff)
+	}
+}
+
+func TestConfigHandlerWrongPath(t *testing.T) {
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := ConfigHandler(testConfig)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusForbidden {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusForbidden)
+	}
+}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -72,6 +72,13 @@ func main() {
 		}()
 	}
 
+	if conf.ConfigPort != "" {
+		go func() {
+			log.Printf("Starting serving config at port %v", conf.ConfigPort)
+			log.Fatal(http.ListenAndServe(conf.ConfigPort, actions.ConfigHandler(conf)))
+		}()
+	}
+
 	log.Printf("Starting application at port %v", conf.Port)
 	if cert != "" && key != "" {
 		err = srv.ListenAndServeTLS(conf.TLSCertFile, conf.TLSKeyFile)

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -99,6 +99,12 @@ EnablePprof = false
 # PprofPort specifies the port on which pprof will be exposed if activated.
 PprofPort = ":3001"
 
+# ConfigPort specifies the port on which the /config endpoint will listen for
+# providing the internal configuration.
+# Note if you have secrets in your configuration, this endpoint will return them in plaintext.
+# This is why they are exposed in a different port and should be used for debugging purposes only.
+ConfigPort = ""
+
 # The filename for the include exclude filter.
 # Env override: ATHENS_FILTER_FILE
 #

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -28,3 +28,15 @@ In this section we'll describe how the upstream proxy can be configured to fetch
 In this section we'll describe how to proxy a Checksum DB as per https://go.googlesource.com/proposal/+/master/design/25530-sumdb.md
 
 - [Checksum](/configuration/sumdb)
+
+### Accessing the configuration
+
+By providing an optional `ConfigPort` parameter, Athens will expose a `/config` service endpoint that will return the configuration used by the proxy. 
+
+##### Configuration:
+
+    # ConfigPort optionally enables a config endpoint on the given port
+    # Env override: ATHENS_CONFIG_PORT
+    ConfigPort = ":3001"
+
+The service is exposed on a different port, as the configuration may contain sensitive informations and different access rules may be implemented (i.e., access on the config port may only be granted locally).

--- a/e2etests/all_test.go
+++ b/e2etests/all_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/envy"
+	"github.com/gomods/athens/pkg/config"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -121,12 +122,25 @@ func (m *E2eSuite) TestWrongGoProxy() {
 	m.Assert().NotNil(err, "Wrong proxy should fail")
 }
 
+func (m *E2eSuite) TestConfigEndpoint() {
+	resp, err := http.Get("http://localhost:3003/config")
+	if err != nil {
+		m.Fail("failed to read config", err)
+	}
+	var config config.Config
+	err = json.NewDecoder(resp.Body).Decode(&config)
+	if err != nil {
+		m.Fail("failed to decode config res", err)
+	}
+}
+
 func (m *E2eSuite) getEnv() []string {
 	res := []string{
 		fmt.Sprintf("GOPATH=%s", m.goPath),
 		"GO111MODULE=on",
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("GOCACHE=%s", filepath.Join(m.goPath, "cache")),
+		fmt.Sprintf("ATHENS_CONFIG_PORT=:%d", 3003),
 	}
 	return res
 }

--- a/e2etests/run_athens.go
+++ b/e2etests/run_athens.go
@@ -50,7 +50,10 @@ func runAthensAndWait(ctx context.Context, athensBin string, env []string) error
 	for {
 		select {
 		case <-ticker.C:
-			resp, _ := http.Get("http://localhost:3000/readyz")
+			resp, err := http.Get("http://localhost:3000/readyz")
+			if err != nil {
+				continue
+			}
 			if resp.StatusCode == 200 {
 				return nil
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	SingleFlight      *SingleFlight
 	Storage           *Storage
 	Index             *Index
+	ConfigPort        string `envconfig:"ATHENS_CONFIG_PORT"`
 }
 
 // EnvList is a list of key-value environment


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

By setting a ConfigPort parameter, athens will expose a /config endpoint returning the
configuration currently used.
This is useful for debugging purposes. The port is different as the configuration
may contain sensitive informations, and we want to make sure it's exposed only locally.

## How is the fix applied?

Expose the configfile  via a /config endpoint.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #1503 

<!-- 
example: Fixes #123
-->
