### PR TITLE
Add Content-Length to .zip requests

### DIFF
--- a/pkg/download/addons/with_pool.go
+++ b/pkg/download/addons/with_pool.go
@@ -2,7 +2,6 @@ package addons
 
 import (
 	"context"
-	"io"
 
 	"github.com/gomods/athens/pkg/download"
 	"github.com/gomods/athens/pkg/errors"
@@ -112,9 +111,9 @@ func (p *withpool) GoMod(ctx context.Context, mod, ver string) ([]byte, error) {
 	return goMod, nil
 }
 
-func (p *withpool) Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error) {
+func (p *withpool) Zip(ctx context.Context, mod, ver string) (storage.SizeReadCloser, error) {
 	const op errors.Op = "pool.Zip"
-	var zip io.ReadCloser
+	var zip storage.SizeReadCloser
 	var err error
 	done := make(chan struct{}, 1)
 	p.jobCh <- func() {

--- a/pkg/download/addons/with_pool_test.go
+++ b/pkg/download/addons/with_pool_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"reflect"
 	"sync"
 	"testing"
@@ -98,7 +97,7 @@ type mockDP struct {
 	info     []byte
 	latest   *storage.RevInfo
 	gomod    []byte
-	zip      io.ReadCloser
+	zip      storage.SizeReadCloser
 	inputMod string
 	inputVer string
 	catalog  []paths.AllPathParams
@@ -143,7 +142,7 @@ func (m *mockDP) GoMod(ctx context.Context, mod, ver string) ([]byte, error) {
 }
 
 // Zip implements GET /{module}/@v/{version}.zip
-func (m *mockDP) Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error) {
+func (m *mockDP) Zip(ctx context.Context, mod, ver string) (storage.SizeReadCloser, error) {
 	if m.inputMod != mod {
 		return nil, fmt.Errorf("expected mod input %v but got %v", m.inputMod, mod)
 	}

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -53,7 +53,7 @@ func RegisterHandlers(r *mux.Router, opts *HandlerOpts) {
 
 	r.Handle(PathVersionInfo, LogEntryHandler(InfoHandler, opts)).Methods(http.MethodGet)
 	r.Handle(PathVersionModule, LogEntryHandler(ModuleHandler, opts)).Methods(http.MethodGet)
-	r.Handle(PathVersionZip, LogEntryHandler(ZipHandler, opts)).Methods(http.MethodGet)
+	r.Handle(PathVersionZip, LogEntryHandler(ZipHandler, opts)).Methods(http.MethodGet, http.MethodHead)
 }
 
 func getRedirectURL(base, downloadPath string) (string, error) {

--- a/pkg/download/handler_test.go
+++ b/pkg/download/handler_test.go
@@ -2,7 +2,6 @@ package download
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +9,7 @@ import (
 	"github.com/gomods/athens/pkg/download/mode"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/log"
+	"github.com/gomods/athens/pkg/storage"
 	"github.com/gorilla/mux"
 )
 
@@ -58,7 +58,7 @@ func (mp *mockProtocol) GoMod(ctx context.Context, mod, ver string) ([]byte, err
 	return nil, errors.E(op, "not found", errors.KindRedirect)
 }
 
-func (mp *mockProtocol) Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error) {
+func (mp *mockProtocol) Zip(ctx context.Context, mod, ver string) (storage.SizeReadCloser, error) {
 	const op errors.Op = "mockProtocol.Zip"
 	return nil, errors.E(op, "not found", errors.KindRedirect)
 }

--- a/pkg/download/protocol.go
+++ b/pkg/download/protocol.go
@@ -2,7 +2,6 @@ package download
 
 import (
 	"context"
-	"io"
 	"regexp"
 	"strings"
 	"sync"
@@ -31,7 +30,7 @@ type Protocol interface {
 	GoMod(ctx context.Context, mod, ver string) ([]byte, error)
 
 	// Zip implements GET /{module}/@v/{version}.zip
-	Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error)
+	Zip(ctx context.Context, mod, ver string) (storage.SizeReadCloser, error)
 }
 
 // Wrapper helps extend the main protocol's functionality with addons.
@@ -188,7 +187,7 @@ func (p *protocol) GoMod(ctx context.Context, mod, ver string) ([]byte, error) {
 	return goMod, nil
 }
 
-func (p *protocol) Zip(ctx context.Context, mod, ver string) (io.ReadCloser, error) {
+func (p *protocol) Zip(ctx context.Context, mod, ver string) (storage.SizeReadCloser, error) {
 	const op errors.Op = "protocol.Zip"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -3,6 +3,7 @@ package download
 import (
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/gomods/athens/pkg/download/mode"
 	"github.com/gomods/athens/pkg/errors"
@@ -43,6 +44,10 @@ func ZipHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handler
 		defer zip.Close()
 
 		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Length", strconv.FormatInt(zip.Size(), 10))
+		if r.Method == http.MethodHead {
+			return
+		}
 		_, err = io.Copy(w, zip)
 		if err != nil {
 			lggr.SystemErr(errors.E(op, errors.M(mod), errors.V(ver), err))

--- a/pkg/storage/azureblob/azureblob.go
+++ b/pkg/storage/azureblob/azureblob.go
@@ -88,7 +88,7 @@ func (c *azureBlobStoreClient) BlobExists(ctx context.Context, path string) (boo
 
 }
 
-// ReadBlob returns an io.ReadCloser for the contents of a blob
+// ReadBlob returns a storage.SizeReadCloser for the contents of a blob
 func (c *azureBlobStoreClient) ReadBlob(ctx context.Context, path string) (storage.SizeReadCloser, error) {
 	const op errors.Op = "azureblob.ReadBlob"
 	blobURL := c.containerURL.NewBlockBlobURL(path)

--- a/pkg/storage/azureblob/getter.go
+++ b/pkg/storage/azureblob/getter.go
@@ -3,12 +3,12 @@ package azureblob
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/observ"
+	"github.com/gomods/athens/pkg/storage"
 )
 
 // Info implements the (./pkg/storage).Getter interface
@@ -76,7 +76,7 @@ func (s *Storage) GoMod(ctx context.Context, module string, version string) ([]b
 }
 
 // Zip implements the (./pkg/storage).Getter interface
-func (s *Storage) Zip(ctx context.Context, module string, version string) (io.ReadCloser, error) {
+func (s *Storage) Zip(ctx context.Context, module string, version string) (storage.SizeReadCloser, error) {
 	const op errors.Op = "azureblob.Zip"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
@@ -87,11 +87,9 @@ func (s *Storage) Zip(ctx context.Context, module string, version string) (io.Re
 	if !exists {
 		return nil, errors.E(op, errors.M(module), errors.V(version), errors.KindNotFound)
 	}
-
 	zipReader, err := s.client.ReadBlob(ctx, config.PackageVersionedName(module, version, "zip"))
 	if err != nil {
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
 	}
-
 	return zipReader, nil
 }

--- a/pkg/storage/compliance/tests.go
+++ b/pkg/storage/compliance/tests.go
@@ -153,6 +153,7 @@ func testGet(t *testing.T, b storage.Backend) {
 	givenZipBts, err := ioutil.ReadAll(zip)
 	require.NoError(t, err)
 	require.Equal(t, zipBts, givenZipBts)
+	require.Equal(t, int64(len(zipBts)), zip.Size())
 }
 
 func testExists(t *testing.T, b storage.Backend) {

--- a/pkg/storage/external/server.go
+++ b/pkg/storage/external/server.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gomods/athens/pkg/download"
@@ -67,6 +68,7 @@ func NewServer(strg storage.Backend) http.Handler {
 			return
 		}
 		defer zip.Close()
+		w.Header().Set("Content-Length", strconv.FormatInt(zip.Size(), 10))
 		io.Copy(w, zip)
 	}).Methods(http.MethodGet)
 	r.HandleFunc("/{module:.+}/@v/{version}.save", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/storage/gcp/getter.go
+++ b/pkg/storage/gcp/getter.go
@@ -3,13 +3,13 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 
 	"cloud.google.com/go/storage"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/observ"
+	pkgstorage "github.com/gomods/athens/pkg/storage"
 )
 
 // Info implements Getter
@@ -48,7 +48,7 @@ func (s *Storage) GoMod(ctx context.Context, module, version string) ([]byte, er
 }
 
 // Zip implements Getter
-func (s *Storage) Zip(ctx context.Context, module, version string) (io.ReadCloser, error) {
+func (s *Storage) Zip(ctx context.Context, module, version string) (pkgstorage.SizeReadCloser, error) {
 	const op errors.Op = "gcp.Zip"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
@@ -56,8 +56,7 @@ func (s *Storage) Zip(ctx context.Context, module, version string) (io.ReadClose
 	if err != nil {
 		return nil, errors.E(op, err, getErrorKind(err), errors.M(module), errors.V(version))
 	}
-
-	return zipReader, nil
+	return pkgstorage.NewSizer(zipReader, zipReader.Size()), nil
 }
 
 func getErrorKind(err error) int {

--- a/pkg/storage/getter.go
+++ b/pkg/storage/getter.go
@@ -9,5 +9,28 @@ import (
 type Getter interface {
 	Info(ctx context.Context, module, vsn string) ([]byte, error)
 	GoMod(ctx context.Context, module, vsn string) ([]byte, error)
-	Zip(ctx context.Context, module, vsn string) (io.ReadCloser, error)
+	Zip(ctx context.Context, module, vsn string) (SizeReadCloser, error)
+}
+
+// SizeReadCloser extends io.ReadCloser
+// with a Size() method that tells you the
+// length of the io.ReadCloser if read in full
+type SizeReadCloser interface {
+	io.ReadCloser
+	Size() int64
+}
+
+// NewSizer is a helper wrapper to return an implementation
+// of ReadCloserSizer
+func NewSizer(rc io.ReadCloser, size int64) SizeReadCloser {
+	return &sizeReadCloser{rc, size}
+}
+
+type sizeReadCloser struct {
+	io.ReadCloser
+	size int64
+}
+
+func (zf *sizeReadCloser) Size() int64 {
+	return zf.size
 }

--- a/pkg/storage/module.go
+++ b/pkg/storage/module.go
@@ -6,10 +6,11 @@ import (
 
 // Module represents a vgo module saved in a storage backend.
 type Module struct {
+	// TODO(marwan-at-work): ID is a mongo-specific field, it should not be
+	// in the generic storage.Module struct.
 	ID      primitive.ObjectID `bson:"_id,omitempty"`
 	Module  string             `bson:"module"`
 	Version string             `bson:"version"`
 	Mod     []byte             `bson:"mod"`
-	Zip     []byte             `bson:"zip"`
 	Info    []byte             `bson:"info"`
 }


### PR DESCRIPTION
This PR enables Athens to return an accurate byte count of a module@version's size via the Content-Length header. 

It also allows HEAD requests to get said header without returning the content of the zip file. 

This is needed for Athens to integrate with pkgsite, particularly here: https://github.com/golang/pkgsite/blob/fd89b15b08609658e2b6d1363f52fd2f691db311/internal/proxy/client.go#L97:L116