### PR TITLE
Support Unix domain sockets for proxy server listener

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -131,6 +131,12 @@ StorageType = "memory"
 # The PORT must be a number or a number prefixed by ":"
 Port = ":3000"
 
+# UnixSocket sets a Unix domain socket path that the proxy listens on.
+# This option, when specified, takes precedence over TCP port configuration.
+# Defaults to empty (i.e. listen on a TCP port only)
+# Env override: ATHENS_UNIX_SOCKET
+UnixSocket = ""
+
 # The endpoint for a package registry in case of a proxy cache miss
 # NOTE: Currently no registries have been implemented
 # Env override: ATHENS_GLOBAL_ENDPOINT

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	StorageType      string    `validate:"required" envconfig:"ATHENS_STORAGE_TYPE"`
 	GlobalEndpoint   string    `envconfig:"ATHENS_GLOBAL_ENDPOINT"` // This feature is not yet implemented
 	Port             string    `envconfig:"ATHENS_PORT"`
+	UnixSocket       string    `envconfig:"ATHENS_UNIX_SOCKET"`
 	BasicAuthUser    string    `envconfig:"BASIC_AUTH_USER"`
 	BasicAuthPass    string    `envconfig:"BASIC_AUTH_PASS"`
 	ForceSSL         bool      `envconfig:"PROXY_FORCE_SSL"`


### PR DESCRIPTION
## What is the problem I am trying to address?

The Athens server currently only supports listening on a TCP port. This change introduces the capability to listen on a Unix domain socket instead, when specified in configuration as `UnixSocket` or in the environment as `ATHENS_UNIX_SOCKET`.

## How is the fix applied?

Changes:

* Augment configuration schema to respect `UnixSocket`
* Update main entry point server to create either a TCP or Unix socket listener depending on configuration
* Serve the HTTP server on the initialized listener

### Patch verification

```bash
$ ATHENS_UNIX_SOCKET=/tmp/athens.sock ./athens 
2023/04/07 18:15:26 Running dev mode with default settings, consult config when you're ready to run in production
INFO[6:15PM]: Exporter not specified. Traces won't be exported	
2023/04/07 18:15:26 Starting application at Unix domain socket /tmp/athens.sock
```

```bash
$ curl -i --unix-socket /tmp/athens.sock http://localhost
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 08 Apr 2023 01:15:42 GMT
Content-Length: 29

"Welcome to The Athens Proxy"
```

Configuration:

```toml
GoBinary = "go"
GoEnv = "development"
GoBinaryEnvVars = ["GOPROXY=direct"]
GoGetWorkers = 32
ProtocolWorkers = 64
LogLevel = "debug"
CloudRuntime = "none"
EnablePprof = false
Timeout = 1200
StorageType = "memory"
UnixSocket = "/tmp/athens.sock"
ForceSSL = false
SumDBs = ["https://sum.golang.org"]
NoSumPatterns = ["*"]
NetworkMode = "strict"
DownloadMode = "sync"
SingleFlightType = "memory"
IndexType = "memory"
```

```bash
$ ./athens --config_file config.toml
INFO[6:16PM]: Exporter not specified. Traces won't be exported	
INFO[6:16PM]: StatsExporter not specified. Stats won't be collected	
2023/04/07 18:16:23 Starting application at Unix domain socket /tmp/athens.sock
```

```bash
$ curl -i --unix-socket /tmp/athens.sock http://localhost
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 08 Apr 2023 01:16:31 GMT
Content-Length: 29

"Welcome to The Athens Proxy"
```