### PR TITLE
fix: go in docker failing

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -47,7 +47,7 @@ RUN apk add --update git git-lfs mercurial openssh-client subversion procps foss
 ARG USER=athens
 RUN adduser -D -h /home/$USER $USER
 
-CMD mkdir /go
+RUN mkdir /go
 
 EXPOSE 3000
 

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -27,7 +27,7 @@ RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && \
     -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE -s -w" \
     -o /bin/athens-proxy ./cmd/proxy
 
-FROM golang:alpine
+FROM alpine:${ALPINE_VERSION}
 
 ENV GOPROXY="https://proxy.golang.org,direct" \
     GOSUMDB="sum.golang.org" \
@@ -36,11 +36,13 @@ ENV GOPROXY="https://proxy.golang.org,direct" \
 
 COPY --from=builder /bin/athens-proxy /bin/athens-proxy
 COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/config.toml
+COPY --from=builder /usr/local/go/bin/go /bin/go
 
 RUN chmod 644 /config/config.toml
 
 # Add tini, see https://github.com/gomods/athens/issues/1155 for details.
-RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini
+RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini && \
+    mkdir -p /usr/local/go
 
 ARG USER=athens
 RUN adduser -D -h /home/$USER $USER

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -27,19 +27,17 @@ RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && \
     -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE -s -w" \
     -o /bin/athens-proxy ./cmd/proxy
 
-FROM alpine:${ALPINE_VERSION}
+FROM golang:${GOLANG_VERSION}-alpine
 
 ENV GO111MODULE=on
 
 COPY --from=builder /bin/athens-proxy /bin/athens-proxy
 COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/config.toml
-COPY --from=builder /usr/local/go/bin/go /bin/go
 
 RUN chmod 644 /config/config.toml
 
 # Add tini, see https://github.com/gomods/athens/issues/1155 for details.
-RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini && \
-    mkdir -p /usr/local/go
+RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini
 
 ARG USER=athens
 RUN adduser -D -h /home/$USER $USER

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -27,9 +27,12 @@ RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && \
     -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE -s -w" \
     -o /bin/athens-proxy ./cmd/proxy
 
-FROM golang:${GOLANG_VERSION}-alpine
+FROM golang:alpine
 
-ENV GO111MODULE=on
+ENV GOPROXY="https://proxy.golang.org,direct" \
+    GOSUMDB="sum.golang.org" \
+    GOROOT="/go" \
+    GO111MODULE=on
 
 COPY --from=builder /bin/athens-proxy /bin/athens-proxy
 COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/config.toml
@@ -41,6 +44,8 @@ RUN apk add --update git git-lfs mercurial openssh-client subversion procps foss
 
 ARG USER=athens
 RUN adduser -D -h /home/$USER $USER
+
+CMD mkdir /go
 
 EXPOSE 3000
 

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -29,25 +29,22 @@ RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && \
 
 FROM alpine:${ALPINE_VERSION}
 
-ENV GOPROXY="https://proxy.golang.org,direct" \
-    GOSUMDB="sum.golang.org" \
-    GOROOT="/go" \
+ENV GOROOT="/usr/local/go" \
+    PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     GO111MODULE=on
 
 COPY --from=builder /bin/athens-proxy /bin/athens-proxy
 COPY --from=builder /go/src/github.com/gomods/athens/config.dev.toml /config/config.toml
-COPY --from=builder /usr/local/go/bin/go /bin/go
+COPY --from=builder /usr/local/go/bin/go /usr/local/go/bin/go
+COPY --from=builder /usr/local/go/go.env /usr/local/go/go.env
 
 RUN chmod 644 /config/config.toml
 
 # Add tini, see https://github.com/gomods/athens/issues/1155 for details.
-RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini && \
-    mkdir -p /usr/local/go
+RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini
 
 ARG USER=athens
 RUN adduser -D -h /home/$USER $USER
-
-RUN mkdir /go
 
 EXPOSE 3000
 

--- a/pkg/module/prepare_env.go
+++ b/pkg/module/prepare_env.go
@@ -29,6 +29,8 @@ func prepareEnv(gopath string, envVars []string) []string {
 		"HTTP_PROXY",
 		"HTTPS_PROXY",
 		"NO_PROXY",
+		// GOROOT needs to be propagated if it exists.
+		"GOROOT",
 		// Need to also check the lower case version of just these three env variables.
 		"http_proxy",
 		"https_proxy",


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

In v0.15.2, an error occurs when trying to use the proxy:
```
INFO[5:50PM]: exit status 2: go: cannot find GOROOT directory: 'go' binary is trimmed and GOROOT is not set
	http-method=GET http-path=/github.com/hamba/avro/@v/list kind=Not Found module= operation=download.ListHandler ops=[download.ListHandler pool.List protocol.List vcsLister.List] request-id=ba64734c-a3b6-4cf2-a0ac-54199c55153a version=
```

It seems in Go 1.21, so defaults are no longer baked into the binary, causing issues when running Go.

My first attempt at a fix was to set `GOROOT` in the Dockerfile, but Athens does not pass all env vars to the Go binary when executing it. I did consider passing `GOROOT` by default to the Go binary, but this seems wrong for people not running the docker image. There are also multiple go call sites, each using their own env calling conventions.

The downside to this approach is the image grows from `170MB` to `379MB`.

## How is the fix applied?

To get around the complexity, the root of the Dockerfile is set to `golang:<ver>-alpine`. This added the least complexity.

