### PR TITLE
Update s3 checker to iterate through all objects pages

### DIFF
--- a/pkg/storage/s3/checker.go
+++ b/pkg/storage/s3/checker.go
@@ -11,10 +11,6 @@ import (
 	"github.com/gomods/athens/pkg/observ"
 )
 
-const (
-	s3ErrorCodeNotFound = "NotFound"
-)
-
 // Exists implements the (./pkg/storage).Checker interface
 // returning true if the module at version exists in storage
 func (s *Storage) Exists(ctx context.Context, module, version string) (bool, error) {
@@ -26,22 +22,25 @@ func (s *Storage) Exists(ctx context.Context, module, version string) (bool, err
 		Bucket: aws.String(s.bucket),
 		Prefix: aws.String(fmt.Sprintf("%s/@v", module)),
 	}
+	var count int
+	err := s.s3API.ListObjectsPagesWithContext(ctx, lsParams, func(loo *s3.ListObjectsOutput, lastPage bool) bool {
+		for _, o := range loo.Contents {
+			// sane assumption: no duplicate keys.
+			switch *o.Key {
+			case config.PackageVersionedName(module, version, "info"):
+				count++
+			case config.PackageVersionedName(module, version, "mod"):
+				count++
+			case config.PackageVersionedName(module, version, "zip"):
+				count++
+			}
+		}
+		return count != 3
+	})
 
-	loo, err := s.s3API.ListObjectsWithContext(ctx, lsParams)
 	if err != nil {
 		return false, errors.E(op, err, errors.M(module), errors.V(version))
 	}
-	var count int
-	for _, o := range loo.Contents {
-		// sane assumption: no duplicate keys.
-		switch *o.Key {
-		case config.PackageVersionedName(module, version, "info"):
-			count++
-		case config.PackageVersionedName(module, version, "mod"):
-			count++
-		case config.PackageVersionedName(module, version, "zip"):
-			count++
-		}
-	}
+
 	return count == 3, nil
 }


### PR DESCRIPTION
## What is the problem I am trying to address?

Athens using AWS S3 as storage could return 404 back to users even if the requested module is present in S3 as the page contents could be truncated (max 1000 objects). 

See details here https://github.com/gomods/athens/issues/1801

## How is the fix applied?

Iterate through all S3 pages for the S3 prefix input using https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.ListObjectsPagesWithContext

## What GitHub issue(s) does this PR fix or close?

Fixes https://github.com/gomods/athens/issues/1801
