### PR TITLE
Handle SIGTERM on unix-like OS

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -13,6 +13,7 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/gomods/athens/cmd/proxy/actions"
+	"github.com/gomods/athens/internal/shutdown"
 	"github.com/gomods/athens/pkg/build"
 	"github.com/gomods/athens/pkg/config"
 )
@@ -51,8 +52,9 @@ func main() {
 
 	go func() {
 		sigint := make(chan os.Signal, 1)
-		signal.Notify(sigint, os.Interrupt)
-		<-sigint
+		signal.Notify(sigint, shutdown.GetSignals()...)
+		s := <-sigint
+		log.Printf("Recived signal (%s): Shutting down server", s)
 
 		// We received an interrupt signal, shut down.
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(conf.ShutdownTimeout))

--- a/internal/shutdown/signals.go
+++ b/internal/shutdown/signals.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package shutdown
+
+import (
+	"os"
+	"syscall"
+)
+
+// GetSignals returns the appropriate signals to catch for a clean shutdown, dependent on the OS.
+//
+// On Unix-like operating systems, it is important to catch SIGTERM in addition to SIGINT.
+func GetSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/shutdown/signals_notunix.go
+++ b/internal/shutdown/signals_notunix.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package shutdown
+
+import "os"
+
+// GetSignals returns the appropriate signals to catch for a clean shutdown, dependent on the OS.
+func GetSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}


### PR DESCRIPTION
## What is the problem I am trying to address?

When running Athens on a unix-like OS (linux, darwin, etc), the TERM signal is not being handled to perform a graceful shutdown, only `INT`. This is especially problematic on Kubernetes, where the default signal sent to pods is `TERM`.

## How is the fix applied?

This commit adds a new package to get the appropriate signals based on the operating system, using `go:build` tags. For `unix`, it includes `os.Interrupt` AND `syscall.SIGTERM`, but only `os.Interrupt` for others, which may not support that signal.