### PR TITLE
Add timeout to vcsLister.List()

### DIFF
--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -99,7 +99,7 @@ func addProxyRoutes(
 		return err
 	}
 
-	lister := module.NewVCSLister(c.GoBinary, c.GoBinaryEnvVars, fs)
+	lister := module.NewVCSLister(c.GoBinary, c.GoBinaryEnvVars, fs, c.TimeoutDuration())
 	checker := storage.WithChecker(s)
 	withSingleFlight, err := getSingleFlight(l, c, s, checker)
 	if err != nil {

--- a/pkg/download/list.go
+++ b/pkg/download/list.go
@@ -28,7 +28,7 @@ func ListHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handle
 
 		versions, err := dp.List(r.Context(), mod)
 		if err != nil {
-			severityLevel := errors.Expect(err, errors.KindNotFound)
+			severityLevel := errors.Expect(err, errors.KindNotFound, errors.KindGatewayTimeout)
 			err = errors.E(op, err, severityLevel)
 			lggr.SystemErr(err)
 			w.WriteHeader(errors.Kind(err))

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -50,7 +50,7 @@ func getDP(t *testing.T) Protocol {
 	return New(&Opts{
 		Storage:     s,
 		Stasher:     st,
-		Lister:      module.NewVCSLister(goBin, conf.GoBinaryEnvVars, fs),
+		Lister:      module.NewVCSLister(goBin, conf.GoBinaryEnvVars, fs, conf.TimeoutDuration()),
 		NetworkMode: Strict,
 	})
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -18,6 +18,7 @@ const (
 	KindRateLimit      = http.StatusTooManyRequests
 	KindNotImplemented = http.StatusNotImplemented
 	KindRedirect       = http.StatusMovedPermanently
+	KindGatewayTimeout = http.StatusGatewayTimeout
 )
 
 // Error is an Athens system error.


### PR DESCRIPTION
<!-- 
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

`vcsLister.List()` can take several minutes to execute for certain modules

## How is the fix applied?

Add a `timeout` field to `vcsLister` that can be used when calling `vcsLister.List()`. The timeout is set by `ATHENS_TIMEOUT`

## What GitHub issue(s) does this PR fix or close?

Fixes #1884 