### PR TITLE
Refactoring: Use errors.AsErr

### DIFF
--- a/pkg/storage/s3/checker.go
+++ b/pkg/storage/s3/checker.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"context"
-	errs "errors"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,7 +45,7 @@ func (s *Storage) Exists(ctx context.Context, module, version string) (bool, err
 			continue
 		}
 		var aerr awserr.Error
-		if errs.As(err, &aerr) && aerr.Code() == "NotFound" {
+		if errors.AsErr(err, &aerr) && aerr.Code() == "NotFound" {
 			err = nil
 			exists = false
 		}

--- a/pkg/storage/s3/getter.go
+++ b/pkg/storage/s3/getter.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"context"
-	errs "errors"
 	"fmt"
 	"io"
 
@@ -24,7 +23,7 @@ func (s *Storage) Info(ctx context.Context, module, version string) ([]byte, err
 	infoReader, err := s.open(ctx, config.PackageVersionedName(module, version, "info"))
 	if err != nil {
 		var aerr awserr.Error
-		if errs.As(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
+		if errors.AsErr(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
 			return nil, errors.E(op, errors.M(module), errors.V(version), errors.KindNotFound)
 		}
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
@@ -47,7 +46,7 @@ func (s *Storage) GoMod(ctx context.Context, module, version string) ([]byte, er
 	modReader, err := s.open(ctx, config.PackageVersionedName(module, version, "mod"))
 	if err != nil {
 		var aerr awserr.Error
-		if errs.As(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
+		if errors.AsErr(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
 			return nil, errors.E(op, errors.M(module), errors.V(version), errors.KindNotFound)
 		}
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
@@ -71,7 +70,7 @@ func (s *Storage) Zip(ctx context.Context, module, version string) (storage.Size
 	zipReader, err := s.open(ctx, config.PackageVersionedName(module, version, "zip"))
 	if err != nil {
 		var aerr awserr.Error
-		if errs.As(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
+		if errors.AsErr(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
 			return nil, errors.E(op, errors.M(module), errors.V(version), errors.KindNotFound)
 		}
 		return nil, errors.E(op, err, errors.M(module), errors.V(version))
@@ -92,7 +91,7 @@ func (s *Storage) open(ctx context.Context, path string) (storage.SizeReadCloser
 	goo, err := s.s3API.GetObjectWithContext(ctx, getParams)
 	if err != nil {
 		var aerr awserr.Error
-		if errs.As(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
+		if errors.AsErr(err, &aerr) && aerr.Code() == s3.ErrCodeNoSuchKey {
 			return nil, errors.E(op, errors.KindNotFound)
 		}
 		return nil, errors.E(op, err)


### PR DESCRIPTION
Using `errors.AsErr` as suggested by @nrwiersma , so we don't need to import two errors packages.