### PR TITLE
fix(proxy): don't check TLS file permission

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -40,11 +40,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	cert, key, err := conf.TLSCertFiles()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	srv := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 2 * time.Second,
@@ -94,7 +89,7 @@ func main() {
 		}
 	}
 
-	if cert != "" && key != "" {
+	if conf.TLSCertFile != "" && conf.TLSKeyFile != "" {
 		err = srv.ServeTLS(ln, conf.TLSCertFile, conf.TLSKeyFile)
 	} else {
 		err = srv.Serve(ln)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -215,30 +215,6 @@ func (c *Config) BasicAuth() (user, pass string, ok bool) {
 	return user, pass, ok
 }
 
-// TLSCertFiles returns certificate and key files and an error if
-// both files doesn't exist and have approperiate file permissions.
-func (c *Config) TLSCertFiles() (cert, key string, err error) {
-	if c.TLSCertFile == "" && c.TLSKeyFile == "" {
-		return "", "", nil
-	}
-
-	certFile, err := os.Stat(c.TLSCertFile)
-	if err != nil {
-		return "", "", fmt.Errorf("could not access TLSCertFile: %w", err)
-	}
-
-	keyFile, err := os.Stat(c.TLSKeyFile)
-	if err != nil {
-		return "", "", fmt.Errorf("could not access TLSKeyFile: %w", err)
-	}
-
-	if keyFile.Mode()&0o077 != 0 && runtime.GOOS != "windows" {
-		return "", "", fmt.Errorf("TLSKeyFile should not be accessible by others")
-	}
-
-	return certFile.Name(), keyFile.Name(), nil
-}
-
 // FilterOff returns true if the FilterFile is empty.
 func (c *Config) FilterOff() bool {
 	return c.FilterFile == ""


### PR DESCRIPTION
## What is the problem I am trying to address?

Athens should not check the permission of TLS files, as it is not compatible with some automatic certificate issuers.

## How is the fix applied?

The config method TLSCertFiles has been removed as it was redundant after the change. The return values were never even used.

## What GitHub issue(s) does this PR fix or close?

Fixes #1879