### PR TITLE
build releases for x86_64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
     - darwin
   goarch:
     - amd64
+    - x86_64
   main: cmd/proxy/main.go
   binary: athens
   ldflags:


### PR DESCRIPTION
## What is the problem I am trying to address?

I would like to add builds for x86_64 machines to the goreleaser versions.

## How is the fix applied?

Simple addition to the .goreleaser.yml config file

## What GitHub issue(s) does this PR fix or close?

None, this is a tiny PR to make my request easier to accept. 
