### PR TITLE
Allow using existing service accounts

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.4.15
+version: 0.4.16
 appVersion: 0.9.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/templates/service-account.yaml
+++ b/charts/athens-proxy/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,3 +12,4 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -147,6 +147,7 @@ sshGitServers: {}
 goGetWorkers: 3
 
 serviceAccount:
+  create: true
   annotations: {}
 
 nodeSelector: {}


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Describe the issue you have been trying to solve.
Right now, there is no way to use existing service accounts to deploy athens using helm chart. It always tries to create a new one. But the requirement here is to use a service account that has already been created.
## How is the fix applied?

Mention briefly how you have applied the fix.
Tested with dry-run and on kubernetes cluster. With this change, athens can use an exiting service account.
## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #

<!-- 
example: Fixes #123
-->
