### PR TITLE
fix flake on redis-sentinel by depending on redis container / step.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,6 +69,9 @@ steps:
   volumes:
   - name: cache
     path: /go
+  depends_on:
+    - redis
+    - redis-sentinel
 
 - name: docker-latest
   image: plugins/docker
@@ -169,6 +172,8 @@ services:
     REDIS_SENTINEL_QUORUM: "1"
   ports:
     - 26379
+  depends_on:
+    - redis
 - name: protectedredis
   image: redis
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,8 @@ services:
       - REDIS_SENTINEL_QUORUM=1
     ports:
       - 26379:26379
+    depends_on:
+      - "redis"
   protectedredis:
     image: redis
     ports:

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
-	github.com/go-redis/redis/v7 v7.2.0
+	github.com/go-redis/redis/v7 v7.4.1
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gobuffalo/envy v1.7.0
 	github.com/gobuffalo/httptest v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEK
 github.com/go-redis/redis/v7 v7.0.0-beta.4/go.mod h1:xhhSbUMTsleRPur+Vgx9sUHtyN33bdjxY+9/0n9Ig8s=
 github.com/go-redis/redis/v7 v7.2.0 h1:CrCexy/jYWZjW0AyVoHlcJUeZN19VWlbepTh1Vq6dJs=
 github.com/go-redis/redis/v7 v7.2.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
+github.com/go-redis/redis/v7 v7.4.1 h1:PASvf36gyUpr2zdOUS/9Zqc80GbM+9BDyiJSJDDOrTI=
+github.com/go-redis/redis/v7 v7.4.1/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Redis tests have flakes, this leads to a bad CI.

Describe the issue you have been trying to solve.

## How is the fix applied?

Redis tests have flakes, by using depends_on flag; I am trying to reduce these flakes.

I tested by force-pushing multiple commits.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #

<!-- 
example: Fixes #123
-->
