### PR TITLE
Fix typo preventing git-credential-github-app being installed

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -44,7 +44,7 @@ RUN chmod 644 /config/config.toml
 RUN apk add --update git git-lfs mercurial openssh-client subversion procps fossil tini
 
 # Add git-credential-github-app for native integration with GitHub Apps
-RUN wget -O git-credential-github-app.tar.gz https://github.com/bdellegrazie/git-credential-github-app/releases/download/v0.3.0/git-credential-github-app_v0.2.0_Linux_x86_64.tar.gz \
+RUN wget -O git-credential-github-app.tar.gz https://github.com/bdellegrazie/git-credential-github-app/releases/download/v0.3.0/git-credential-github-app_v0.3.0_Linux_x86_64.tar.gz \
   && tar xvzf 'git-credential-github-app.tar.gz' git-credential-github-app -C /usr/local/bin \
   && rm git-credential-github-app.tar.gz || true;
 


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

#1988 had a type in the URL which prevented `git-credential-github-app` being installed properly (v0.2.0 in the filename but v0.3.0 in the path)

## How is the fix applied?

Found the correct URL from the releases page and copied it in

## What GitHub issue(s) does this PR fix or close?

N/A