### PR TITLE
chore: fix broken links to 'absolutely everybody' blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Speaking of contributing, read on!
 
 # Contributing
 
-If you use Athens for your development workflow, we hope that you'll consider contributing back to the project. Athens is widely used and has plenty of interesting work to do, from technical challenges to technical documentation to release management. We have a wonderful community that we would love you to be a part of. [Absolutely everyone is welcome](https://arschles.com/blog/absolutely-everybody-is-welcome/).
+If you use Athens for your development workflow, we hope that you'll consider contributing back to the project. Athens is widely used and has plenty of interesting work to do, from technical challenges to technical documentation to release management. We have a wonderful community that we would love you to be a part of. [Absolutely everyone is welcome](https://arschles.com/blog/absolutely-everybody/).
 
 The quickest way to get involved is by [filing issues](https://github.com/gomods/athens/issues/new/choose) if you find bugs or find that you need Athens to do something it doesn't.
 

--- a/docs/content/contributing/community/_index.md
+++ b/docs/content/contributing/community/_index.md
@@ -13,7 +13,7 @@ Welcome, Athenian! We've put together this section to help you get involved with
 Before we go further, we want you to know two things:
 
 1. You can contribute in many ways, including documentation, testing, writing code, reporting bugs, reviewing code, technical writing, and more
-2. [Absolutely everybody is welcome](https://arschles.com/blog/absolutely-everybody-is-welcome/). You are welcome in our community, regardless of your level of programming experience, number of years writing Go, race, religion, sexual orientation, gender identity, or anything else. If you want to be here, we will do everything we can to help you feel welcome and involved
+2. [Absolutely everybody is welcome](https://arschles.com/blog/absolutely-everybody/). You are welcome in our community, regardless of your level of programming experience, number of years writing Go, race, religion, sexual orientation, gender identity, or anything else. If you want to be here, we will do everything we can to help you feel welcome and involved
 
 
 Ready to join us? Head over to the [guide on how to participate](./participating) to get started!


### PR DESCRIPTION
## What is the problem I am trying to address?

The links to the "absolutely everybody" blog post are broken, greeting those who click on them with a nice big 404 😅

## How is the fix applied?

Updated to the correct links.
