### PR TITLE
use https if proxied

### DIFF
--- a/cmd/proxy/actions/home.go
+++ b/cmd/proxy/actions/home.go
@@ -111,7 +111,7 @@ func proxyHomeHandler(c *config.Config) http.HandlerFunc {
 
 		// if the host does not have a scheme, add one based on the request
 		if !strings.HasPrefix(templateData["Host"], "http://") && !strings.HasPrefix(templateData["Host"], "https://") {
-			if r.TLS != nil {
+			if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 				templateData["Host"] = "https://" + templateData["Host"]
 			} else {
 				templateData["Host"] = "http://" + templateData["Host"]


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

I have athens deployed in k8s with the service on http and an ingress on https. The home page is displaying an http URL, which is incorrect. Not a huge deal, but I *think* this will fix it. Haven't tested yet, wanted to run this by you and see if it makes sense before going to all the trouble of setting up the builds and testing, since it's a simple one liner.

## How is the fix applied?

I think (hope) all that's needed is this one line change.

## What GitHub issue(s) does this PR fix or close?

I didn't make an issue for this, but I could if you want.

