### PR TITLE
feat: support arm64 and multi-arch docker images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,11 +12,14 @@ builds:
     - darwin
   goarch:
     - amd64
+    - arm64
   main: cmd/proxy/main.go
   binary: athens
   ldflags:
     - -X "github.com/gomods/athens/pkg/build.version={{ .Tag }}"
     - -X "github.com/gomods/athens/pkg/build.buildDate={{ .Env.DATE }}"
+universal_binaries:
+- replace: true
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/scripts/push-docker-images.sh
+++ b/scripts/push-docker-images.sh
@@ -25,10 +25,12 @@ fi
 
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd )/"
 
-docker build --build-arg VERSION=${VERSION} -t ${REGISTRY}athens:${VERSION} -f ${REPO_DIR}cmd/proxy/Dockerfile ${REPO_DIR}
+# Build & Publish Multi-arch Docker Image
+docker buildx build \
+  --pull --push \
+  --platform=linux/amd64/v1,linux/arm64/v8 \
+  --tag "${REGISTRY}athens:${VERSION}" \
+  --tag "${REGISTRY}athens:${MUTABLE_TAG}" \
+  --build-arg=VERSION=${VERSION} \
+  --file ${REPO_DIR}cmd/proxy/Dockerfile ${REPO_DIR}
 
-# Apply the mutable tag to the immutable version
-docker tag ${REGISTRY}athens:${VERSION} ${REGISTRY}athens:${MUTABLE_TAG}
-
-docker push ${REGISTRY}athens:${VERSION}
-docker push ${REGISTRY}athens:${MUTABLE_TAG}


### PR DESCRIPTION
## What is the problem I am trying to address?

Adds support for AMD64 binaries and builds a multi-arch docker image for linux/amd64/v1 + linux/arm64/v8

## How is the fix applied?

- modified the .goreleaser.yaml to add arm64 build target and macos universal binaries
- updated the docker build/push script to use docker buildx with both linux/amd64/v1 and linux/arm64/v8

## What GitHub issue(s) does this PR fix or close?

Fixes #1869

## Additional Information

I've built an image and pushed it to [Docker Hub](https://hub.docker.com/layers/justenwalker/athens/v0.12.1-multiarch/images/sha256-33f5b96cdda5d6425ea7a9ecd7fb01dac6cf72c924d63d953e40a21fe892c707?context=explore)

`docker pull justenwalker/athens:v0.12.1-multiarch`

