### PR TITLE
Pass Athens's logger to the Redis package

### DIFF
--- a/pkg/stash/with_redis.go
+++ b/pkg/stash/with_redis.go
@@ -13,9 +13,16 @@ import (
 	"github.com/gomods/athens/pkg/storage"
 )
 
+// RedisLogger mirrors github.com/go-redis/redis/v8/internal.Logging
+type RedisLogger interface {
+	Printf(ctx context.Context, format string, v ...interface{})
+}
+
 // WithRedisLock returns a distributed singleflight
 // using a redis cluster. If it cannot connect, it will return an error.
-func WithRedisLock(endpoint string, password string, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
+func WithRedisLock(l RedisLogger, endpoint string, password string, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
+	redis.SetLogger(l)
+
 	const op errors.Op = "stash.WithRedisLock"
 	client := redis.NewClient(&redis.Options{
 		Network:  "tcp",

--- a/pkg/stash/with_redis_sentinel.go
+++ b/pkg/stash/with_redis_sentinel.go
@@ -2,6 +2,7 @@ package stash
 
 import (
 	"context"
+
 	"github.com/go-redis/redis/v8"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
@@ -10,7 +11,9 @@ import (
 
 // WithRedisSentinelLock returns a distributed singleflight
 // with a redis cluster that utilizes sentinel for quorum and failover
-func WithRedisSentinelLock(endpoints []string, master, password string, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
+func WithRedisSentinelLock(l RedisLogger, endpoints []string, master, password string, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
+	redis.SetLogger(l)
+
 	const op errors.Op = "stash.WithRedisSentinelLock"
 	// The redis client constructor does not return an error when no endpoints
 	// are provided, so we check for ourselves.

--- a/pkg/stash/with_redis_sentinel_test.go
+++ b/pkg/stash/with_redis_sentinel_test.go
@@ -27,8 +27,9 @@ func TestWithRedisSentinelLock(t *testing.T) {
 		t.Fatal(err)
 	}
 	ms := &mockRedisStasher{strg: strg}
+	l := &testingRedisLogger{t: t}
 
-	wrapper, err := WithRedisSentinelLock([]string{endpoint}, masterName, password, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	wrapper, err := WithRedisSentinelLock(l, []string{endpoint}, masterName, password, storage.WithChecker(strg), config.DefaultRedisLockConfig())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

The Redis package used by `pkg/stash/with_redis*` occasionally logs bits of information, such as when a Redis Sentinel is discovered or changes, but it uses its own logger by default. If Athens is configured to log in JSON but Redis is logging in plain text, this creates problems when parsing the log output.

## How is the fix applied?

Make an adapter struct around `pkg/log.Logger` to implement the interface that Redis v8 expects, then pass the logger to the `WithRedis*` functions to call `redis.SetLogger`.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Haven't found an Issue specifically for this.