### PR TITLE
chore: switch from `interface{}` to `any`

### DIFF
--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -133,7 +133,7 @@ type athensLoggerForRedis struct {
 	logger *log.Logger
 }
 
-func (l *athensLoggerForRedis) Printf(ctx context.Context, format string, v ...interface{}) {
+func (l *athensLoggerForRedis) Printf(ctx context.Context, format string, v ...any) {
 	l.logger.WithContext(ctx).Printf(format, v...)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,9 +22,9 @@ func testConfigFile(t *testing.T) (testConfigFile string) {
 	return testConfigFile
 }
 
-func compareConfigs(parsedConf *Config, expConf *Config, t *testing.T, ignoreTypes ...interface{}) {
+func compareConfigs(parsedConf *Config, expConf *Config, t *testing.T, ignoreTypes ...any) {
 	t.Helper()
-	opts := cmpopts.IgnoreTypes(append([]interface{}{Index{}}, ignoreTypes...)...)
+	opts := cmpopts.IgnoreTypes(append([]any{Index{}}, ignoreTypes...)...)
 	eq := cmp.Equal(parsedConf, expConf, opts)
 	if !eq {
 		diff := cmp.Diff(parsedConf, expConf, opts)

--- a/pkg/errors/doc.go
+++ b/pkg/errors/doc.go
@@ -11,7 +11,7 @@
 // the logger's SystemError method, although it accepts any type of error,
 // it knows how to deal with errors constructed from this package in a debuggable way.
 // To construct an Athens error, call the errors.E function. The E function takes
-// an Op and a variadic interface{}, but the values of the Error struct are what you can
+// an Op and a variadic of any, but the values of the Error struct are what you can
 // pass to it. Values such as the error Kind, Module, Version, Error Message,
 // and Seveirty (seriousness of an error) are all optional. The only truly required value is
 // the errors.Op so you can construct a traceable stack that leads to where

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -88,7 +88,7 @@ type V string
 // an error or a string to describe what exactly went wrong.
 // You can optionally pass a Logrus severity to indicate
 // the log level of an error based on the context it was constructed in.
-func E(op Op, args ...interface{}) error {
+func E(op Op, args ...any) error {
 	e := Error{Op: op}
 	if len(args) == 0 {
 		msg := "errors.E called with 0 args"

--- a/pkg/log/entry.go
+++ b/pkg/log/entry.go
@@ -12,13 +12,13 @@ import (
 // Fields are being overwritten.
 type Entry interface {
 	// Basic Logging Operation
-	Debugf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
+	Debugf(format string, args ...any)
+	Infof(format string, args ...any)
+	Warnf(format string, args ...any)
+	Errorf(format string, args ...any)
 
 	// Attach contextual information to the logging entry
-	WithFields(fields map[string]interface{}) Entry
+	WithFields(fields map[string]any) Entry
 
 	// SystemErr is a method that disects the error
 	// and logs the appropriate level and fields for it.
@@ -29,7 +29,7 @@ type entry struct {
 	*logrus.Entry
 }
 
-func (e *entry) WithFields(fields map[string]interface{}) Entry {
+func (e *entry) WithFields(fields map[string]any) Entry {
 	ent := e.Entry.WithFields(fields)
 	return &entry{ent}
 }

--- a/pkg/log/format.go
+++ b/pkg/log/format.go
@@ -31,7 +31,7 @@ const lightGrey = 0xffccc
 
 func (devFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	var buf bytes.Buffer
-	var sprintf func(format string, a ...interface{}) string
+	var sprintf func(format string, a ...any) string
 	switch e.Level {
 	case logrus.DebugLevel:
 		sprintf = color.New(lightGrey).Sprintf

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -35,7 +35,7 @@ func (l *Logger) SystemErr(err error) {
 }
 
 // WithFields Entry implementation.
-func (l *Logger) WithFields(fields map[string]interface{}) Entry {
+func (l *Logger) WithFields(fields map[string]any) Entry {
 	e := l.Logger.WithFields(fields)
 
 	return &entry{e}

--- a/pkg/stash/with_redis.go
+++ b/pkg/stash/with_redis.go
@@ -15,7 +15,7 @@ import (
 
 // RedisLogger mirrors github.com/go-redis/redis/v8/internal.Logging.
 type RedisLogger interface {
-	Printf(ctx context.Context, format string, v ...interface{})
+	Printf(ctx context.Context, format string, v ...any)
 }
 
 // WithRedisLock returns a distributed singleflight

--- a/pkg/stash/with_redis_test.go
+++ b/pkg/stash/with_redis_test.go
@@ -20,7 +20,7 @@ type testingRedisLogger struct {
 	t *testing.T
 }
 
-func (l *testingRedisLogger) Printf(ctx context.Context, format string, v ...interface{}) {
+func (l *testingRedisLogger) Printf(ctx context.Context, format string, v ...any) {
 	l.t.Logf(format, v...)
 }
 


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

This PR switches all instances of `interface{}` to `any`. The `any` type alias was introduced in Go 1.18 along with generics, and `any` is now conventionally used instead of `interface{}`.

## How is the fix applied?

Replace all instances of `interface{}` with `any`.
