### PR TITLE
Introducing Athens Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/gomods/athens.svg?maxAge=604800)](https://hub.docker.com/r/gomods/athens/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 [![Open Source Helpers](https://www.codetriage.com/gomods/athens/badges/users.svg)](https://www.codetriage.com/gomods/athens)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Athens%20Guru-006BFF)](https://gurubase.io/g/athens)
 
 Welcome to the Athens project! Athens is an open source, enterprise ready implementation of the [Go Module proxy](https://go.dev/ref/mod#module-proxy) for the [Go Modules download API](https://docs.gomods.io/intro/protocol/).
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Athens Guru](https://gurubase.io/g/athens) to Gurubase. Athens Guru uses the data from this repo and data from the [docs](https://docs.gomods.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Athens Guru", which highlights that Athens now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Athens Guru in Gurubase, just let me know that's totally fine.
