### PR TITLE
Update Exists method to use HeadObjectWithContext

### DIFF
--- a/pkg/storage/s3/checker.go
+++ b/pkg/storage/s3/checker.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -21,7 +20,7 @@ func (s *Storage) Exists(ctx context.Context, module, version string) (bool, err
 
 	lsParams := &s3.ListObjectsInput{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(fmt.Sprintf("%s/@v", module)),
+		Prefix: aws.String(config.PackageVersionedName(module, version, "")),
 	}
 	found := make(map[string]struct{}, 3)
 	err := s.s3API.ListObjectsPagesWithContext(ctx, lsParams, func(loo *s3.ListObjectsOutput, lastPage bool) bool {


### PR DESCRIPTION
## What is the problem I am trying to address?

The .mod endpoint for modules with a large number of tags (such as the [aws-sdk-go](https://github.com/aws/aws-sdk-go) module) is currently experiencing slow performance. 

This is due to a change in the S3 filtering prefix introduced during the implementation of "Using directory as prefix for S3 #1720."

When listing objects using the S3 prefix `"github.com/aws/aws-sdk-go/@v"`, which returns approximately 4000 S3 objects, it takes almost **6 seconds** to complete the .mod endpoint request.

### About PR #1720 

The original PR https://github.com/gomods/athens/pull/1720 mentioned that list objects on S3 with prefixes like `"github.com/golang/mock/@v/v1.4.4."` will return empty list, this is no longer the case:

![Screenshot 2023-02-28 at 3 39 54 PM](https://user-images.githubusercontent.com/43508840/221785951-014af64f-be71-4f89-8c59-6e9ae6376b3b.png)

```sh
❯ aws s3 ls s3://s3-cache/github.com/golang/mock/@v/v1.4.4.
2022-10-28 15:43:05         50 v1.4.4.info
2022-10-28 15:43:05        102 v1.4.4.mod
2022-10-28 15:43:05      95367 v1.4.4.zip

❯ aws s3 ls s3://s3-cache/github.com/golang/mock/@v/v1.4.4
2022-10-28 15:43:05         50 v1.4.4.info
2022-10-28 15:43:05        102 v1.4.4.mod
2022-10-28 15:43:05      95367 v1.4.4.zip
```


## Examples

1. Result when using the [current HEAD commit](https://github.com/gomods/athens/blob/af82a7a9cd7cc32db37dba102f1b1e18297702fc/pkg/storage/s3/checker.go#L24) (af82a7a9):
```sh
❯ time curl http://localhost:3000/github.com/aws/aws-sdk-go/@v/v1.40.58.mod
module github.com/aws/aws-sdk-go

require (
	github.com/jmespath/go-jmespath v0.4.0
	github.com/pkg/errors v0.9.1
	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
)

go 1.11
curl http://localhost:3000/github.com/aws/aws-sdk-go/@v/v1.40.58.mo  0.02s user 0.01s system 0% cpu 5.986 total

❯ aws s3 ls s3://s3-cache/github.com/aws/aws-sdk-go/@v --recursive | wc -l
    4542
```

In the example above, we're listing objects using the S3 prefix `"github.com/aws/aws-sdk-go/@v"`, which returns **~4000** S3 objects. To iterate through that many objects, it took us ~5.9s to complete the `.mod` endpoint request.

2. Result when using [Athens v0.11.0](https://github.com/gomods/athens/blob/v0.11.0/pkg/storage/s3/checker.go#L26)
```sh
❯ time curl http://localhost:3000.com/aws/aws-sdk-go/@v/v1.40.58.mod
module github.com/aws/aws-sdk-go

require (
	github.com/jmespath/go-jmespath v0.4.0
	github.com/pkg/errors v0.9.1
	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
)

go 1.11
curl http://localhost:3000.com/aws/aws-sdk-go/@v/v1.40.58.mod  0.02s user 0.01s system 13% cpu 0.246 total

❯ aws s3 ls s3://s3-cache/github.com/aws/aws-sdk-go/@v/v1.40.59. --recursive | wc -l
       3
```

In the example above, we're listing objects using the S3 prefix `"github.com/aws/aws-sdk-go/@v/v1.40.58."`, which returns only **3** S3 objects. As a result, it only took ~0.2s to complete the `.mod` request.

## How is the fix applied?

Essentially I propose to just undo the change of https://github.com/gomods/athens/pull/1720.

This will allow us to list objects on S3 with prefixes like `"github.com/aws/aws-sdk-go/@v/v1.40.58."`, which returns only 3 S3 objects in this example. This results in a much faster response time of only 0.2 seconds.


## References

- [Old AWS docs](https://web.archive.org/web/20210507070946/https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html)
- [Latest AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html)


I hope that this fix will improve the performance of the .mod endpoint for modules with a large number of tags. Thank you for considering this PR!
