### PR TITLE
chore: keep github actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -6,6 +7,15 @@ updates:
       interval: weekly
     commit-message:
       prefix: update-go-pkg
+      include: scope
+    open-pull-requests-limit: 2
+    target-branch: main
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: update-github-action
       include: scope
     open-pull-requests-limit: 2
     target-branch: main


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Github actions, like go modules, should be kept up-to-date.

## How is the fix applied?

Instruct dependabot to check github actions.
