### PR TITLE
Use actual content length when it is not available in headers

### DIFF
--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -44,15 +44,14 @@ func ZipHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handler
 		defer zip.Close()
 
 		w.Header().Set("Content-Type", "application/zip")
+		size := zip.Size()
+		if size >= 0 {
+			w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+		}
 		if r.Method == http.MethodHead {
 			return
 		}
-		written, err := io.Copy(w, zip)
-		size := zip.Size()
-		if size < 0 {
-			size = written
-		}
-		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+		_, err = io.Copy(w, zip)
 		if err != nil {
 			lggr.SystemErr(errors.E(op, errors.M(mod), errors.V(ver), err))
 		}

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -45,7 +45,7 @@ func ZipHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handler
 
 		w.Header().Set("Content-Type", "application/zip")
 		size := zip.Size()
-		if size >= 0 {
+		if size > 0 {
 			w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 		}
 		if r.Method == http.MethodHead {

--- a/pkg/download/version_zip.go
+++ b/pkg/download/version_zip.go
@@ -44,11 +44,15 @@ func ZipHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handler
 		defer zip.Close()
 
 		w.Header().Set("Content-Type", "application/zip")
-		w.Header().Set("Content-Length", strconv.FormatInt(zip.Size(), 10))
 		if r.Method == http.MethodHead {
 			return
 		}
-		_, err = io.Copy(w, zip)
+		written, err := io.Copy(w, zip)
+		size := zip.Size()
+		if size < 0 {
+			size = written
+		}
+		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 		if err != nil {
 			lggr.SystemErr(errors.E(op, errors.M(mod), errors.V(ver), err))
 		}

--- a/pkg/storage/s3/getter.go
+++ b/pkg/storage/s3/getter.go
@@ -100,7 +100,7 @@ func (s *Storage) open(ctx context.Context, path string) (storage.SizeReadCloser
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
-	var size int64 = -1
+	var size int64
 	if goo.ContentLength != nil {
 		size = *goo.ContentLength
 	}

--- a/pkg/storage/s3/getter.go
+++ b/pkg/storage/s3/getter.go
@@ -100,7 +100,7 @@ func (s *Storage) open(ctx context.Context, path string) (storage.SizeReadCloser
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
-	var size int64
+	var size int64 = -1
 	if goo.ContentLength != nil {
 		size = *goo.ContentLength
 	}


### PR DESCRIPTION
## What is the problem I am trying to address?

In some cases, Amazon S3 may not always return a Content-Length header. In this case, the size will not be set and take the zero value, and `http.ResponseWriter` will complain:
```
http: wrote more than the declared Content-Length
```
The data will be ignored

## How is the fix applied?

Skip  `Content-Length` in response when the size is 0, so at least the data can be sent.
