### PR TITLE
Passing http client to S3 client

### DIFF
--- a/cmd/proxy/actions/storage.go
+++ b/cmd/proxy/actions/storage.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/storage"
@@ -56,7 +57,9 @@ func GetStorage(storageType string, storageConfig *config.Storage, timeout time.
 		if storageConfig.S3 == nil {
 			return nil, errors.E(op, "Invalid S3 Storage Configuration")
 		}
-		return s3.New(storageConfig.S3, timeout)
+		return s3.New(storageConfig.S3, timeout, func(config *aws.Config) {
+			config.HTTPClient = client
+		})
 	case "azureblob":
 		if storageConfig.AzureBlob == nil {
 			return nil, errors.E(op, "Invalid AzureBlob Storage Configuration")


### PR DESCRIPTION
## What is the problem I am trying to address?

Athens doesn't emit metrics when it calls to S3

## How is the fix applied?

Athens already has an HTTP client created from go.opencensus.io/plugin/ochttp, which can "that instruments all outgoing requests with OpenCensus stats and tracing". So we can pass that to S3 client.
