### PR TITLE
Update alpine version to 3.14.2

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -6,7 +6,7 @@
 # See project Makefile if using make.
 # See docker --build-arg if building directly.
 ARG GOLANG_VERSION=1.14
-ARG ALPINE_VERSION=3.11.5
+ARG ALPINE_VERSION=3.14.2
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?
Alpine 3.11 which the athens images is built on will reach end of support soon.

## How is the fix applied?

Use a recent version of alpine.

## What GitHub issue(s) does this PR fix or close?

None

