### PR TITLE
Support IRSA for S3 bucket

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -35,15 +35,14 @@ type Storage struct {
 func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Config)) (*Storage, error) {
 	const op errors.Op = "s3.New"
 
-	awsConfig := defaults.Config()
+	awsConfig := &aws.Config{}
 	awsConfig.Region = aws.String(s3Conf.Region)
 	for _, o := range options {
 		o(awsConfig)
 	}
 
-	credProviders := defaults.CredProviders(awsConfig, defaults.Handlers())
-
 	if !s3Conf.UseDefaultConfiguration {
+		credProviders := defaults.CredProviders(awsConfig, defaults.Handlers())
 		endpointcreds := []credentials.Provider{
 			endpointcreds.NewProviderClient(*awsConfig, defaults.Handlers(), endpointFrom(s3Conf.CredentialsEndpoint, s3Conf.AwsContainerCredentialsRelativeURI)),
 			&credentials.StaticProvider{
@@ -56,10 +55,10 @@ func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Co
 		}
 
 		credProviders = append(endpointcreds, credProviders...)
+		awsConfig.Credentials = credentials.NewChainCredentials(credProviders)
 	}
 
 	awsConfig.S3ForcePathStyle = aws.Bool(s3Conf.ForcePathStyle)
-	awsConfig.Credentials = credentials.NewChainCredentials(credProviders)
 	awsConfig.CredentialsChainVerboseErrors = aws.Bool(true)
 	if s3Conf.Endpoint != "" {
 		awsConfig.Endpoint = aws.String(s3Conf.Endpoint)


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?
Support IAM Roles for Service Accounts, when the back-end storage is an S3 bucket.

Describe the issue you have been trying to solve.
If AWS credentials are provided keep using then, otherwise use default credential methods.

Mention briefly how you have applied the fix.
I have installed a pod on a kubernetes cluster with a docker image that has this fix and athens proxy with s3 bucket as back-end storage. The cluster was configured with a service account with appropriate IAM roles. Athens proxy seems to work fine with this change.

