### PR TITLE
Update protocol.md

### DIFF
--- a/docs/content/intro/protocol.md
+++ b/docs/content/intro/protocol.md
@@ -19,7 +19,7 @@ In the examples below, `$HOST` and `$PORT` are placeholders for the host and por
 This endpoint returns a list of versions that Athens knows about for `acidburn/htp`. The list is just separated by newlines:
 
 ```HTTP
-GET $HOST:$PORT/github.com/acidburn/htp/@v/list
+GET $HOST:$PORT/?=github.com/acidburn/htp/@v/list
 ```
 
 ```HTML
@@ -34,7 +34,7 @@ v1.2.0
 
 
 ```HTTP
-GET $HOST:$PORT/github.com/acidburn/htp/@v/v1.0.0.info
+GET $HOST:$PORT/github.com/?=acidburn/htp/@v/v1.0.0.info
 ```
 
 This returns JSON with information about v1.0.0. It looks like this:
@@ -51,7 +51,7 @@ This returns JSON with information about v1.0.0. It looks like this:
 ## Go.mod file
 
 ```HTTP
-GET $HOST:$PORT/github.com/acidburn/htp/@v/v1.0.0.mod
+GET $HOST:$PORT/github.com/?=acidburn/htp/@v/v1.0.0.mod
 ```
 
 This returns the go.mod file for version v1.0.0. If $HOST:$PORT/github.com/acidburn/htp version `v1.0.0` has no dependencies, the response body would look like this:
@@ -63,7 +63,7 @@ module github.com/acidburn/htp
 ## Module sources
 
 ```HTTP
-GET $HOST:$PORT/github.com/acidburn/htp/@v/v1.0.0.zip
+GET $HOST:$PORT/?=github.com/acidburn/htp/@v/v1.0.0.zip
 ```
 
 This is what it sounds like — it sends back a zip file with the source code for the module in version v1.0.0.
@@ -71,7 +71,7 @@ This is what it sounds like — it sends back a zip file with the source code fo
 ## Latest
 
 ```HTTP
-GET $HOST:$PORT/github.com/acidburn/htp/@latest
+GET $HOST:$PORT/?=github.com/acidburn/htp/@latest
 ```
 
 This endpoint returns the latest version of the module.


### PR DESCRIPTION
the get requests were not working
```bash
GET $GOPROXY:3000/?=github.com/acidburn
```
is what worked for me
Ubuntu WSL2 , might differ elsewheres but just a suggestion :-)

<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?
The functionality of the commands for examples,
urls were not working without `?=` after the `$HOST$PORT/`
just wanted to clarify
![Screenshot 2024-08-14 025019](https://github.com/user-attachments/assets/62a97784-08f0-4ece-8bbe-ff4ba3977cc2)


Describe the issue you have been trying to solve.

## How is the fix applied?

Mention briefly how you have applied the fix.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #

<!-- 
example: Fixes #123
-->
