### PR TITLE
Revert retries in redis-flake as builds are failing again.

### DIFF
--- a/pkg/stash/with_redis_sentinel_test.go
+++ b/pkg/stash/with_redis_sentinel_test.go
@@ -27,19 +27,9 @@ func TestWithRedisSentinelLock(t *testing.T) {
 	}
 	ms := &mockRedisStasher{strg: strg}
 
-	// retries because of flaky test on drone.
-	var wrapper Wrapper
-	for i := 1; i <= 3; i++ {
-		wrapper, err = WithRedisSentinelLock([]string{endpoint}, masterName, password, storage.WithChecker(strg))
-		if err != nil {
-			t.Logf("Retried %d time because we got error: %s", i, err.Error())
-		}
-		time.Sleep(1 * time.Second)
-	}
-
+	wrapper, err := WithRedisSentinelLock([]string{endpoint}, masterName, password, storage.WithChecker(strg))
 	if err != nil {
-		t.Fatalf("Please file an issue at https://github.com/gomods/athens/issues as the "+
-			"test flake is not fixed.  The error that occured was: %s", err)
+		t.Fatal(err)
 	}
 	s := wrapper(ms)
 


### PR DESCRIPTION


<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?


Revert retries as main is failing again. There is no point in
slowing down the flaky tests.

## How is the fix applied?

Reverting the previous test

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #

<!-- 
example: Fixes #123
-->
