### PR TITLE
Fix aws default credentials

### DIFF
--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -40,10 +40,6 @@ func New(s3Conf *config.S3Config, timeout time.Duration, options ...func(*aws.Co
 		return nil, errors.E(op, err)
 	}
 
-	// Remove anonymous credentials from the default config so that
-	// session.NewSession can auto-resolve credentials from role, profile, env etc.
-	awsConfig.Credentials = nil
-
 	for _, o := range options {
 		o(&awsConfig)
 	}


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Unable to access s3 with default config in v0.14.0, but v0.13.x works very well.

## How is the fix applied?

Mention briefly how you have applied the fix.

## What GitHub issue(s) does this PR fix or close?

Fixes https://github.com/gomods/athens/issues/1961
