### PR TITLE
chore: improve docker testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 VERSION = "unset"
 DATE=$(shell date -u +%Y-%m-%d-%H:%M:%S-%Z)
 
+GO_MODCACHE?=$(shell go env GOMODCACHE)
+
 ifndef GOLANG_VERSION
 override GOLANG_VERSION = 1.19
 endif
+
+export GO_MODCACHE
 
 .PHONY: build
 build: ## build the athens proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       dockerfile: Dockerfile.test
       args:
         GOLANG_VERSION: 1.19
-    command: ["./scripts/test_e2e.sh"]
+    command: "/bin/sh -c 'cd e2etests && go test --tags e2etests'"
   azurite:
     image: arafato/azurite:2.6.5
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - ATHENS_MONGO_STORAGE_URL=mongodb://mongo:27017
       - TIMEOUT=20 # in case the mongo dependency takes longer to start up
       - ATHENS_STORAGE_TYPE=mongo
+    volumes:
+      - ${GO_MODCACHE}:/go/pkg/mod
     depends_on:
       - mongo
       - minio
@@ -38,6 +40,8 @@ services:
       args:
         GOLANG_VERSION: 1.19
     command: "/bin/sh -c 'cd e2etests && go test --tags e2etests'"
+    volumes:
+      - ${GO_MODCACHE}:/go/pkg/mod
   azurite:
     image: arafato/azurite:2.6.5
     ports:


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

This PR fixes the docker e2e tests that are currently broken and additionally adds mod cache mounting to make testing in docker faster.

## How is the fix applied?

The mod cache location is determined from the go environment and volume mounted into test containers.
As the docker e2e testing seems to not have been updated when e2e tests changed, I fix that as well.
