### PR TITLE
fix: relax file permissions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -383,7 +383,7 @@ func checkFilePerms(files ...string) error {
 		// Assume unix based system (MacOS and Linux)
 		// the bit mask is calculated using the umask command which tells which permissions
 		// should not be allowed for a particular user, group or world
-		if fInfo.Mode()&0o077 != 0 && runtime.GOOS != "windows" {
+		if fInfo.Mode()&0o033 != 0 && runtime.GOOS != "windows" {
 			return errors.E(op, f+" should have at most rwx,-, - (bit mask 077) as permission")
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -409,7 +409,7 @@ func Test_checkFilePerms(t *testing.T) {
 		t.Skipf("Chmod is not supported in windows, so not possible to test. Ref: https://github.com/golang/go/blob/master/src/os/os_test.go#L1031\n")
 	}
 
-	incorrectPerms := []os.FileMode{0777, 0610, 0660}
+	incorrectPerms := []os.FileMode{0o777, 0o610, 0o660}
 	var incorrectFiles = make([]string, len(incorrectPerms))
 
 	for i := range incorrectPerms {
@@ -421,7 +421,7 @@ func Test_checkFilePerms(t *testing.T) {
 		defer os.Remove(f)
 	}
 
-	correctPerms := []os.FileMode{0600, 0400}
+	correctPerms := []os.FileMode{0o600, 0o400, 0o644}
 	var correctFiles = make([]string, len(correctPerms))
 
 	for i := range correctPerms {
@@ -441,8 +441,8 @@ func Test_checkFilePerms(t *testing.T) {
 
 	tests := []test{
 		{
-			"should not have an error on 0600, 0400, 0640",
-			[]string{correctFiles[0], correctFiles[1]},
+			"should not have an error on 0600, 0400, 0644",
+			[]string{correctFiles[0], correctFiles[1], correctFiles[2]},
 			false,
 		},
 		{


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

This relaxes the permissible config file permission to allow read for group and other (effectively 0o644).

For reference, the current docker build sets the file permissions to 0o644.

## How is the fix applied?

Changed the permission check and added a test for allowing 0o644.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #1007

<!-- 
example: Fixes #123
-->
