### PR TITLE
Add logging configuration docs

### DIFF
--- a/docs/content/configuration/logging.md
+++ b/docs/content/configuration/logging.md
@@ -1,0 +1,15 @@
+---
+title: Logging
+description: Configure the logger for your desired output
+weight: 9
+---
+
+Athens is designed to support a myriad of logging scenarios.
+
+## Standard
+
+The standard structured logger can be configured in `plain` or `json` formatting via `LogFormat` or `ATHENS_LOG_FORMAT`. Additionally, verbosity can be controlled by setting `LogLevel` or `ATHENS_LOG_LEVEL`. In order for the standard structured logger to work, `CloudRuntime` and `ATHENS_CLOUD_RUNTIME` should not be set to a valid value.
+
+## Runtimes
+
+Athens can be configured according to certain cloud provider specific runtimes. The **GCP** runtime configures Athens to rename certain logging fields that could be dropped or overriden when running in a GCP logging environment. This runtime can be used with `LogLevel` or `ATHENS_LOG_LEVEL` to control the verbosity of logs.


### PR DESCRIPTION
## What is the problem I am trying to address?

Logging configuration is a bit ambiguous based on reports. `CloudRuntime` affects logging for specific scenarios but many users may want to manually configure the logger.

## How is the fix applied?

Adds a page on logging to the docs

## What GitHub issue(s) does this PR fix or close?

N/A
