### PR TITLE
Fix broken link to docker hub

### DIFF
--- a/docs/content/install/using-docker.md
+++ b/docs/content/install/using-docker.md
@@ -12,7 +12,7 @@ Whether setting Athens up using [Kubernetes](install/install-on-kubernetes/) or 
 
 The Athens project produces two docker images, available via [Docker Hub](https://hub.docker.com/) 
 
-1. A release version as [`gomods/athens`](https://hub.docker.com/gomods/athens), each tag corresponds with an Athens [release](https://github.com/gomods/athens/releases), e.g. `v0.7.1`. Additionally, a `canary` tag is available and tracks each commit to `main`
+1. A release version as [`gomods/athens`](https://hub.docker.com/r/gomods/athens), each tag corresponds with an Athens [release](https://github.com/gomods/athens/releases), e.g. `v0.7.1`. Additionally, a `canary` tag is available and tracks each commit to `main`
 2. A tip version, as [`gomods/athens-dev`](https://hub.docker.com/r/gomods/athens-dev), tagged with every commit to `main`, e.g. `1573339`
 
 For a detailed tags list, check each image's Docker Hub


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

A broken link to the docker hub image in the documentation.

## How is the fix applied?

Link fixed!

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

<!-- 
example: Fixes #123
-->
