### PR TITLE
Use quotes for args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: cmd/proxy/Dockerfile
       args:
-        GOLANG_VERSION: 1.20
+        GOLANG_VERSION: "1.20"
     environment:
       - ATHENS_MONGO_STORAGE_URL=mongodb://mongo:27017
       - TIMEOUT=20 # in case the mongo dependency takes longer to start up
@@ -20,7 +20,7 @@ services:
       context: .
       dockerfile: Dockerfile.test
       args:
-        GOLANG_VERSION: 1.20
+        GOLANG_VERSION: "1.20"
     command: ["./scripts/test_unit.sh"]
     environment:
       - GO_ENV=test
@@ -36,7 +36,7 @@ services:
       context: .
       dockerfile: Dockerfile.test
       args:
-        GOLANG_VERSION: 1.20
+        GOLANG_VERSION: "1.20"
     command: ["./scripts/test_e2e.sh"]
   azurite:
     image: arafato/azurite:2.6.5


### PR DESCRIPTION
## What is the problem I am trying to address?

Args in `docker-compose.yaml` were not surrounded by quotes and caste as floats. This worked up until `1.20` where `1.20` was interpreted as `1.2`.

## How is the fix applied?

Enclose args in quotes.

## What GitHub issue(s) does this PR fix or close?

N/A
