### PR TITLE
Fixed "make test-e2e-docker"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ test-unit-docker: ## run unit tests with docker
 
 .PHONY: test-e2e
 test-e2e:
-	cd e2etests && go test --tags e2etests
+	./scripts/test_e2e.sh
 
 .PHONY: test-e2e-docker
 test-e2e-docker:

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# test_e2e.sh
+
+# Run the e2e tests with the race detector enabled
+set -xeuo pipefail
+cd e2etests && go test --tags e2etests -race


### PR DESCRIPTION
## What is the problem I am trying to address?

Fixes issue #1947 where `make test-e2e-docker` fails from calling `scripts/test_e2e.sh`, which does not exist.

## How is the fix applied?

created `scripts/test_e2e.sh` which allows us to run the e2e tests in docker compose. I also modified the Makefile to use this script in `make test-e2e` for readability and consistency with `make test-unit`

## What GitHub issue(s) does this PR fix or close?

Fixes #1947 