### PR TITLE
Send standard logger's output to logrus

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -44,6 +44,16 @@ func main() {
 
 	logger := athenslog.New(conf.CloudRuntime, logLvl)
 
+	// logrus.Writer() spawns a go routine, so instead of doing that each time
+	// we need to make logrus look like a (standard) log.Logger (and then Close()ing it),
+	// we can do it once in main and have the global log.Logger use it.
+	{
+		logrusWriter := logger.Writer()
+		defer logrusWriter.Close()
+		stdlog.SetOutput(logrusWriter)
+		stdlog.SetFlags(stdlog.Flags() &^ (stdlog.Ldate | stdlog.Ltime))
+	}
+
 	handler, err := actions.App(logger, conf)
 	if err != nil {
 		logger.WithError(err).Fatal("Could not create App")

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -48,7 +48,7 @@ func main() {
 	// we need to make logrus look like a (standard) log.Logger (and then Close()ing it),
 	// we can do it once in main and have the global log.Logger use it.
 	{
-		logrusWriter := logger.Writer()
+		logrusWriter := logger.WriterLevel(logrus.ErrorLevel)
 		defer func() {
 			if err := logrusWriter.Close(); err != nil {
 				logger.WithError(err).Warn("Could not close logrus writer pipe")

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -49,7 +49,11 @@ func main() {
 	// we can do it once in main and have the global log.Logger use it.
 	{
 		logrusWriter := logger.Writer()
-		defer logrusWriter.Close()
+		defer func() {
+			if err := logrusWriter.Close(); err != nil {
+				logger.WithError(err).Warn("Could not close logrus writer pipe")
+			}
+		}()
 		stdlog.SetOutput(logrusWriter)
 		stdlog.SetFlags(stdlog.Flags() &^ (stdlog.Ldate | stdlog.Ltime))
 	}


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Some packages like [`httputil`'s `ReverseProxy`](https://pkg.go.dev/http/httputil#ReverseProxy) [use the standard `log.Logger`](https://github.com/golang/go/blob/6db1102605f227093ea95538f0fe9e46022ad7ea/src/net/http/httputil/reverseproxy.go#L307) to emit log traces. This means that their output won't match the format of Athens's `logrus` output.

## How is the fix applied?

[`logrus.Logger.Writer`](https://pkg.go.dev/github.com/sirupsen/logrus#Logger.Writer)'s documentation states that it "can be used to override the standard library logger easily." It spawns a go routine, so instead of doing that each time we need to make `logrus` look like a (standard) `log.Logger` (and then remembering to `Close()` it right away), this calls `logrus.Writer()` once in `main`, `defer`s the `Close()`,  and sets it into the global `log.Logger`.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Related to the work done in #1819 to unify logging.

<!-- 
example: Fixes #123
-->
