### PR TITLE
fix s3 credentials set to anonymous by default

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -36,6 +36,9 @@ func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Co
 	const op errors.Op = "s3.New"
 
 	awsConfig := defaults.Config()
+	// remove anonymous credentials from the default config so that
+	// session.NewSession can auto-resolve credentials from role, profile, env etc.
+	awsConfig.Credentials = nil
 	awsConfig.Region = aws.String(s3Conf.Region)
 	for _, o := range options {
 		o(awsConfig)


### PR DESCRIPTION
## What is the problem I am trying to address?

Using default S3 credentials is currently broken in the main branch, and based on my investigation it broke after this change: https://github.com/gomods/athens/issues/1730.

### Explanation:

Using `defaults.Config()` [sets `Credentials` as anonymous]( https://github.com/aws/aws-sdk-go/blob/v1.40.31/aws/defaults/defaults.go#L57) and hence it [breaks aws lib's logic to resolve default credentials](https://github.com/aws/aws-sdk-go/blob/v1.32.7/aws/session/session.go#L575) which only works when `Credentials` passed by the user to [`session.NewSession` ](https://github.com/gomods/athens/blob/main/pkg/storage/s3/s3.go#L68) is `nil` and hence it ends up using the anonymous credential leading to authorization failures.

Note:
- Before https://github.com/gomods/athens/issues/1730 `config.Credentials` was being set as nil for the default case (`UseDefaultConfiguration `).
- This PR doesn't mess with https://github.com/gomods/athens/issues/1729 as based on the user report, that panic happens only when  `UseDefaultConfiguration` is set to false and in that case [we're already building custom credentials](https://github.com/gomods/athens/blob/main/pkg/storage/s3/s3.go#L44) so setting it to nil by default won't affect that case.




