### PR TITLE
Adding GH action to check links in documentation

### DIFF
--- a/.github/workflows/linkinator.yml
+++ b/.github/workflows/linkinator.yml
@@ -1,0 +1,17 @@
+name: Check links on all markdown documents
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  linkinator:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JustinBeckwith/linkinator-action@v1
+        with:
+          paths: "**/*.md"
+          markdown: true
+          retry: true


### PR DESCRIPTION
## What is the problem I am trying to address?

Links in documentation (markdown files) may become stale or incorrect.

## How is the fix applied?

This GitHub action checks links in all markdown files

## What GitHub issue(s) does this PR fix or close?

N/A
