### PR TITLE
feat: replace ioutil with io and os

### DIFF
--- a/cmd/proxy/actions/app_proxy_test.go
+++ b/cmd/proxy/actions/app_proxy_test.go
@@ -2,7 +2,7 @@ package actions
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,7 +42,7 @@ func TestProxyRoutes(t *testing.T) {
 	testCases := []routeTest{
 		{"GET", "/", "", func(t *testing.T, resp *http.Response) {
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Equal(t, `"Welcome to The Athens Proxy"`, string(body))
 		}},

--- a/cmd/proxy/actions/auth.go
+++ b/cmd/proxy/actions/auth.go
@@ -2,8 +2,8 @@ package actions
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -19,7 +19,7 @@ func initializeAuthFile(path string) {
 		return
 	}
 
-	fileBts, err := ioutil.ReadFile(path)
+	fileBts, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("could not read %s: %v", path, err)
 	}
@@ -31,7 +31,7 @@ func initializeAuthFile(path string) {
 
 	fileName := transformAuthFileName(filepath.Base(path))
 	rcp := filepath.Join(hdir, fileName)
-	if err := ioutil.WriteFile(rcp, fileBts, 0600); err != nil {
+	if err := os.WriteFile(rcp, fileBts, 0600); err != nil {
 		log.Fatalf("could not write to file: %v", err)
 	}
 }
@@ -45,7 +45,7 @@ func netrcFromToken(tok string) {
 		log.Fatalf("netrcFromToken: could not get homedir: %v", err)
 	}
 	rcp := filepath.Join(hdir, getNETRCFilename())
-	if err := ioutil.WriteFile(rcp, []byte(fileContent), 0600); err != nil {
+	if err := os.WriteFile(rcp, []byte(fileContent), 0600); err != nil {
 		log.Fatalf("netrcFromToken: could not write to file: %v", err)
 	}
 }

--- a/e2etests/all_test.go
+++ b/e2etests/all_test.go
@@ -1,3 +1,4 @@
+//go:build e2etests
 // +build e2etests
 
 package e2etests
@@ -6,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -35,12 +35,12 @@ type catalogRes struct {
 
 func (m *E2eSuite) SetupSuite() {
 	var err error
-	m.goPath, err = ioutil.TempDir("/tmp", "gopath")
+	m.goPath, err = os.MkdirTemp("/tmp", "gopath")
 	if err != nil {
 		m.Fail("Failed to make temp dir", err)
 	}
 
-	m.sampleRepoPath, err = ioutil.TempDir("/tmp", "repopath")
+	m.sampleRepoPath, err = os.MkdirTemp("/tmp", "repopath")
 	if err != nil {
 		m.Fail("Failed to make temp dir for sample repo", err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -433,7 +432,7 @@ func restoreEnv(envVars map[string]string) {
 }
 
 func tempFile(perm os.FileMode) (name string, err error) {
-	f, err := ioutil.TempFile(os.TempDir(), "prefix-")
+	f, err := os.CreateTemp(os.TempDir(), "prefix-")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/download/list_merge_test.go
+++ b/pkg/download/list_merge_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	athenserr "github.com/gomods/athens/pkg/errors"
@@ -125,7 +125,7 @@ func TestListMerge(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, v := range tc.strVersions {
-				s.Save(ctx, testModName, v, bts, ioutil.NopCloser(bytes.NewReader(bts)), bts)
+				s.Save(ctx, testModName, v, bts, io.NopCloser(bytes.NewReader(bts)), bts)
 			}
 			defer clearStorage(s, testModName, tc.strVersions)
 			dp := New(&Opts{s, nil, &listerMock{versions: tc.goVersions, err: tc.goErr}, nil, Strict})

--- a/pkg/download/mode/mode.go
+++ b/pkg/download/mode/mode.go
@@ -3,7 +3,7 @@ package mode
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/gomods/athens/pkg/errors"
@@ -59,7 +59,7 @@ func NewFile(m Mode, downloadURL string) (*DownloadFile, error) {
 
 	if strings.HasPrefix(string(m), "file:") {
 		filePath := string(m[5:])
-		bts, err := ioutil.ReadFile(filePath)
+		bts, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -22,6 +22,7 @@ import (
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/gomods/athens/pkg/storage/mem"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -358,7 +359,7 @@ func TestGoMod(t *testing.T) {
 func getGoldenFile(t *testing.T, name string) []byte {
 	t.Helper()
 	file := filepath.Join("test_data", strings.Replace(name, " ", "_", -1)+".golden")
-	bts, err := ioutil.ReadFile(file)
+	bts, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +419,7 @@ func (m *mockFetcher) Fetch(ctx context.Context, mod, ver string) (*storage.Vers
 	return &storage.Version{
 		Mod:  bts,
 		Info: bts,
-		Zip:  ioutil.NopCloser(bytes.NewReader(bts)),
+		Zip:  io.NopCloser(bytes.NewReader(bts)),
 	}, nil
 }
 
@@ -429,7 +430,7 @@ func TestDownloadProtocolWhenFetchFails(t *testing.T) {
 	}
 	fakeMod := testMod{"github.com/athens-artifacts/samplelib", "v1.0.0"}
 	bts := []byte(fakeMod.mod + "@" + fakeMod.ver)
-	err = s.Save(context.Background(), fakeMod.mod, fakeMod.ver, bts, ioutil.NopCloser(bytes.NewReader(bts)), bts)
+	err = s.Save(context.Background(), fakeMod.mod, fakeMod.ver, bts, io.NopCloser(bytes.NewReader(bts)), bts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -58,7 +57,7 @@ func newTestFilter(filterFile string) (*module.Filter, error) {
 func Test_FilterMiddleware(t *testing.T) {
 	r := require.New(t)
 
-	filter, err := ioutil.TempFile(os.TempDir(), "filter-")
+	filter, err := os.CreateTemp(os.TempDir(), "filter-")
 	if err != nil {
 		t.FailNow()
 	}

--- a/pkg/middleware/validation.go
+++ b/pkg/middleware/validation.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gomods/athens/pkg/errors"
@@ -99,6 +99,6 @@ func validate(ctx context.Context, client *http.Client, hook, mod, ver string) (
 func validationResponseFromRequest(resp *http.Response) validationResponse {
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	return validationResponse{Valid: resp.StatusCode == http.StatusOK, Message: body}
 }

--- a/pkg/module/filter_test.go
+++ b/pkg/module/filter_test.go
@@ -1,7 +1,6 @@
 package module
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -208,27 +207,27 @@ func (t *FilterTests) Test_initFromConfig() {
 	defer os.Remove(filterFile)
 
 	goodInput := []byte("+ github.com/a/b\n\n# some comment\n- github.com/c/d\n\nD github.com/x")
-	ioutil.WriteFile(filterFile, goodInput, 0644)
+	os.WriteFile(filterFile, goodInput, 0644)
 
 	f, err := initFromConfig(filterFile)
 	r.NotNil(f)
 	r.NoError(err)
 
 	badInput := []byte("+ github.com/a/b\n\n# some comment\n\n- github.com/c/d\n\nD github.com/x\nsome_random_line")
-	ioutil.WriteFile(filterFile, badInput, 0644)
+	os.WriteFile(filterFile, badInput, 0644)
 	f, err = initFromConfig(filterFile)
 	r.Nil(f)
 	r.Error(err)
 
 	versionInput := []byte("+ github.com/a/b\n\n# some comment\n\n- github.com/c/d v1,v2.3.4,v3.2.*\n\nD github.com/x\n")
-	ioutil.WriteFile(filterFile, versionInput, 0644)
+	os.WriteFile(filterFile, versionInput, 0644)
 	f, err = initFromConfig(filterFile)
 	r.NotNil(f)
 	r.NoError(err)
 }
 
 func tempFilterFile(t *testing.T) (path string) {
-	filter, err := ioutil.TempFile(os.TempDir(), "filter-")
+	filter, err := os.CreateTemp(os.TempDir(), "filter-")
 	if err != nil {
 		t.FailNow()
 	}

--- a/pkg/module/go_get_fetcher_test.go
+++ b/pkg/module/go_get_fetcher_test.go
@@ -2,7 +2,7 @@ package module
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -48,7 +48,7 @@ func (s *ModuleSuite) TestGoGetFetcherFetch() {
 
 	r.True(len(ver.Mod) > 0)
 
-	zipBytes, err := ioutil.ReadAll(ver.Zip)
+	zipBytes, err := io.ReadAll(ver.Zip)
 	r.NoError(err)
 	r.True(len(zipBytes) > 0)
 
@@ -76,7 +76,7 @@ func (s *ModuleSuite) TestGoGetFetcherSumDB() {
 		return
 	}
 	r := s.Require()
-	zipBytes, err := ioutil.ReadFile("test_data/mockmod.xyz@v1.2.3.zip")
+	zipBytes, err := os.ReadFile("test_data/mockmod.xyz@v1.2.3.zip")
 	r.NoError(err)
 	mp := &mockProxy{paths: map[string][]byte{
 		"/mockmod.xyz/@v/v1.2.3.info": []byte(`{"Version":"v1.2.3"}`),
@@ -101,7 +101,7 @@ func (s *ModuleSuite) TestGoGetFetcherSumDB() {
 func (s *ModuleSuite) TestGoGetDir() {
 	r := s.Require()
 	t := s.T()
-	dir, err := ioutil.TempDir("", "nested")
+	dir, err := os.MkdirTemp("", "nested")
 	r.NoError(err)
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
@@ -113,7 +113,7 @@ func (s *ModuleSuite) TestGoGetDir() {
 	r.NoError(err)
 	defer ver.Zip.Close()
 
-	dirInfo, err := ioutil.ReadDir(dir)
+	dirInfo, err := os.ReadDir(dir)
 	r.NoError(err)
 
 	if len(dirInfo) <= 0 {

--- a/pkg/stash/stasher_test.go
+++ b/pkg/stash/stasher_test.go
@@ -3,7 +3,6 @@ package stash
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -104,7 +103,7 @@ func (mf *mockFetcher) Fetch(ctx context.Context, mod, ver string) (*storage.Ver
 	return &storage.Version{
 		Info:   []byte("info"),
 		Mod:    []byte("gomod"),
-		Zip:    ioutil.NopCloser(strings.NewReader("zipfile")),
+		Zip:    io.NopCloser(strings.NewReader("zipfile")),
 		Semver: mf.ver,
 	}, nil
 }

--- a/pkg/stash/with_gcs_test.go
+++ b/pkg/stash/with_gcs_test.go
@@ -3,7 +3,7 @@ package stash
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -67,7 +67,7 @@ func TestWithGCS(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer zip.Close()
-	zipContent, err := ioutil.ReadAll(zip)
+	zipContent, err := io.ReadAll(zip)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/azureblob/getter.go
+++ b/pkg/storage/azureblob/getter.go
@@ -3,7 +3,7 @@ package azureblob
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
@@ -30,7 +30,7 @@ func (s *Storage) Info(ctx context.Context, module string, version string) ([]by
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
 	}
 
-	infoBytes, err := ioutil.ReadAll(infoReader)
+	infoBytes, err := io.ReadAll(infoReader)
 	if err != nil {
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
 	}
@@ -62,7 +62,7 @@ func (s *Storage) GoMod(ctx context.Context, module string, version string) ([]b
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
 	}
 
-	modBytes, err := ioutil.ReadAll(modReader)
+	modBytes, err := io.ReadAll(modReader)
 	if err != nil {
 		return nil, errors.E(op, fmt.Errorf("could not get new reader for mod file: %s", err), errors.M(module), errors.V(version))
 	}

--- a/pkg/storage/compliance/benchmarks.go
+++ b/pkg/storage/compliance/benchmarks.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/gomods/athens/pkg/storage"
@@ -49,7 +49,7 @@ func benchSave(b *testing.B, s storage.Backend, clear func() error) {
 
 	module, version := "benchSaveModule", "1.0.1"
 	mock := getMockModule()
-	zipBts, err := ioutil.ReadAll(mock.Zip)
+	zipBts, err := io.ReadAll(mock.Zip)
 	require.NoError(b, err)
 
 	mi := 0
@@ -76,7 +76,7 @@ func benchDelete(b *testing.B, s storage.Backend, clear func() error) {
 
 	module, version := "benchDeleteModule", "1.0.1"
 	mock := getMockModule()
-	zipBts, err := ioutil.ReadAll(mock.Zip)
+	zipBts, err := io.ReadAll(mock.Zip)
 	require.NoError(b, err)
 	ctx := context.Background()
 

--- a/pkg/storage/compliance/tests.go
+++ b/pkg/storage/compliance/tests.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"sort"
 	"testing"
@@ -136,7 +136,7 @@ func testGet(t *testing.T, b storage.Backend) {
 	modname := "github.com/gomods/athens"
 	ver := "v1.2.3"
 	mock := getMockModule()
-	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	zipBts, _ := io.ReadAll(mock.Zip)
 	b.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
 	defer b.Delete(ctx, modname, ver)
 
@@ -150,7 +150,7 @@ func testGet(t *testing.T, b storage.Backend) {
 
 	zip, err := b.Zip(ctx, modname, ver)
 	require.NoError(t, err)
-	givenZipBts, err := ioutil.ReadAll(zip)
+	givenZipBts, err := io.ReadAll(zip)
 	require.NoError(t, err)
 	require.Equal(t, zipBts, givenZipBts)
 	require.Equal(t, int64(len(zipBts)), zip.Size())
@@ -161,7 +161,7 @@ func testExists(t *testing.T, b storage.Backend) {
 	modname := "github.com/gomods/athens"
 	ver := "v1.2.3"
 	mock := getMockModule()
-	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	zipBts, _ := io.ReadAll(mock.Zip)
 	b.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
 	defer b.Delete(ctx, modname, ver)
 	checker := storage.WithChecker(b)
@@ -175,7 +175,7 @@ func testShouldNotExist(t *testing.T, b storage.Backend) {
 	mod := "github.com/gomods/shouldNotExist"
 	ver := "v1.2.3-pre.1"
 	mock := getMockModule()
-	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	zipBts, _ := io.ReadAll(mock.Zip)
 	err := b.Save(ctx, mod, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
 	require.NoError(t, err, "should successfully safe a mock module")
 	defer b.Delete(ctx, mod, ver)
@@ -217,7 +217,7 @@ func testCatalog(t *testing.T, b storage.Backend) {
 	ctx := context.Background()
 
 	mock := getMockModule()
-	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	zipBts, _ := io.ReadAll(mock.Zip)
 	modname := "github.com/gomods/testCatalogModule"
 	for i := 0; i < 6; i++ {
 		ver := fmt.Sprintf("v1.2.%04d", i)
@@ -256,6 +256,6 @@ func getMockModule() *storage.Version {
 	return &storage.Version{
 		Info: []byte("123"),
 		Mod:  []byte("456"),
-		Zip:  ioutil.NopCloser(bytes.NewReader([]byte("789"))),
+		Zip:  io.NopCloser(bytes.NewReader([]byte("789"))),
 	}
 }

--- a/pkg/storage/external/client.go
+++ b/pkg/storage/external/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"strconv"
@@ -53,7 +52,7 @@ func (s *service) Info(ctx context.Context, mod, ver string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
-	info, err := ioutil.ReadAll(body)
+	info, err := io.ReadAll(body)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -66,7 +65,7 @@ func (s *service) GoMod(ctx context.Context, mod, ver string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
-	modFile, err := ioutil.ReadAll(body)
+	modFile, err := io.ReadAll(body)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -107,7 +106,7 @@ func (s *service) Save(ctx context.Context, mod, ver string, modFile []byte, zip
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		bts, _ := ioutil.ReadAll(resp.Body)
+		bts, _ := io.ReadAll(resp.Body)
 		return errors.E(op, fmt.Errorf("unexpected status code: %v - body: %s", resp.StatusCode, bts), resp.StatusCode)
 	}
 	return nil
@@ -176,7 +175,7 @@ func (s *service) doRequest(ctx context.Context, method, mod, ver, ext string) (
 		return nil, 0, errors.E(op, err)
 	}
 	if resp.StatusCode != 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		return nil, 0, errors.E(op, fmt.Errorf("none 200 status code: %v - body: %s", resp.StatusCode, body), resp.StatusCode)
 	}

--- a/pkg/storage/external/server.go
+++ b/pkg/storage/external/server.go
@@ -3,7 +3,6 @@ package external
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -88,7 +87,7 @@ func NewServer(strg storage.Backend) http.Handler {
 			return
 		}
 		defer infoFile.Close()
-		info, err := ioutil.ReadAll(infoFile)
+		info, err := io.ReadAll(infoFile)
 		if err != nil {
 			http.Error(w, err.Error(), 400)
 			return
@@ -99,7 +98,7 @@ func NewServer(strg storage.Backend) http.Handler {
 			return
 		}
 		defer modReader.Close()
-		modFile, err := ioutil.ReadAll(modReader)
+		modFile, err := io.ReadAll(modReader)
 		if err != nil {
 			http.Error(w, err.Error(), 400)
 			return

--- a/pkg/storage/gcp/getter.go
+++ b/pkg/storage/gcp/getter.go
@@ -3,7 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"cloud.google.com/go/storage"
 	"github.com/gomods/athens/pkg/config"
@@ -21,7 +21,7 @@ func (s *Storage) Info(ctx context.Context, module, version string) ([]byte, err
 	if err != nil {
 		return nil, errors.E(op, err, getErrorKind(err), errors.M(module), errors.V(version))
 	}
-	infoBytes, err := ioutil.ReadAll(infoReader)
+	infoBytes, err := io.ReadAll(infoReader)
 	infoReader.Close()
 	if err != nil {
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
@@ -38,7 +38,7 @@ func (s *Storage) GoMod(ctx context.Context, module, version string) ([]byte, er
 	if err != nil {
 		return nil, errors.E(op, err, getErrorKind(err), errors.M(module), errors.V(version))
 	}
-	modBytes, err := ioutil.ReadAll(modReader)
+	modBytes, err := io.ReadAll(modReader)
 	modReader.Close()
 	if err != nil {
 		return nil, errors.E(op, fmt.Errorf("could not get new reader for mod file: %s", err), errors.M(module), errors.V(version))

--- a/pkg/storage/minio/getter.go
+++ b/pkg/storage/minio/getter.go
@@ -3,7 +3,7 @@ package minio
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gomods/athens/pkg/errors"
@@ -22,7 +22,7 @@ func (v *storageImpl) Info(ctx context.Context, module, vsn string) ([]byte, err
 		return nil, errors.E(op, err)
 	}
 	defer infoReader.Close()
-	info, err := ioutil.ReadAll(infoReader)
+	info, err := io.ReadAll(infoReader)
 	if err != nil {
 		return nil, transformNotFoundErr(op, module, vsn, err)
 	}
@@ -40,7 +40,7 @@ func (v *storageImpl) GoMod(ctx context.Context, module, vsn string) ([]byte, er
 		return nil, errors.E(op, err)
 	}
 	defer modReader.Close()
-	mod, err := ioutil.ReadAll(modReader)
+	mod, err := io.ReadAll(modReader)
 	if err != nil {
 		return nil, transformNotFoundErr(op, module, vsn, err)
 	}

--- a/pkg/storage/mongo/mongo.go
+++ b/pkg/storage/mongo/mongo.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -109,7 +109,7 @@ func (m *ModuleStore) newClient() (*mongo.Client, error) {
 			roots = x509.NewCertPool()
 		}
 
-		cert, err := ioutil.ReadFile(m.certPath)
+		cert, err := os.ReadFile(m.certPath)
 		if err != nil {
 			return nil, errors.E(op, err)
 		}

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -3,7 +3,7 @@ package mongo
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -48,13 +48,13 @@ func TestQueryModuleVersionExists(t *testing.T) {
 	mock := &storage.Version{
 		Info: []byte("123"),
 		Mod:  []byte("456"),
-		Zip:  ioutil.NopCloser(bytes.NewReader([]byte("789"))),
+		Zip:  io.NopCloser(bytes.NewReader([]byte("789"))),
 	}
 
 	ctx := context.Background()
 	backend := getStorage(t)
 
-	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	zipBts, _ := io.ReadAll(mock.Zip)
 	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
 	defer backend.Delete(ctx, modname, ver)
 
@@ -69,13 +69,13 @@ func TestQueryKindNotFoundErrorCases(t *testing.T) {
 	mock := &storage.Version{
 		Info: []byte("123"),
 		Mod:  []byte("456"),
-		Zip:  ioutil.NopCloser(bytes.NewReader([]byte("789"))),
+		Zip:  io.NopCloser(bytes.NewReader([]byte("789"))),
 	}
 
 	ctx := context.Background()
 	backend := getStorage(t)
 
-	zipBts, _ := ioutil.ReadAll(mock.Zip)
+	zipBts, _ := io.ReadAll(mock.Zip)
 	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
 	defer backend.Delete(ctx, modname, ver)
 
@@ -111,12 +111,12 @@ func TestNewStorageWithDefaultOverrides(t *testing.T) {
 		collName    string
 		expCollName string
 	}{
-		{"Test Default 'Athens' DB Name", "athens", "athens", "modules", "modules"},          //Tests the default database name
-		{"Test Custom DB Name", "testAthens", "testAthens", "modules", "modules"},            //Tests a non-default database name
-		{"Test Blank DB Name", "", "athens", "modules", "modules"},                           //Tests the blank database name edge-case
-		{"Test Default 'Modules' Collection Name", "athens", "athens", "modules", "modules"}, //Tests the default collection name
-		{"Test Custom Collection Name", "athens", "athens", "testModules", "testModules"},    //Tests the non-default collection name
-		{"Test Blank Collection Name", "athens", "athens", "", "modules"},                    //Tests the blank collection name edge-case
+		{"Test Default 'Athens' DB Name", "athens", "athens", "modules", "modules"},          // Tests the default database name
+		{"Test Custom DB Name", "testAthens", "testAthens", "modules", "modules"},            // Tests a non-default database name
+		{"Test Blank DB Name", "", "athens", "modules", "modules"},                           // Tests the blank database name edge-case
+		{"Test Default 'Modules' Collection Name", "athens", "athens", "modules", "modules"}, // Tests the default collection name
+		{"Test Custom Collection Name", "athens", "athens", "testModules", "testModules"},    // Tests the non-default collection name
+		{"Test Blank Collection Name", "athens", "athens", "", "modules"},                    // Tests the blank collection name edge-case
 
 	}
 

--- a/pkg/storage/s3/getter.go
+++ b/pkg/storage/s3/getter.go
@@ -3,7 +3,7 @@ package s3
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -32,7 +32,7 @@ func (s *Storage) Info(ctx context.Context, module, version string) ([]byte, err
 	}
 	defer infoReader.Close()
 
-	infoBytes, err := ioutil.ReadAll(infoReader)
+	infoBytes, err := io.ReadAll(infoReader)
 	if err != nil {
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
 	}
@@ -58,7 +58,7 @@ func (s *Storage) GoMod(ctx context.Context, module, version string) ([]byte, er
 	}
 	defer modReader.Close()
 
-	modBytes, err := ioutil.ReadAll(modReader)
+	modBytes, err := io.ReadAll(modReader)
 	if err != nil {
 		return nil, errors.E(op, fmt.Errorf("could not get new reader for mod file: %s", err), errors.M(module), errors.V(version))
 	}


### PR DESCRIPTION
## What is the problem I am trying to address?

`io/ioutil` package was deprecated in Go 1.16 and should not longer be used.

## How is the fix applied?

Replaces all occurrences of `io/ioutil` with functions on the `io` or `os` package.

The replacement functions can be found in the package docs for [`io/ioutil`](https://pkg.go.dev/io/ioutil) for reference.

