### PR TITLE
Redis Sentinel SingeFlight: support of Redis master node username and password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       REDIS_SENTINEL_TEST_MASTER_NAME: redis-1
       REDIS_SENTINEL_TEST_PASSWORD: sekret
       PROTECTED_REDIS_TEST_ENDPOINT: localhost:6380
+      PROTECTED_REDIS_TEST_USERNAME: default
+      REDIS_SENTINEL_TEST_PROTECTED_ENDPOINT: localhost:26380
+      REDIS_SENTINEL_TEST_PROTECTED_MASTER_NAME: protectedredis-1
       ATHENS_PROTECTED_REDIS_PASSWORD: AthensPass1
       GA_PULL_REQUEST: ${{github.event.number}}
     runs-on: ubuntu-latest
@@ -69,6 +72,17 @@ jobs:
         env:
           REDIS_PORT_NUMBER: 6380
           REDIS_PASSWORD: AthensPass1
+      redis-sentinel-protected-redis:
+        image: bitnami/redis-sentinel
+        env:
+          REDIS_MASTER_HOST: protectedredis
+          REDIS_MASTER_PORT_NUMBER: 6380
+          REDIS_MASTER_SET: protectedredis-1
+          REDIS_SENTINEL_PASSWORD: sekret
+          REDIS_SENTINEL_QUORUM: "1"
+          REDIS_SENTINEL_PORT_NUMBER: 26380
+        ports:
+          - 26380:26380
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -166,6 +166,8 @@ func getSingleFlight(l *log.Logger, c *config.Config, s storage.Backend, checker
 			c.SingleFlight.RedisSentinel.Endpoints,
 			c.SingleFlight.RedisSentinel.MasterName,
 			c.SingleFlight.RedisSentinel.SentinelPassword,
+			c.SingleFlight.RedisSentinel.RedisUsername,
+			c.SingleFlight.RedisSentinel.RedisPassword,
 			checker,
 			c.SingleFlight.RedisSentinel.LockConfig,
 		)

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -369,6 +369,12 @@ ShutdownTimeout = 60
         # Env override: ATHENS_REDIS_SENTINEL_PASSWORD
         SentinelPassword = "sekret"
 
+        # The Redis master authorization parameters
+        # Env override: ATHENS_REDIS_USERNAME
+        RedisUsername = ""
+        # Env override: ATHENS_REDIS_PASSWORD
+        RedisPassword = ""
+
         [SingleFlight.RedisSentinel.LockConfig]
             # TTL for the lock in seconds. Defaults to 900 seconds (15 minutes).
             # Env override: ATHENS_REDIS_LOCK_TTL

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,6 +179,8 @@ func defaultConfig() *Config {
 				Endpoints:        []string{"127.0.0.1:26379"},
 				MasterName:       "redis-1",
 				SentinelPassword: "sekret",
+				RedisUsername:    "",
+				RedisPassword:    "",
 				LockConfig:       DefaultRedisLockConfig(),
 			},
 			GCP: DefaultGCPConfig(),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -375,7 +375,7 @@ func getEnvMap(config *Config) map[string]string {
 		if singleFlight.Redis != nil {
 			envVars["ATHENS_SINGLE_FLIGHT_TYPE"] = "redis"
 			envVars["ATHENS_REDIS_ENDPOINT"] = singleFlight.Redis.Endpoint
-			envVars["ATHENS_REDIS_PASSWORD"] = singleFlight.Redis.Endpoint
+			envVars["ATHENS_REDIS_PASSWORD"] = singleFlight.Redis.Password
 			if singleFlight.Redis.LockConfig != nil {
 				envVars["ATHENS_REDIS_LOCK_TTL"] = strconv.Itoa(singleFlight.Redis.LockConfig.TTL)
 				envVars["ATHENS_REDIS_LOCK_TIMEOUT"] = strconv.Itoa(singleFlight.Redis.LockConfig.Timeout)
@@ -386,6 +386,8 @@ func getEnvMap(config *Config) map[string]string {
 			envVars["ATHENS_REDIS_SENTINEL_ENDPOINTS"] = strings.Join(singleFlight.RedisSentinel.Endpoints, ",")
 			envVars["ATHENS_REDIS_SENTINEL_MASTER_NAME"] = singleFlight.RedisSentinel.MasterName
 			envVars["ATHENS_REDIS_SENTINEL_PASSWORD"] = singleFlight.RedisSentinel.SentinelPassword
+			envVars["ATHENS_REDIS_USERNAME"] = singleFlight.RedisSentinel.RedisUsername
+			envVars["ATHENS_REDIS_PASSWORD"] = singleFlight.RedisSentinel.RedisPassword
 			if singleFlight.RedisSentinel.LockConfig != nil {
 				envVars["ATHENS_REDIS_LOCK_TTL"] = strconv.Itoa(singleFlight.RedisSentinel.LockConfig.TTL)
 				envVars["ATHENS_REDIS_LOCK_TIMEOUT"] = strconv.Itoa(singleFlight.RedisSentinel.LockConfig.Timeout)

--- a/pkg/config/singleflight.go
+++ b/pkg/config/singleflight.go
@@ -31,6 +31,8 @@ type RedisSentinel struct {
 	Endpoints        []string `envconfig:"ATHENS_REDIS_SENTINEL_ENDPOINTS"`
 	MasterName       string   `envconfig:"ATHENS_REDIS_SENTINEL_MASTER_NAME"`
 	SentinelPassword string   `envconfig:"ATHENS_REDIS_SENTINEL_PASSWORD"`
+	RedisUsername    string   `envconfig:"ATHENS_REDIS_USERNAME"`
+	RedisPassword    string   `envconfig:"ATHENS_REDIS_PASSWORD"`
 	LockConfig       *RedisLockConfig
 }
 

--- a/pkg/stash/with_redis_sentinel.go
+++ b/pkg/stash/with_redis_sentinel.go
@@ -11,7 +11,7 @@ import (
 
 // WithRedisSentinelLock returns a distributed singleflight
 // with a redis cluster that utilizes sentinel for quorum and failover.
-func WithRedisSentinelLock(l RedisLogger, endpoints []string, master, password string, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
+func WithRedisSentinelLock(l RedisLogger, endpoints []string, master, sentinelPassword, redisUsername, redisPassword string, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
 	redis.SetLogger(l)
 
 	const op errors.Op = "stash.WithRedisSentinelLock"
@@ -23,7 +23,9 @@ func WithRedisSentinelLock(l RedisLogger, endpoints []string, master, password s
 	client := redis.NewFailoverClient(&redis.FailoverOptions{
 		MasterName:       master,
 		SentinelAddrs:    endpoints,
-		SentinelPassword: password,
+		SentinelPassword: sentinelPassword,
+		Username:         redisUsername,
+		Password:         redisPassword,
 	})
 	_, err := client.Ping(context.Background()).Result()
 	if err != nil {

--- a/pkg/stash/with_redis_sentinel_test.go
+++ b/pkg/stash/with_redis_sentinel_test.go
@@ -1,7 +1,6 @@
 package stash
 
 import (
-	"cmp"
 	"context"
 	"os"
 	"testing"
@@ -20,8 +19,6 @@ func TestWithRedisSentinelLock(t *testing.T) {
 	endpoint := os.Getenv("REDIS_SENTINEL_TEST_ENDPOINT")
 	masterName := os.Getenv("REDIS_SENTINEL_TEST_MASTER_NAME")
 	sentinelPassword := os.Getenv("REDIS_SENTINEL_TEST_PASSWORD")
-	redisUsername := cmp.Or(os.Getenv("REDIS_TEST_USERNAME"), "")
-	redisPassword := cmp.Or(os.Getenv("REDIS_TEST_PASSWORD"), "")
 	if len(endpoint) == 0 || len(masterName) == 0 || len(sentinelPassword) == 0 {
 		t.SkipNow()
 	}
@@ -32,6 +29,83 @@ func TestWithRedisSentinelLock(t *testing.T) {
 	ms := &mockRedisStasher{strg: strg}
 	l := &testingRedisLogger{t: t}
 
+	wrapper, err := WithRedisSentinelLock(l, []string{endpoint}, masterName, sentinelPassword, "", "", storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := wrapper(ms)
+
+	var eg errgroup.Group
+	for i := 0; i < 5; i++ {
+		eg.Go(func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+			_, err := s.Stash(ctx, "mod", "ver")
+			return err
+		})
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWithRedisSentinelLockWithRedisPassword verifies WithRedisSentinelLock working with
+// password protected redis sentinel and redis master nodes
+func TestWithRedisSentinelLockWithRedisPassword(t *testing.T) {
+	endpoint := os.Getenv("REDIS_SENTINEL_TEST_PROTECTED_ENDPOINT")
+	masterName := os.Getenv("REDIS_SENTINEL_TEST_PROTECTED_MASTER_NAME")
+	sentinelPassword := os.Getenv("REDIS_SENTINEL_TEST_PASSWORD")
+	redisPassword := os.Getenv("ATHENS_PROTECTED_REDIS_PASSWORD")
+	if len(endpoint) == 0 || len(masterName) == 0 {
+		t.SkipNow()
+	}
+	strg, err := mem.NewStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms := &mockRedisStasher{strg: strg}
+	l := &testingRedisLogger{t: t}
+	wrapper, err := WithRedisSentinelLock(l, []string{endpoint}, masterName, sentinelPassword, "", redisPassword, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := wrapper(ms)
+
+	var eg errgroup.Group
+	for i := 0; i < 5; i++ {
+		eg.Go(func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+			_, err := s.Stash(ctx, "mod", "ver")
+			return err
+		})
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWithRedisSentinelLockWithPassword verifies WithRedisSentinelLock working with
+// username & password protected master node under the redis sentinel
+func TestWithRedisSentinelLockWithUsernameAndPassword(t *testing.T) {
+	endpoint := os.Getenv("REDIS_SENTINEL_TEST_PROTECTED_ENDPOINT")
+	masterName := os.Getenv("REDIS_SENTINEL_TEST_PROTECTED_MASTER_NAME")
+	sentinelPassword := os.Getenv("REDIS_SENTINEL_TEST_PASSWORD")
+	redisPassword := os.Getenv("ATHENS_PROTECTED_REDIS_PASSWORD")
+	redisUsername := os.Getenv("PROTECTED_REDIS_TEST_USERNAME")
+	if len(endpoint) == 0 || len(masterName) == 0 {
+		t.SkipNow()
+	}
+	strg, err := mem.NewStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms := &mockRedisStasher{strg: strg}
+	l := &testingRedisLogger{t: t}
 	wrapper, err := WithRedisSentinelLock(l, []string{endpoint}, masterName, sentinelPassword, redisUsername, redisPassword, storage.WithChecker(strg), config.DefaultRedisLockConfig())
 	if err != nil {
 		t.Fatal(err)
@@ -51,5 +125,34 @@ func TestWithRedisSentinelLock(t *testing.T) {
 	err = eg.Wait()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestWithRedisSentinelLockWithWrongPassword verifies the WithRedisSentinelLock fails
+// with the correct error when trying to connect with wrong passwords
+func TestWithRedisSentinelLockWithWrongRedisPassword(t *testing.T) {
+	endpoint := os.Getenv("REDIS_SENTINEL_TEST_PROTECTED_ENDPOINT")
+	masterName := os.Getenv("REDIS_SENTINEL_TEST_PROTECTED_MASTER_NAME")
+	sentinelPassword := os.Getenv("REDIS_SENTINEL_TEST_PASSWORD")
+	redisPassword := os.Getenv("ATHENS_PROTECTED_REDIS_PASSWORD")
+	if len(endpoint) == 0 || len(masterName) == 0 {
+		t.SkipNow()
+	}
+	strg, err := mem.NewStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := &testingRedisLogger{t: t}
+
+	// Test with wrong sentinel password
+	_, err = WithRedisSentinelLock(l, []string{endpoint}, masterName, "wrong-sentinel-password", "", redisPassword, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	if err == nil {
+		t.Fatal("Expected Connection Error for wrong sentinel password")
+	}
+
+	// Test with wrong redis password
+	_, err = WithRedisSentinelLock(l, []string{endpoint}, masterName, sentinelPassword, "", "wrong-redis-password", storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	if err == nil {
+		t.Fatal("Expected Connection Error for wrong redis password")
 	}
 }

--- a/pkg/stash/with_redis_sentinel_test.go
+++ b/pkg/stash/with_redis_sentinel_test.go
@@ -1,6 +1,7 @@
 package stash
 
 import (
+	"cmp"
 	"context"
 	"os"
 	"testing"
@@ -18,8 +19,10 @@ import (
 func TestWithRedisSentinelLock(t *testing.T) {
 	endpoint := os.Getenv("REDIS_SENTINEL_TEST_ENDPOINT")
 	masterName := os.Getenv("REDIS_SENTINEL_TEST_MASTER_NAME")
-	password := os.Getenv("REDIS_SENTINEL_TEST_PASSWORD")
-	if len(endpoint) == 0 || len(masterName) == 0 || len(password) == 0 {
+	sentinelPassword := os.Getenv("REDIS_SENTINEL_TEST_PASSWORD")
+	redisUsername := cmp.Or(os.Getenv("REDIS_TEST_USERNAME"), "")
+	redisPassword := cmp.Or(os.Getenv("REDIS_TEST_PASSWORD"), "")
+	if len(endpoint) == 0 || len(masterName) == 0 || len(sentinelPassword) == 0 {
 		t.SkipNow()
 	}
 	strg, err := mem.NewStorage()
@@ -29,7 +32,7 @@ func TestWithRedisSentinelLock(t *testing.T) {
 	ms := &mockRedisStasher{strg: strg}
 	l := &testingRedisLogger{t: t}
 
-	wrapper, err := WithRedisSentinelLock(l, []string{endpoint}, masterName, password, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	wrapper, err := WithRedisSentinelLock(l, []string{endpoint}, masterName, sentinelPassword, redisUsername, redisPassword, storage.WithChecker(strg), config.DefaultRedisLockConfig())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Introduced Redis master authentication parameters (username and password) to the Redis Sentinel setup. This enhances compatibility with Redis environments that require authentication for both sentinel and master nodes.

<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

There is no way to provide master node authentication credentials when using Single Flight mode with Redis Sentinel. 
The only parameter that can be used is `SentinelPassword`, but in my scenario, I have Redis Sentinel with password authentication and Redis Master Node with password authentication as well. As a result, I receive an error: `NOAUTH Authentication required`.

```
INFO[10:05AM]: Exporter not specified. Traces won't be exported
INFO[10:05M]: sentinel: discovered new sentinel="XX.XX.XX.XX:26379" for master="athens"
INFO[10:05AM]: sentinel: new master="athens" addr="XX.XX.XX.XX:6379"
FATAL[10:05AM]: Could not create App     error=adding proxy routes: NOAUTH Authentication required.
```

## How is the fix applied?

For fixing the issue, I've added two configuration parameters that can be overwritten by environment variables:
```
# The Redis master authorization parameters
# Env override: ATHENS_REDIS_USERNAME
RedisUsername = ""
# Env override: ATHENS_REDIS_PASSWORD
RedisPassword = ""
```

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #2040

<!-- 
example: Fixes #123
-->
