### PR TITLE
Update alpine to 3.17 and build smaller binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ endif
 
 .PHONY: build
 build: ## build the athens proxy
-	go build -o ./cmd/proxy/proxy ./cmd/proxy
+	go build -ldflags="-w -s" -o ./cmd/proxy/proxy ./cmd/proxy
 
 .PHONY: build-ver
 build-ver: ## build the athens proxy with version number
-	GO111MODULE=on CGO_ENABLED=0 GOPROXY="https://proxy.golang.org" go build -ldflags "-X github.com/gomods/athens/pkg/build.version=$(VERSION) -X github.com/gomods/athens/pkg/build.buildDate=$(DATE)" -o athens ./cmd/proxy
+	GO111MODULE=on CGO_ENABLED=0 GOPROXY="https://proxy.golang.org" go build -ldflags "-s -w -X github.com/gomods/athens/pkg/build.version=$(VERSION) -X github.com/gomods/athens/pkg/build.buildDate=$(DATE)" -o athens ./cmd/proxy
 
 athens:
 	$(MAKE) build-ver

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -6,7 +6,7 @@
 # See project Makefile if using make.
 # See docker --build-arg if building directly.
 ARG GOLANG_VERSION=1.20
-ARG ALPINE_VERSION=3.15
+ARG ALPINE_VERSION=3.17
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -16,7 +16,7 @@ COPY . .
 
 ARG VERSION="unset"
 
-RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && GO111MODULE=on CGO_ENABLED=0 GOPROXY="https://proxy.golang.org" go build -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE" -o /bin/athens-proxy ./cmd/proxy
+RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && GO111MODULE=on CGO_ENABLED=0 GOPROXY="https://proxy.golang.org" go build -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE -s -w" -o /bin/athens-proxy ./cmd/proxy
 
 FROM alpine:${ALPINE_VERSION}
 


### PR DESCRIPTION
This PR updates alpine to 3.17 and builds smaller athens binary. By using these flags; we are saving around 14M in athens binary size.
