### PR TITLE
Override service account

### DIFF
--- a/charts/athens-proxy/templates/_helpers.tpl
+++ b/charts/athens-proxy/templates/_helpers.tpl
@@ -17,3 +17,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "readinessPath" -}}
 {{- if contains "v0.2.0" .Values.image.tag -}}/{{- else -}}/readyz{{- end -}}
 {{- end -}}
+{{- define "serviceaccountname" -}}
+{{- if eq .Values.serviceAccount.name  "" -}}
+{{ include "fullname" . }}
+{{- else -}}
+{{ .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -247,3 +247,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ template "serviceaccountname" . }}

--- a/charts/athens-proxy/templates/service-account.yaml
+++ b/charts/athens-proxy/templates/service-account.yaml
@@ -1,9 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "serviceaccountname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ include "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- end -}}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -153,6 +153,13 @@ tolerations: []
 affinity: {}
 
 resources: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  ## Annotations for the Service Account
+  annotations: {}
+
 #  limits:
 #    cpu: 100m
 #    memory: 64Mi


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?
Describe the issue you have been trying to solve.
Athens chart uses the default service account and does not allow overriding it at the time of installation. This pr allows overriding service account name while installing athens with helm chart.
## How is the fix applied?

Mention briefly how you have applied the fix.
This fix will allow providing a service account name at the time of installation. Also the default name will be changed from "default" to "".
