### PR TITLE
Fix no child processes error

### DIFF
--- a/pkg/errors/command.go
+++ b/pkg/errors/command.go
@@ -1,0 +1,15 @@
+package errors
+
+import "strings"
+
+// IsNoChildProcessesErr returns true for an error from
+// exec.Command().Run() that can be safely ignored.
+// Reference: https://github.com/slimtoolkit/slim/blob/79b63a80c10083ece51be0ef1fd1e7c090ff6346/pkg/util/errutil/errutil.go#L95-L110
+func IsNoChildProcessesErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "wait: no child processes") ||
+		strings.Contains(err.Error(), "waitid: no child processes")
+}

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -143,6 +143,10 @@ func downloadModule(
 	cmd.Stderr = stderr
 
 	err := cmd.Run()
+	if errors.IsNoChildProcessesErr(err) {
+		err = nil
+	}
+
 	if err != nil {
 		err = fmt.Errorf("%w: %s", err, stderr)
 		var m goModule

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -143,11 +143,8 @@ func downloadModule(
 	cmd.Stderr = stderr
 
 	err := cmd.Run()
-	if errors.IsNoChildProcessesErr(err) {
-		err = nil
-	}
 
-	if err != nil {
+	if err != nil && !errors.IsNoChildProcessesErr(err) {
 		err = fmt.Errorf("%w: %s", err, stderr)
 		var m goModule
 		if jsonErr := json.NewDecoder(stdout).Decode(&m); jsonErr != nil {

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -143,7 +143,6 @@ func downloadModule(
 	cmd.Stderr = stderr
 
 	err := cmd.Run()
-
 	if err != nil && !errors.IsNoChildProcessesErr(err) {
 		err = fmt.Errorf("%w: %s", err, stderr)
 		var m goModule

--- a/pkg/module/go_vcs_lister.go
+++ b/pkg/module/go_vcs_lister.go
@@ -81,11 +81,8 @@ func (l *vcsLister) List(ctx context.Context, module string) (*storage.RevInfo, 
 		cmd.Env = prepareEnv(gopath, l.env)
 
 		err = cmd.Run()
-		if errors.IsNoChildProcessesErr(err) {
-			err = nil
-		}
 
-		if err != nil {
+		if err != nil && !errors.IsNoChildProcessesErr(err) {
 			err = fmt.Errorf("%w: %s", err, stderr)
 			if errors.IsErr(timeoutCtx.Err(), context.DeadlineExceeded) {
 				return nil, errors.E(op, err, errors.KindGatewayTimeout)

--- a/pkg/module/go_vcs_lister.go
+++ b/pkg/module/go_vcs_lister.go
@@ -81,6 +81,10 @@ func (l *vcsLister) List(ctx context.Context, module string) (*storage.RevInfo, 
 		cmd.Env = prepareEnv(gopath, l.env)
 
 		err = cmd.Run()
+		if errors.IsNoChildProcessesErr(err) {
+			err = nil
+		}
+
 		if err != nil {
 			err = fmt.Errorf("%w: %s", err, stderr)
 			if errors.IsErr(timeoutCtx.Err(), context.DeadlineExceeded) {

--- a/pkg/module/go_vcs_lister.go
+++ b/pkg/module/go_vcs_lister.go
@@ -81,7 +81,6 @@ func (l *vcsLister) List(ctx context.Context, module string) (*storage.RevInfo, 
 		cmd.Env = prepareEnv(gopath, l.env)
 
 		err = cmd.Run()
-
 		if err != nil && !errors.IsNoChildProcessesErr(err) {
 			err = fmt.Errorf("%w: %s", err, stderr)
 			if errors.IsErr(timeoutCtx.Err(), context.DeadlineExceeded) {


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Package download sometimes fails with error `waitid: no child processes`, due to a race condition described in the code snippet below:

https://github.com/slimtoolkit/slim/blob/79b63a80c10083ece51be0ef1fd1e7c090ff6346/pkg/util/errutil/errutil.go#L95-L110

A GitHub search (e.g. <https://github.com/search?q=%22waitid%3A+no+child+processes%22&type=code>) also shows a similar workaround in many other Go projects.

## How is the fix applied?

For `exec.Command().Run()`, ignore the error (set the error to `nil`) if the error corresponds to the issue above.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

(No GitHub issue yet)

<!-- 
example: Fixes #123
-->
