### PR TITLE
Add handling for SIGCHLD to cleanup child processes

### DIFF
--- a/internal/shutdown/signals.go
+++ b/internal/shutdown/signals.go
@@ -3,8 +3,13 @@
 package shutdown
 
 import (
+	"context"
+	"errors"
 	"os"
+	"os/signal"
 	"syscall"
+
+	"github.com/sirupsen/logrus"
 )
 
 // GetSignals returns the appropriate signals to catch for a clean shutdown, dependent on the OS.
@@ -12,4 +17,43 @@ import (
 // On Unix-like operating systems, it is important to catch SIGTERM in addition to SIGINT.
 func GetSignals() []os.Signal {
 	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+// ChildProcReaper spawns a goroutine to listen for SIGCHLD signals to cleanup
+// zombie child processes. The returned context will be canceled once all child
+// processes have been cleaned up, and should be waited on before exiting.
+//
+// This only applies to Unix platforms, and returns an already canceled context
+// on Windows.
+func ChildProcReaper(ctx context.Context, logger logrus.FieldLogger) context.Context {
+	sigChld := make(chan os.Signal, 1)
+	signal.Notify(sigChld, syscall.SIGCHLD)
+	done, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	go func() {
+		defer cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				reap(logger)
+				return
+			case <-sigChld:
+				reap(logger)
+			}
+		}
+	}()
+	return done
+}
+
+func reap(logger logrus.FieldLogger) {
+	for {
+		var wstatus syscall.WaitStatus
+		pid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
+		if err != nil && !errors.Is(err, syscall.ECHILD) {
+			logger.Errorf("failed to reap child process: %v", err)
+			continue
+		} else if pid <= 0 {
+			return
+		}
+		logger.Infof("reaped child process %v, exit status: %v", pid, wstatus.ExitStatus())
+	}
 }

--- a/internal/shutdown/signals_notunix.go
+++ b/internal/shutdown/signals_notunix.go
@@ -2,9 +2,26 @@
 
 package shutdown
 
-import "os"
+import (
+	"context"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
 
 // GetSignals returns the appropriate signals to catch for a clean shutdown, dependent on the OS.
 func GetSignals() []os.Signal {
 	return []os.Signal{os.Interrupt}
+}
+
+// ChildProcReaper spawns a goroutine to listen for SIGCHLD signals to cleanup
+// zombie child processes. The returned context will be canceled once all child
+// processes have been cleaned up, and should be waited on before exiting.
+//
+// This only applies to Unix platforms, and returns an already canceled context
+// on Windows.
+func ChildProcReaper(ctx context.Context, logger logrus.FieldLogger) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	return ctx
 }


### PR DESCRIPTION
## What is the problem I am trying to address?

Athens is constantly spawning child processes to run the go toolchain for module management and downloading. The go toolchain also spawns child processes for git, which spawns child processes to use ssh, when appropriate.

Occasionally, things go wrong with these child processes, which can then end up as zombie processes. Currently, these zombies are not being reaped, causing significant resource leakage over extended times. This is especially problematic in shared resource environments, like Kubernetes.

## How is the fix applied?

This change adds handling for the `SIGCHLD` signal, waiting on the child processes to cleanup their resources. It also updates the shutdown signal handling to make use of NotifyContext.

## What GitHub issue(s) does this PR fix or close?

None