### PR TITLE
Fixing panic with S3 storage

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -35,7 +35,7 @@ type Storage struct {
 func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Config)) (*Storage, error) {
 	const op errors.Op = "s3.New"
 
-	awsConfig := &aws.Config{}
+	awsConfig := defaults.Config()
 	awsConfig.Region = aws.String(s3Conf.Region)
 	for _, o := range options {
 		o(awsConfig)


### PR DESCRIPTION
## What is the problem I am trying to address?

Fixing a panic when S3 storage is used but configured without default storage

## How is the fix applied?

Per @kylelemons 's suggestion, I've changed the initial s3 config to use AWS defaults

NOTE: I'm not very familiar with S3 storage in Athens, so it would be very helpful if someone more knowledgeable than me could review this

## What GitHub issue(s) does this PR fix or close?

Fixes #1729

