### PR TITLE
chore: use builtin action linter package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
+          skip-pkg-cache: true
+          skip-build-cache: true
 
   build:
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      GOLANGCI_LINT_VERSION: v1.51.2
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -13,7 +16,9 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: Lint code
-        run: make lint-docker
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
 
   build:
     env:


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

The CI linter is currently uses docker, which is very slow due to not having a cache.

## How is the fix applied?

Use the provided Golanci-lint actions package which has caching builtin.
