### PR TITLE
Use ISO compatible timestamp format in logs

### DIFF
--- a/pkg/log/format.go
+++ b/pkg/log/format.go
@@ -44,7 +44,7 @@ func (devFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	}
 	lvl := strings.ToUpper(e.Level.String())
 	buf.WriteString(sprintf(lvl))
-	buf.WriteString("[" + e.Time.Format(time.Kitchen) + "]")
+	buf.WriteString("[" + e.Time.Format(time.Now().Format(time.RFC3339)) + "]")
 	buf.WriteString(": ")
 	buf.WriteString(e.Message)
 	buf.WriteByte('\t')


### PR DESCRIPTION
Current logs do not provide info about day or timezone.
Use RFC3339 format.

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

## What is the problem I am trying to address?
Current logs in Athens do not provide information about the day or timezone. Timestamps might be different on various clusters located in different timezones. This information is insufficient for production security team. 

Current logs:
INFO[6:22PM]: incoming request	http-method=GET http-path=/ http-status=200 request-id=XXXXX

Logs with proposed change:
INFO[2022-04-13T09:07:09Z]: incoming request	http-method=GET http-path=/ http-status=200 request-id=XXXXX

Describe the issue you have been trying to solve.
Described in section above. 

