### PR TITLE
Add possibility to specify image pull secrets

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.4.15
-appVersion: 0.9.0
+version: 0.4.16
+appVersion: 0.10.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png
 keywords:

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             subPath: id_rsa-{{ $server.host }}
           {{- end }}
       {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecrets | quote }}
+      {{- end }}
       containers:
       - name: {{ template "fullname" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
## What is the problem I am trying to address?

Deploy athens proxy from private Docker repository

## How is the fix applied?

It can be applied, when invoked with helm chart values like:
```
image:
  pullSecrets: your-secret-in-k8s-name
```
If this variable is not defined, helm chart will not emit any changes to final K8S object

## What GitHub issue(s) does this PR fix or close?
None

