### PR TITLE
Register HTTP client views for stats

### DIFF
--- a/pkg/observ/stats.go
+++ b/pkg/observ/stats.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 	"time"
 
+	"contrib.go.opencensus.io/exporter/prometheus"
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gorilla/mux"
-	"contrib.go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"
 )
@@ -92,7 +92,15 @@ func registerStatsStackDriverExporter(projectID string) (func(), error) {
 // registerViews register stats which should be collected in Athens
 func registerViews() error {
 	const op errors.Op = "observ.registerViews"
-	if err := view.Register(ochttp.DefaultServerViews...); err != nil {
+	if err := view.Register(
+		ochttp.ServerRequestCountView,
+		ochttp.ServerResponseBytesView,
+		ochttp.ServerLatencyView,
+		ochttp.ServerResponseCountByStatusCode,
+		ochttp.ClientReceivedBytesDistribution,
+		ochttp.ClientRoundtripLatencyDistribution,
+		ochttp.ClientCompletedCount,
+	); err != nil {
 		return errors.E(op, err)
 	}
 

--- a/pkg/observ/stats.go
+++ b/pkg/observ/stats.go
@@ -97,6 +97,8 @@ func registerViews() error {
 		ochttp.ServerResponseBytesView,
 		ochttp.ServerLatencyView,
 		ochttp.ServerResponseCountByStatusCode,
+		ochttp.ServerRequestBytesView,
+		ochttp.ServerRequestCountByMethod,
 		ochttp.ClientReceivedBytesDistribution,
 		ochttp.ClientRoundtripLatencyDistribution,
 		ochttp.ClientCompletedCount,


### PR DESCRIPTION
## What is the problem I am trying to address?

HTTP client metrics are still not collected after #1786

## How is the fix applied?

Registering HTTP client views in additional to the server views. Also `ochttp.DefaultServerViews` is [deprecated](https://pkg.go.dev/go.opencensus.io/plugin/ochttp@v0.23.0#DefaultServerViews). The official doc recommends registering server views individually, which I did.

## What GitHub issue(s) does this PR fix or close?

Partially Fixes #446 

<!-- 
example: Fixes #123
-->
