### PR TITLE
Fix the README Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It's not too long and it's ok for you to "skim" it (or even just read the first 
 
 If you're not ready to contribute code yet, there are plenty of other great ways to get involved:
 
-- Come talk to us in the `#athens` channel in the [Gophers slack](http://gophers.slack.com/). We’re a really friendly group, so come say hi and join us! Ping me (`@arschles` on slack) in the channel and I’ll give you the lowdown
+- Come talk to us in the `#athens` channel in the [Gophers slack](https://join.slack.com/t/gophers/shared_invite/zt-2x2fraaj5-Gai4CThbNTLvXKOxhbrDOQ). We’re a really friendly group, so come say hi and join us! Ping me (`@arschles` on slack) in the channel and I’ll give you the lowdown
 - Get familiar with the technology. There's lots to read about. Here are some places to start:
     - [Gentle Introduction to the Project](https://medium.com/@arschles/project-athens-c80606497ce1) - the basics of why we started this project
     - [The Download Protocol](https://medium.com/@arschles/project-athens-the-download-protocol-2b346926a818) - the core API that the proxy implements and the `go` CLI uses to download packages


### PR DESCRIPTION




<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

The README Slack link points to the Gophers Slack but is not an invite link

## How is the fix applied?

Generated a Slack invite link on Gophers that doesn't expire

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #2013

<!-- 
example: Fixes #123
-->
