### PR TITLE
fix: arm64 build

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -8,7 +8,7 @@
 ARG GOLANG_VERSION=1.20
 ARG ALPINE_VERSION=3.17
 
-FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION}-alpine AS builder
+FROM golang:${GOLANG_VERSION}-alpine AS builder
 
 ARG VERSION="unset" \
     TARGETARCH


### PR DESCRIPTION
## What is the problem I am trying to address?

Current arm64 docker image contains an arm64 binary (`athens-proxy`) and an amd64 binary (`go`).

## How is the fix applied?

I manage to make a build on a private repo and use it on a kubernetes cluster with arm64 nodes.

I used the same kind of command than the one already configured in GH action:

```shell
docker buildx build --build-arg VERSION=v0.13.0 --file cmd/proxy/Dockerfile   --platform linux/amd64,linux/arm64 --tag ${MY_REGISTRY}/athens:v0.13.0-test --push .
```

## What GitHub issue(s) does this PR fix or close?

Fixes #1910 
Follow up of #1862