### PR TITLE
Deprecate bzr as it is unmaintained.

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -6,7 +6,7 @@
 # See project Makefile if using make.
 # See docker --build-arg if building directly.
 ARG GOLANG_VERSION=1.17
-ARG ALPINE_VERSION=3.14.2
+ARG ALPINE_VERSION=3.15
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -29,7 +29,7 @@ COPY --from=builder /usr/local/go/bin/go /bin/go
 RUN chmod 644 /config/config.toml
 
 # Add tini, see https://github.com/gomods/athens/issues/1155 for details.
-RUN apk add --update bzr git git-lfs mercurial openssh-client subversion procps fossil tini && \
+RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini && \
 	mkdir -p /usr/local/go
 
 EXPOSE 3000

--- a/docs/content/configuration/authentication.md
+++ b/docs/content/configuration/authentication.md
@@ -55,6 +55,8 @@ weight: 2
 
 ## Bazaar(bzr) private repositories
 
+* Bazaar is not supported with the Dockerfile provided by Athens. but the instructions are valid for custom Athens build with bazaar.*
+
 1. Bazaaar config files are located in
 
 - Unix


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Athens does not build on main. See example build:
https://cloud.drone.io/gomods/athens/2273/1/10

## How is the fix applied?

Alpine moved bzr to unmaintained status. See
https://gitlab.alpinelinux.org/alpine/abuild/-/issues/10000

Deprecate bzr from the Dockerfile as it is deprecated from alpine.
Also, update alpine version.




## What GitHub issue(s) does this PR fix or close?

