### PR TITLE
Implement CodeQL GitHub Action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,14 @@
-name: "CodeQL Scanning"
+name: "CodeQL Security Scanning"
 
 on:
   push:
+    branches:
+      [main]
   pull_request:
+    branches:
+      [main]
+  schedule:
+    - cron: '0 15 * * 0'
 
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,13 @@
+---
 name: "CodeQL Security Scanning"
 
 on:
   push:
-    branches:
-      [main]
+    branches: [main]
   pull_request:
-    branches:
-      [main]
+    branches: [main]
   schedule:
-    - cron: '0 15 * * 0'
-
+    - cron: "0 15 * * 0"
 
 jobs:
   analyze:
@@ -30,7 +28,6 @@ jobs:
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1
-
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,30 @@
+name: "CodeQL Scanning"
+
+on:
+  push:
+  pull_request:
+
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
## What is the problem I am trying to address?

CodeQL's GitHub integration is out of invite only and now available to public repositories. We should have some security scanning in place as a check.

## How is the fix applied?

Added the CodeQL action which autobuilds, scans and reports issues. It currently runs against main and on a schedule of 0 15 * * 0 or 15:00 every Sunday.
