### PR TITLE
feat: add non-root user to docker image

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -32,6 +32,9 @@ RUN chmod 644 /config/config.toml
 RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini && \
 	mkdir -p /usr/local/go
 
+ARG USER=athens
+RUN adduser -D -h /home/$USER $USER
+
 EXPOSE 3000
 
 ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/docs/content/install/using-docker.md
+++ b/docs/content/install/using-docker.md
@@ -53,6 +53,23 @@ docker run -d -v "$($env:ATHENS_STORAGE):/var/lib/athens" `
    gomods/athens:latest
 ```
 
+## Non-Root User
+
+The Athens docker images comes with a non-root user `authens` with `uid: 1000`, `gid: 1000` and home directory `/home/athens`.
+In situations where running as root is not permitted, this user can be used instead. In all other instuctions
+replace `/root/` with `/home/athens/` and set the user and group ids in the run environment to `1000`.
+
+```shell
+docker run -d -v $ATHENS_STORAGE:/var/lib/athens \
+   -e ATHENS_DISK_STORAGE_ROOT=/var/lib/athens \
+   -e ATHENS_STORAGE_TYPE=disk \
+   -v "$PWD/gitconfig/.gitconfig:/home/athens/.gitconfig" \
+   --name athens-proxy \
+   --restart always \
+   -p 3000:3000 \
+   -u 1000:1000 \
+   gomods/athens:latest
+```
 
 ## Troubleshooting Athens in Docker
 

--- a/docs/content/install/using-docker.md
+++ b/docs/content/install/using-docker.md
@@ -55,7 +55,7 @@ docker run -d -v "$($env:ATHENS_STORAGE):/var/lib/athens" `
 
 ## Non-Root User
 
-The Athens docker images comes with a non-root user `authens` with `uid: 1000`, `gid: 1000` and home directory `/home/athens`.
+The Athens docker images comes with a non-root user `athens` with `uid: 1000`, `gid: 1000` and home directory `/home/athens`.
 In situations where running as root is not permitted, this user can be used instead. In all other instuctions
 replace `/root/` with `/home/athens/` and set the user and group ids in the run environment to `1000`.
 


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

In many modern deployment environments, root containers are not allowed. While it is simple to switch the user on the fly, that user needs to have a home directory for this to work.

## How is the fix applied?

A non-root user `athens` uid/gid 1000 is created in the docker image, but not used by default. As existing users will still want to use `root` for this to be non-breaking, the new user is not used by default. Documentation on the non-root user has also been added to make this change discoverable.
