### PR TITLE
Fix Markdown link in Storage docs

### DIFF
--- a/docs/content/configuration/storage.md
+++ b/docs/content/configuration/storage.md
@@ -346,7 +346,7 @@ It assumes that you already have the following:
 ## External Storage
 
 External storage lets Athens connect to your own implementation of a storage backend. 
-All you have to do is implement the (storage.Backend)[https://github.com/gomods/athens/blob/main/pkg/storage/backend.go#L4] interface and run it behind an http server. 
+All you have to do is implement the [storage.Backend](https://github.com/gomods/athens/blob/main/pkg/storage/backend.go#L4) interface and run it behind an http server. 
 
 Once you implement the backend server, you must then configure Athens to use that storage backend as such:
 


### PR DESCRIPTION
This fixes bad link rendering on https://docs.gomods.io/configuration/storage/:
![Screenshot 2024-03-14 at 3 14 15 PM](https://github.com/gomods/athens/assets/665269/f5dd0547-eb73-4797-99ad-93c60c623460)
