### PR TITLE
Use new Ingress API

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: athens-proxy
-version: 0.4.12
+version: 0.4.13
 appVersion: 0.9.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/templates/ingress.yaml
+++ b/charts/athens-proxy/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "fullname" . -}}
 {{- $servicePort := .Values.service.servicePort -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
## What is the problem I am trying to address?

`extensions/v1beta1` API for Ingress is deprecated since Kuberentes 1.14.
Ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#deprecations


## How is the fix applied?

This commit adds a check using Helm Capabilities to deploy Ingress with newer API.

## What GitHub issue(s) does this PR fix or close?

