### PR TITLE
gcp/saver: Only return errors.KindAlreadyExists if all three exist

### DIFF
--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -101,7 +101,7 @@ func addProxyRoutes(
 
 	lister := module.NewVCSLister(c.GoBinary, c.GoBinaryEnvVars, fs)
 	checker := storage.WithChecker(s)
-	withSingleFlight, err := getSingleFlight(l, c, checker)
+	withSingleFlight, err := getSingleFlight(l, c, s, checker)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (l *athensLoggerForRedis) Printf(ctx context.Context, format string, v ...a
 	l.logger.WithContext(ctx).Printf(format, v...)
 }
 
-func getSingleFlight(l *log.Logger, c *config.Config, checker storage.Checker) (stash.Wrapper, error) {
+func getSingleFlight(l *log.Logger, c *config.Config, s storage.Backend, checker storage.Checker) (stash.Wrapper, error) {
 	switch c.SingleFlightType {
 	case "", "memory":
 		return stash.WithSingleflight, nil
@@ -173,7 +173,7 @@ func getSingleFlight(l *log.Logger, c *config.Config, checker storage.Checker) (
 		if c.StorageType != "gcp" {
 			return nil, fmt.Errorf("gcp SingleFlight only works with a gcp storage type and not: %v", c.StorageType)
 		}
-		return stash.WithGCSLock, nil
+		return stash.WithGCSLock(c.SingleFlight.GCP.StaleThreshold, s)
 	case "azureblob":
 		if c.StorageType != "azureblob" {
 			return nil, fmt.Errorf("azureblob SingleFlight only works with a azureblob storage type and not: %v", c.StorageType)

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -377,6 +377,10 @@ ShutdownTimeout = 60
             # Max retries while acquiring the lock. Defaults to 10.
             # Env override: ATHENS_REDIS_LOCK_MAX_RETRIES
             MaxRetries = 10
+    [SingleFlight.GCP]
+        # Threshold for how long to wait in seconds for an in-progress GCP upload to
+        # be considered to have failed to unlock.
+        StaleThreshold = 120
 [Storage]
     # Only storage backends that are specified in Proxy.StorageType are required here
     [Storage.CDN]

--- a/docs/content/configuration/storage.md
+++ b/docs/content/configuration/storage.md
@@ -492,3 +492,14 @@ Optionally, like `redis`, you can also specify a password to connect to the `red
           SentinelPassword = "sekret"
 
 Distributed lock options can be customised for redis sentinal as well, in a similar manner as described above for redis.
+
+
+### Using GCP as a singleflight mechanism
+
+The GCP singleflight mechanism does not required configuration, and works out of the box. It has a
+single option with which it can be customized:
+
+    [SingleFlight.GCP]
+        # Threshold for how long to wait in seconds for an in-progress GCP upload to
+        # be considered to have failed to unlock.
+        StaleThreshold = 120

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,6 +181,7 @@ func defaultConfig() *Config {
 				SentinelPassword: "sekret",
 				LockConfig:       DefaultRedisLockConfig(),
 			},
+			GCP: DefaultGCPConfig(),
 		},
 		Index: &Index{
 			MySQL: &MySQL{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -255,6 +255,7 @@ func TestParseExampleConfig(t *testing.T) {
 			LockConfig:       DefaultRedisLockConfig(),
 		},
 		Etcd: &Etcd{Endpoints: "localhost:2379,localhost:22379,localhost:32379"},
+		GCP:  DefaultGCPConfig(),
 	}
 
 	expConf := &Config{
@@ -391,6 +392,8 @@ func getEnvMap(config *Config) map[string]string {
 		} else if singleFlight.Etcd != nil {
 			envVars["ATHENS_SINGLE_FLIGHT_TYPE"] = "etcd"
 			envVars["ATHENS_ETCD_ENDPOINTS"] = singleFlight.Etcd.Endpoints
+		} else if singleFlight.GCP != nil {
+			envVars["ATHENS_GCP_STALE_THRESHOLD"] = strconv.Itoa(singleFlight.GCP.StaleThreshold)
 		}
 	}
 	return envVars

--- a/pkg/config/singleflight.go
+++ b/pkg/config/singleflight.go
@@ -7,6 +7,7 @@ type SingleFlight struct {
 	Etcd          *Etcd
 	Redis         *Redis
 	RedisSentinel *RedisSentinel
+	GCP           *GCP
 }
 
 // Etcd holds client side configuration
@@ -46,5 +47,17 @@ func DefaultRedisLockConfig() *RedisLockConfig {
 		TTL:        900,
 		Timeout:    15,
 		MaxRetries: 10,
+	}
+}
+
+// GCP is the configuration for GCP locking.
+type GCP struct {
+	StaleThreshold int `envconfig:"ATHENS_GCP_STALE_THRESHOLD"`
+}
+
+// DefaultGCPConfig returns the default GCP locking configuration.
+func DefaultGCPConfig() *GCP {
+	return &GCP{
+		StaleThreshold: 120,
 	}
 }

--- a/pkg/stash/with_gcs_test.go
+++ b/pkg/stash/with_gcs_test.go
@@ -3,6 +3,7 @@ package stash
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -16,6 +17,12 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 )
+
+type failReader int
+
+func (f *failReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("failure")
+}
 
 // TestWithGCS requires a real GCP backend implementation
 // and it will ensure that saving to modules at the same time
@@ -54,6 +61,68 @@ func TestWithGCS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	info, err := strg.Info(ctx, mod, ver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modContent, err := strg.GoMod(ctx, mod, ver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zip, err := strg.Zip(ctx, mod, ver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zip.Close()
+	zipContent, err := io.ReadAll(zip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(info, modContent) {
+		t.Fatalf("expected info and go.mod to be equal but info was {%v} and content was {%v}", string(info), string(modContent))
+	}
+	if !bytes.Equal(info, zipContent) {
+		t.Fatalf("expected info and zip to be equal but info was {%v} and content was {%v}", string(info), string(zipContent))
+	}
+}
+
+// TestWithGCSPartialFailure equires a real GCP backend implementation
+// and ensures that if one of the non-singleflight-lock files fails to
+// upload, that the cache does not remain poisoned.
+func TestWithGCSPartialFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+	const (
+		mod = "stashmod"
+		ver = "v1.0.0"
+	)
+	strg := getStorage(t)
+	strg.Delete(ctx, mod, ver)
+	defer strg.Delete(ctx, mod, ver)
+
+	// sanity check
+	_, err := strg.GoMod(ctx, mod, ver)
+	if !errors.Is(err, errors.KindNotFound) {
+		t.Fatalf("expected the stash bucket to return a NotFound error but got: %v", err)
+	}
+
+	content := uuid.New().String()
+	ms := &mockGCPStasher{strg, content}
+	fr := new(failReader)
+	// We simulate a failure by manually passing an io.Reader that will fail.
+	err = ms.strg.Save(ctx, "stashmod", "v1.0.0", []byte(ms.content), fr, []byte(ms.content))
+	if err == nil {
+		// We *want* to fail.
+		t.Fatal(err)
+	}
+
+	// Now try a Stash. This should upload the missing files.
+	s := WithGCSLock(ms)
+	_, err = s.Stash(ctx, "stashmod", "v1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	info, err := strg.Info(ctx, mod, ver)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -15,8 +15,9 @@ import (
 
 // Storage implements the (./pkg/storage).Backend interface.
 type Storage struct {
-	bucket  *storage.BucketHandle
-	timeout time.Duration
+	bucket         *storage.BucketHandle
+	timeout        time.Duration
+	staleThreshold time.Duration
 }
 
 // New returns a new Storage instance backed by a Google Cloud Storage bucket.

--- a/pkg/storage/gcp/saver.go
+++ b/pkg/storage/gcp/saver.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/gomods/athens/pkg/config"
@@ -11,6 +12,10 @@ import (
 	"github.com/gomods/athens/pkg/observ"
 	googleapi "google.golang.org/api/googleapi"
 )
+
+// After how long we consider an "in_progress" metadata key stale,
+// due to failure to remove it.
+const inProgressStaleThreshold = 2 * time.Minute
 
 // Save uploads the module's .mod, .zip and .info files for a given version
 // It expects a context, which can be provided using context.Background
@@ -20,34 +25,124 @@ import (
 // Uploaded files are publicly accessible in the storage bucket as per
 // an ACL rule.
 func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
-	const op errors.Op = "gcp.Save"
+	const op errors.Op = "gcp.save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 	gomodPath := config.PackageVersionedName(module, version, "mod")
-	err := s.upload(ctx, gomodPath, bytes.NewReader(mod))
-	if err != nil {
+	innerErr := s.save(ctx, module, version, mod, zip, info)
+	if errors.Is(innerErr, errors.KindAlreadyExists) {
+		// Cache hit.
+		return errors.E(op, innerErr)
+	}
+	// No cache hit. Remove the metadata lock if it is there.
+	inProgress, outerErr := s.checkUploadInProgress(ctx, gomodPath)
+	if outerErr != nil {
+		return errors.E(op, outerErr)
+	}
+	if inProgress {
+		outerErr = s.removeInProgressMetadata(ctx, gomodPath)
+		if outerErr != nil {
+			return errors.E(op, outerErr)
+		}
+	}
+	return innerErr
+}
+
+func (s *Storage) save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+	const op errors.Op = "gcp.save"
+	ctx, span := observ.StartSpan(ctx, op.String())
+	defer span.End()
+	gomodPath := config.PackageVersionedName(module, version, "mod")
+	seenAlreadyExists := 0
+	err := s.upload(ctx, gomodPath, bytes.NewReader(mod), true)
+	// If it already exists, check the object metadata to see if the
+	// other two are still uploading in progress somewhere else. If they
+	// are, return a cache hit. If not, continue on to the other two,
+	// and only return a cache hit if all three exist.
+	if errors.Is(err, errors.KindAlreadyExists) {
+		inProgress, progressErr := s.checkUploadInProgress(ctx, gomodPath)
+		if progressErr != nil {
+			return errors.E(op, progressErr)
+		}
+		if inProgress {
+			// err is known to be errors.KindAlreadyExists at this point, so
+			// this is a cache hit return.
+			return errors.E(op, err)
+		}
+		seenAlreadyExists++
+	} else if err != nil {
+		// Other errors
 		return errors.E(op, err)
 	}
 	zipPath := config.PackageVersionedName(module, version, "zip")
-	err = s.upload(ctx, zipPath, zip)
-	if err != nil {
+	err = s.upload(ctx, zipPath, zip, false)
+	if errors.Is(err, errors.KindAlreadyExists) {
+		seenAlreadyExists++
+	} else if err != nil {
 		return errors.E(op, err)
 	}
 	infoPath := config.PackageVersionedName(module, version, "info")
-	err = s.upload(ctx, infoPath, bytes.NewReader(info))
+	err = s.upload(ctx, infoPath, bytes.NewReader(info), false)
+	// Have all three returned errors.KindAlreadyExists?
+	if errors.Is(err, errors.KindAlreadyExists) {
+		if seenAlreadyExists == 2 {
+			return errors.E(op, err)
+		}
+	} else if err != nil {
+		return errors.E(op, err)
+	}
+	return nil
+}
+
+func (s *Storage) removeInProgressMetadata(ctx context.Context, gomodPath string) error {
+	const op errors.Op = "gcp.removeInProgressMetadata"
+	ctx, span := observ.StartSpan(ctx, op.String())
+	defer span.End()
+	_, err := s.bucket.Object(gomodPath).Update(ctx, storage.ObjectAttrsToUpdate{
+		Metadata: map[string]string{},
+	})
 	if err != nil {
 		return errors.E(op, err)
 	}
 	return nil
 }
 
-func (s *Storage) upload(ctx context.Context, path string, stream io.Reader) error {
+func (s *Storage) checkUploadInProgress(ctx context.Context, gomodPath string) (bool, error) {
+	const op errors.Op = "gcp.checkUploadInProgress"
+	ctx, span := observ.StartSpan(ctx, op.String())
+	defer span.End()
+	attrs, err := s.bucket.Object(gomodPath).Attrs(ctx)
+	if err != nil {
+		return false, errors.E(op, err)
+	}
+	if attrs.Metadata != nil {
+		_, ok := attrs.Metadata["in_progress"]
+		if ok {
+			// In case the final call to remove the metadata fails for some reason,
+			// we have a threshold after which we consider this to be stale.
+			if time.Since(attrs.Created) > inProgressStaleThreshold {
+				return false, nil
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Storage) upload(ctx context.Context, path string, stream io.Reader, first bool) error {
 	const op errors.Op = "gcp.upload"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 	wc := s.bucket.Object(path).If(storage.Conditions{
 		DoesNotExist: true,
 	}).NewWriter(ctx)
+
+	// We set this metadata only for the first of the three files uploaded,
+	// for use as a singleflight lock.
+	if first {
+		wc.ObjectAttrs.Metadata = make(map[string]string)
+		wc.ObjectAttrs.Metadata["in_progress"] = "true"
+	}
 
 	// NOTE: content type is auto detected on GCP side and ACL defaults to public
 	// Once we support private storage buckets this may need refactoring


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

In #1124, a GCP lock type was added as a singleflight backend. As part of this work, the GCP storage backend's `Save()` was made serial, likely because `moduploader.Upload` requires a call to `Exists()` before it, rendering the GCP lock less useful, by doubling the calls to GCS.

However, by doing this, the existence check was now only checking the existence of the mod file, and not the info or zip. This meant that if during a `Save()`, the zip or info uploads failed, on subsequent rquests, that when using the GCP singleflight backend, Athens woul assume everything had been stashed and saved properly, and then fail to serve up the info or zip that had failed upload, meaning the cache was in an unhealable broklen state, requiring a manual intervention.

## How is the fix applied?

To fix this, without breaking the singleflight behavior, introduce a metadata key that is set on the mod file during its initial upload, indicating that a `Stash` is still in progress on subsequent files, which gets removed once all three files are uploaded successfully, which can be checked if it it is determined that the mod file already exists. That way we can return a `errors.KindAlreadyExists` if a `Stash` is in progress, but also properly return it when a `Stash` is *not* currently in progress if and only if all three files exist on GCS, which prevents the cache from becoming permanently poisoned.

One note is that it is possible the GCS call to remove the metadata key fails, which would mean it is left on the mod object forever. To avoid this, consider it stale after 2 minutes.


## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

N/A

# Extra Notes

This is my first time touching the Athens codebase, so apologies for any faux pas. We hit this at `$dayjob`, so thought I would take a stab at fixing it.

It is a more complex than I would like, so comments very welcome.

This also contains a small fix I found when writing the test: if `io.Copy` failed during an upload to GCS, it would call `Close()` on the writer, which would leave a partial/broken file. The `storage` docs say to cancel the context to prevent this.
