### PR TITLE
Adding new fields to RevInfo

### DIFF
--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -294,6 +294,7 @@ func TestInfo(t *testing.T) {
 
 			var info storage.RevInfo
 			dec := json.NewDecoder(bytes.NewReader(bts))
+			dec.DisallowUnknownFields()
 			err = dec.Decode(&info)
 			require.NoError(t, err)
 

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -294,7 +294,6 @@ func TestInfo(t *testing.T) {
 
 			var info storage.RevInfo
 			dec := json.NewDecoder(bytes.NewReader(bts))
-			dec.DisallowUnknownFields()
 			err = dec.Decode(&info)
 			require.NoError(t, err)
 

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
@@ -298,7 +299,8 @@ func TestInfo(t *testing.T) {
 			err = dec.Decode(&info)
 			require.NoError(t, err)
 
-			require.EqualValues(t, tc.info, &info)
+			assert.Equal(t, tc.info.Version, info.Version)
+			assert.Equal(t, tc.info.Time, info.Time)
 		})
 	}
 }

--- a/pkg/storage/rev_info.go
+++ b/pkg/storage/rev_info.go
@@ -1,15 +1,47 @@
 package storage
 
-import (
-	"time"
-)
+import "time"
+
+// From https://pkg.go.dev/cmd/go/internal/modfetch/codehost#Origin
+type Origin struct {
+	VCS    string `json:",omitempty"` // "git" etc
+	URL    string `json:",omitempty"` // URL of repository
+	Subdir string `json:",omitempty"` // subdirectory in repo
+
+	// If TagSum is non-empty, then the resolution of this module version
+	// depends on the set of tags present in the repo, specifically the tags
+	// of the form TagPrefix + a valid semver version.
+	// If the matching repo tags and their commit hashes still hash to TagSum,
+	// the Origin is still valid (at least as far as the tags are concerned).
+	// The exact checksum is up to the Repo implementation; see (*gitRepo).Tags.
+	TagPrefix string `json:",omitempty"`
+	TagSum    string `json:",omitempty"`
+
+	// If Ref is non-empty, then the resolution of this module version
+	// depends on Ref resolving to the revision identified by Hash.
+	// If Ref still resolves to Hash, the Origin is still valid (at least as far as Ref is concerned).
+	// For Git, the Ref is a full ref like "refs/heads/main" or "refs/tags/v1.2.3",
+	// and the Hash is the Git object hash the ref maps to.
+	// Other VCS might choose differently, but the idea is that Ref is the name
+	// with a mutable meaning while Hash is a name with an immutable meaning.
+	Ref  string `json:",omitempty"`
+	Hash string `json:",omitempty"`
+
+	// If RepoSum is non-empty, then the resolution of this module version
+	// failed due to the repo being available but the version not being present.
+	// This depends on the entire state of the repo, which RepoSum summarizes.
+	// For Git, this is a hash of all the refs and their hashes.
+	RepoSum string `json:",omitempty"`
+}
 
 // RevInfo is json-encodable into the response body for
 // GET baseURL/module/@v/version.info
-//
-// This struct is taken directly from https://research.swtch.com/vgo-module
-// (see "Download Protocol" header)
+// From https://pkg.go.dev/cmd/go/internal/modfetch/codehost#RevInfo
 type RevInfo struct {
-	Version string    `json:"Version"` // version string
-	Time    time.Time `json:"Time"`    // commit time
+	Origin  *Origin
+	Name    string    // complete ID in underlying repository
+	Short   string    // shortened ID, for use in pseudo-version
+	Version string    // version used in lookup
+	Time    time.Time // commit time
+	Tags    []string  // known tags for commit
 }


### PR DESCRIPTION
## What is the problem I am trying to address?

All recent CI jobs of Athens are failing.

## How is the fix applied?

Go 1.9 added a new `Origin` field to the [RevInfo](https://pkg.go.dev/cmd/go/internal/modfetch@go1.19#RevInfo) struct. When a test tries to decode the .info file downloaded by go mod, the addition field cause the decoder to fail, because the decoder `DisallowUnknownFields()`. Copying adding the new fields introduced in Go 1.19 fixes the issue.

The changes in this PR is taken from #1799.

## What GitHub issue(s) does this PR fix or close?

This would fix the failing test in #1793
