### PR TITLE
Offline mode

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -23,6 +23,8 @@ const Service = "proxy"
 // should be defined. This is the nerve center of your
 // application.
 func App(conf *config.Config) (http.Handler, error) {
+	fmt.Printf("Athens is running in %s mode\n", conf.Mode)
+
 	// ENV is used to help switch settings based on where the
 	// application is being run. Default is "development".
 	ENV := conf.GoEnv

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -127,7 +127,7 @@ func addProxyRoutes(
 		handlerOpts := &download.HandlerOpts{Protocol: dp, Logger: l, DownloadFile: df}
 		download.RegisterHandlers(r, handlerOpts)
 	} else {
-		handlerOpts := download.OfflineHandlerOpts{Logger: l, Storage: s}
+		handlerOpts := &download.OfflineHandlerOpts{Logger: l, Storage: s}
 		download.RegisterOfflineHandlers(r, handlerOpts)
 	}
 

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -86,45 +86,50 @@ func addProxyRoutes(
 	// 4. The plain stash.New just takes a request from upstream and saves it into storage.
 	fs := afero.NewOsFs()
 
-	// TODO: remove before we release v0.7.0
-	if c.GoProxy != "direct" && c.GoProxy != "" {
-		l.Error("GoProxy is deprecated, please use GoBinaryEnvVars")
-	}
-	if !c.GoBinaryEnvVars.HasKey("GONOSUMDB") {
-		c.GoBinaryEnvVars.Add("GONOSUMDB", strings.Join(c.NoSumPatterns, ","))
-	}
-	if err := c.GoBinaryEnvVars.Validate(); err != nil {
-		return err
-	}
-	mf, err := module.NewGoGetFetcher(c.GoBinary, c.GoGetDir, c.GoBinaryEnvVars, fs, c.PropagateAuthHost)
-	if err != nil {
-		return err
-	}
+	if c.Mode == config.ModeOnline {
+		// TODO: remove before we release v0.7.0
+		if c.GoProxy != "direct" && c.GoProxy != "" {
+			l.Error("GoProxy is deprecated, please use GoBinaryEnvVars")
+		}
+		if !c.GoBinaryEnvVars.HasKey("GONOSUMDB") {
+			c.GoBinaryEnvVars.Add("GONOSUMDB", strings.Join(c.NoSumPatterns, ","))
+		}
+		if err := c.GoBinaryEnvVars.Validate(); err != nil {
+			return err
+		}
+		mf, err := module.NewGoGetFetcher(c.GoBinary, c.GoGetDir, c.GoBinaryEnvVars, fs, c.PropagateAuthHost)
+		if err != nil {
+			return err
+		}
 
-	lister := module.NewVCSLister(c.GoBinary, c.GoBinaryEnvVars, fs, c.PropagateAuthHost)
-	checker := storage.WithChecker(s)
-	withSingleFlight, err := getSingleFlight(c, checker)
-	if err != nil {
-		return err
+		lister := module.NewVCSLister(c.GoBinary, c.GoBinaryEnvVars, fs, c.PropagateAuthHost)
+		checker := storage.WithChecker(s)
+		withSingleFlight, err := getSingleFlight(c, checker)
+		if err != nil {
+			return err
+		}
+		st := stash.New(mf, s, indexer, stash.WithPool(c.GoGetWorkers), withSingleFlight)
+
+		df, err := mode.NewFile(c.DownloadMode, c.DownloadURL)
+		if err != nil {
+			return err
+		}
+
+		dpOpts := &download.Opts{
+			Storage:      s,
+			Stasher:      st,
+			Lister:       lister,
+			DownloadFile: df,
+		}
+
+		dp := download.New(dpOpts, addons.WithPool(c.ProtocolWorkers))
+
+		handlerOpts := &download.HandlerOpts{Protocol: dp, Logger: l, DownloadFile: df}
+		download.RegisterHandlers(r, handlerOpts)
+	} else {
+		handlerOpts := download.OfflineHandlerOpts{Logger: l, Storage: s}
+		download.RegisterOfflineHandlers(r, handlerOpts)
 	}
-	st := stash.New(mf, s, indexer, stash.WithPool(c.GoGetWorkers), withSingleFlight)
-
-	df, err := mode.NewFile(c.DownloadMode, c.DownloadURL)
-	if err != nil {
-		return err
-	}
-
-	dpOpts := &download.Opts{
-		Storage:      s,
-		Stasher:      st,
-		Lister:       lister,
-		DownloadFile: df,
-	}
-
-	dp := download.New(dpOpts, addons.WithPool(c.ProtocolWorkers))
-
-	handlerOpts := &download.HandlerOpts{Protocol: dp, Logger: l, DownloadFile: df}
-	download.RegisterHandlers(r, handlerOpts)
 
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ const defaultConfigFile = "athens.toml"
 // Config provides configuration values for all components
 type Config struct {
 	TimeoutConf
+	Mode              Mode      `validate:"required" envconfig:"MODE"`
 	GoEnv             string    `validate:"required" envconfig:"GO_ENV"`
 	GoBinary          string    `validate:"required" envconfig:"GO_BINARY_PATH"`
 	GoProxy           string    `envconfig:"GOPROXY"`
@@ -61,6 +62,13 @@ type Config struct {
 	Storage           *Storage
 	Index             *Index
 }
+
+type Mode string
+
+const (
+	ModeOffline Mode = "offline"
+	ModeOnline  Mode = "online"
+)
 
 // EnvList is a list of key-value environment
 // variables that are passed to the Go command

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -30,7 +30,9 @@ type HandlerOpts struct {
 }
 
 type OfflineHandlerOpts struct {
-	Storage *storage.Backend
+	Storage storage.Backend
+	Logger  *log.Logger
+	// DownloadFile *mode.DownloadFile
 }
 
 // LogEntryHandler pulls a log entry from the request context. Thanks to the
@@ -49,7 +51,7 @@ func LogEntryHandler(ph ProtocolHandler, opts *HandlerOpts) http.Handler {
 func OfflineLogEntryHandler(ph OfflineProtocolHandler, opts *OfflineHandlerOpts) http.Handler {
 	f := func(w http.ResponseWriter, r *http.Request) {
 		ent := log.EntryFromContext(r.Context())
-		handler := ph(ent, *opts.Storage)
+		handler := ph(ent, opts.Storage)
 		handler.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(f)
@@ -82,12 +84,6 @@ func getRedirectURL(base, downloadPath string) (string, error) {
 	}
 	url.Path = path.Join(url.Path, downloadPath)
 	return url.String(), nil
-}
-
-type OfflineHandlerOpts struct {
-	Storage storage.Backend
-	Logger  *log.Logger
-	// DownloadFile *mode.DownloadFile
 }
 
 func RegisterOfflineHandlers(r *mux.Router, opts *OfflineHandlerOpts) {

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -29,6 +29,10 @@ type HandlerOpts struct {
 	DownloadFile *mode.DownloadFile
 }
 
+type OfflineHandlerOpts struct {
+	Storage *storage.Backend
+}
+
 // LogEntryHandler pulls a log entry from the request context. Thanks to the
 // LogEntryMiddleware, we should have a log entry stored in the context for each
 // request with request-specific fields. This will grab the entry and pass it to
@@ -43,8 +47,12 @@ func LogEntryHandler(ph ProtocolHandler, opts *HandlerOpts) http.Handler {
 }
 
 func OfflineLogEntryHandler(ph OfflineProtocolHandler, opts *OfflineHandlerOpts) http.Handler {
-	// TODO: implement this
-	return nil
+	f := func(w http.ResponseWriter, r *http.Request) {
+		ent := log.EntryFromContext(r.Context())
+		handler := ph(ent, *opts.Storage)
+		handler.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(f)
 }
 
 // RegisterHandlers is a convenience method that registers

--- a/pkg/download/list.go
+++ b/pkg/download/list.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/paths"
+	"github.com/gomods/athens/pkg/storage"
+	"github.com/sirupsen/logrus"
 )
 
 // PathList URL.
@@ -37,4 +39,30 @@ func ListHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handle
 		fmt.Fprint(w, strings.Join(versions, "\n"))
 	}
 	return http.HandlerFunc(f)
+}
+
+// OfflineListHandler returns an http.Handler capable of serving /@v/list endpoints
+// directly from storage. No network traffic to anywhere other than the storage
+// backend will be attempted
+func OfflineListHandler(lggr log.Entry, s storage.Backend) http.Handler {
+	const op errors.Op = "download.OfflineListHandler"
+	f := func(w http.ResponseWriter, r *http.Request) {
+		mod, err := paths.GetModule(r)
+		if err != nil {
+			lggr.SystemErr(errors.E(op, err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		versions, err := s.List(r.Context(), mod)
+		if err != nil {
+			err = errors.E(op, err, logrus.ErrorLevel)
+			lggr.SystemErr(err)
+			w.WriteHeader(errors.Kind(err))
+			return
+		}
+		fmt.Fprint(w, strings.Join(versions, "\n"))
+	}
+
+	return http.HandlerFunc(f)
+
 }

--- a/pkg/download/version_info.go
+++ b/pkg/download/version_info.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gomods/athens/pkg/download/mode"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/log"
+	"github.com/gomods/athens/pkg/storage"
 )
 
 // PathVersionInfo URL.
@@ -41,4 +42,26 @@ func InfoHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handle
 		w.Write(info)
 	}
 	return http.HandlerFunc(f)
+}
+
+func OfflineInfoHandler(lggr log.Entry, s storage.Backend) http.Handler {
+	const op errors.Op = "download.InfoHandler"
+	f := func(w http.ResponseWriter, r *http.Request) {
+		mod, ver, err := getModuleParams(r, op)
+		if err != nil {
+			lggr.SystemErr(err)
+			w.WriteHeader(errors.Kind(err))
+			return
+		}
+
+		info, err := s.Info(r.Context(), mod, ver)
+		if err != nil {
+			lggr.SystemErr(err)
+			w.WriteHeader(errors.Kind(err))
+			return
+		}
+		w.Write(info)
+	}
+	return http.HandlerFunc(f)
+
 }

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gomods/athens/pkg/download/mode"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/log"
+	"github.com/gomods/athens/pkg/storage"
 )
 
 // PathVersionZip URL.
@@ -37,6 +38,36 @@ func ZipHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handler
 				http.Redirect(w, r, url, errors.KindRedirect)
 				return
 			}
+			w.WriteHeader(errors.Kind(err))
+			return
+		}
+		defer zip.Close()
+
+		w.Header().Set("Content-Type", "application/zip")
+		_, err = io.Copy(w, zip)
+		if err != nil {
+			lggr.SystemErr(errors.E(op, errors.M(mod), errors.V(ver), err))
+		}
+	}
+	return http.HandlerFunc(f)
+}
+
+// ZipHandler implements GET baseURL/module/@v/version.zip
+func OfflineZipHandler(lggr log.Entry, s storage.Backend) http.Handler {
+	const op errors.Op = "download.ZipHandler"
+	f := func(w http.ResponseWriter, r *http.Request) {
+		mod, ver, err := getModuleParams(r, op)
+		if err != nil {
+			lggr.SystemErr(err)
+			w.WriteHeader(errors.Kind(err))
+			return
+		}
+
+		zip, err := s.Zip(r.Context(), mod, ver)
+		if err != nil {
+			severityLevel := errors.Expect(err, errors.KindNotFound, errors.KindRedirect)
+			err = errors.E(op, err, severityLevel)
+			lggr.SystemErr(err)
 			w.WriteHeader(errors.Kind(err))
 			return
 		}


### PR DESCRIPTION
Hi,

I've been trying to use Athens on an air-gaped machine (offline) to fetch all my Golang dependencies. I've been able to make Athens work by copying the cache folder from an internet machine to the offline one.

However, Golang can only download the needed modules if the exact version of the dependency is specified since the `@latest` listing always tries to connect to internet.

This seems to be a recurrent issue as demonstrated by https://github.com/gomods/athens/issues/1506 https://github.com/gomods/athens/issues/1378 https://github.com/gomods/athens/issues/395

I saw the following PR https://github.com/gomods/athens/pull/1668 which seems to address this issue by adding a `MODE=offline` configuration. 

This PR only fix a few issues on the draft above. It has been tested and works perfectly fine in my offline setup.

Thank you


