### PR TITLE
Resolve memory leaks when using Minio storage

### DIFF
--- a/pkg/storage/minio/getter.go
+++ b/pkg/storage/minio/getter.go
@@ -21,6 +21,7 @@ func (v *storageImpl) Info(ctx context.Context, module, vsn string) ([]byte, err
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
+	defer infoReader.Close()
 	info, err := ioutil.ReadAll(infoReader)
 	if err != nil {
 		return nil, transformNotFoundErr(op, module, vsn, err)
@@ -38,6 +39,7 @@ func (v *storageImpl) GoMod(ctx context.Context, module, vsn string) ([]byte, er
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
+	defer modReader.Close()
 	mod, err := ioutil.ReadAll(modReader)
 	if err != nil {
 		return nil, transformNotFoundErr(op, module, vsn, err)
@@ -45,6 +47,7 @@ func (v *storageImpl) GoMod(ctx context.Context, module, vsn string) ([]byte, er
 
 	return mod, nil
 }
+
 func (v *storageImpl) Zip(ctx context.Context, module, vsn string) (storage.SizeReadCloser, error) {
 	const op errors.Op = "minio.Zip"
 	ctx, span := observ.StartSpan(ctx, op.String())
@@ -62,6 +65,7 @@ func (v *storageImpl) Zip(ctx context.Context, module, vsn string) (storage.Size
 	}
 	oi, err := zipReader.Stat()
 	if err != nil {
+		zipReader.Close()
 		return nil, errors.E(op, err)
 	}
 	return storage.NewSizer(zipReader, oi.Size), nil


### PR DESCRIPTION
## What is the problem I am trying to address?

When using the Minio storage provider, there is an apparent memory or goroutine leak, causing memory usage to steadily increase in use. After profiling, it appears that it is related to `GetObject` calls on the `minioClient`. I noticed that the `minio.Object` that is returned has a `Close` method, and found [a similar issue in minio/warp](https://github.com/minio/warp/issues/113) that was [fixed by closing the objects](https://github.com/minio/warp/pull/115/files).

## How is the fix applied?

This PR adds deferred `Close` calls in the `storageImpl.Info` and `storageImpl.GoMod` functions so that the objects may be released and garbage collected. The `storageImpl.Zip` function does not use `defer`, since it has the object embedded into the return value, so I added the `Close` only on error.
