### PR TITLE
Set GO111MODULE to auto in golint script– #1743

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ setup-dev-env:
 .PHONY: verify
 verify: ## verify athens codebase
 	./scripts/check_gofmt.sh
-	./scripts/check_golint.sh
+	./scripts/check_govet.sh
 	./scripts/check_deps.sh
 	./scripts/check_conflicts.sh
 

--- a/pkg/stash/with_etcd.go
+++ b/pkg/stash/with_etcd.go
@@ -29,10 +29,13 @@ func WithEtcd(endpoints []string, checker storage.Checker) (Wrapper, error) {
 	}
 	var eg errgroup.Group
 	for _, ep := range endpoints {
-		eg.Go(func() error {
-			_, err := c.Status(ctx, ep)
-			return err
-		})
+		epStat := func(ep string) func() error {
+			return func() error {
+				_, err := c.Status(ctx, ep)
+				return err
+			}
+		}(ep)
+		eg.Go(epStat)
 	}
 	err = eg.Wait()
 	if err != nil {

--- a/scripts/check_golint.sh
+++ b/scripts/check_golint.sh
@@ -4,4 +4,4 @@
 # Run the linter on everything except generated code
 set -euo pipefail
 
-golint -set_exit_status $(GO111MODULE=off go list ./... | grep -v '/mocks')
+golint -set_exit_status $(GO111MODULE=auto go list ./... | grep -v '/mocks')

--- a/scripts/check_golint.sh
+++ b/scripts/check_golint.sh
@@ -4,4 +4,4 @@
 # Run the linter on everything except generated code
 set -euo pipefail
 
-golint -set_exit_status $(GO111MODULE=auto go list ./... | grep -v '/mocks')
+golint -set_exit_status $(go list ./...)

--- a/scripts/check_govet.sh
+++ b/scripts/check_govet.sh
@@ -4,4 +4,4 @@
 # Run the linter on everything except generated code
 set -euo pipefail
 
-golint -set_exit_status $(go list ./...)
+go vet ./...


### PR DESCRIPTION
As mentioned in #1743 the Go modules environment flag is set to `off`
in the script which appears to cause a warning message for each module
of the codebase that it is "not in GOROOT".

Set to `auto` as this allows the same build to be run the original way
should someone choose to delete the `go.mod` file from the project root.

<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Golint warning for each submodule of Athens "package not in GOROOT" when running Make target `verify`

## How is the fix applied?

Set `GO111MODULE=auto` in `./scripts/check_golint.sh` 

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #1743

<!-- 
example: Fixes #123
-->
