### PR TITLE
Update GCP Storage authentication comment

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -353,10 +353,10 @@ IndexType = "none"
 
         # JSONKey is a base64 encoded service account 
         # key that allows Athens to be run outside of GCP
-        # but still be able to access GCS. If you are
-        # running Athens inside GCP, you will most
-        # likely not need this as GCP figures out
-        # internal authentication between products for you.
+        # but still be able to access GCS. This is not needed
+        # when relying on default GCP authentication with 
+        # GOOGLE_APPLICATION_CREDENTIALS variable set up. 
+        # See https://cloud.google.com/docs/authentication/getting-started.
         #
         # Env override: ATHENS_STORAGE_GCP_JSON_KEY
         JSONKey = ""


### PR DESCRIPTION
## What is the problem I am trying to address?

I am suggesting replacing a vague phrasing about how GCP out-of-box authentication works. If Athens is used in a GCP product like Cloud Run it will work without any extra work because `GOOGLE_APPLICATION_CREDENTIALS` variable is automatically propagated by GCP so the previous comment was not wrong but this is more helpful for custom deployments where `GOOGLE_APPLICATION_CREDENTIALS` approach can also be used.

## How is the fix applied?

A comment in the config file.