### PR TITLE
Move Single-flight from Fetcher to Stasher

### DIFF
--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gomods/athens/pkg/observ"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/spf13/afero"
-	"golang.org/x/sync/singleflight"
 )
 
 type goGetFetcher struct {
@@ -22,7 +21,6 @@ type goGetFetcher struct {
 	goBinaryName string
 	envVars      []string
 	gogetDir     string
-	sfg          *singleflight.Group
 }
 
 type goModule struct {
@@ -48,7 +46,6 @@ func NewGoGetFetcher(goBinaryName, gogetDir string, envVars []string, fs afero.F
 		goBinaryName: goBinaryName,
 		envVars:      envVars,
 		gogetDir:     gogetDir,
-		sfg:          &singleflight.Group{},
 	}, nil
 }
 
@@ -59,63 +56,57 @@ func (g *goGetFetcher) Fetch(ctx context.Context, mod, ver string) (*storage.Ver
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
-	resp, err, _ := g.sfg.Do(mod+"###"+ver, func() (any, error) {
-		// setup the GOPATH
-		goPathRoot, err := afero.TempDir(g.fs, g.gogetDir, "athens")
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		sourcePath := filepath.Join(goPathRoot, "src")
-		modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
-		if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
-			_ = clearFiles(g.fs, goPathRoot)
-			return nil, errors.E(op, err)
-		}
-
-		m, err := downloadModule(
-			ctx,
-			g.goBinaryName,
-			g.envVars,
-			goPathRoot,
-			modPath,
-			mod,
-			ver,
-		)
-		if err != nil {
-			_ = clearFiles(g.fs, goPathRoot)
-			return nil, errors.E(op, err)
-		}
-
-		var storageVer storage.Version
-		storageVer.Semver = m.Version
-		info, err := afero.ReadFile(g.fs, m.Info)
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		storageVer.Info = info
-
-		gomod, err := afero.ReadFile(g.fs, m.GoMod)
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		storageVer.Mod = gomod
-
-		zip, err := g.fs.Open(m.Zip)
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		// note: don't close zip here so that the caller can read directly from disk.
-		//
-		// if we close, then the caller will panic, and the alternative to make this work is
-		// that we read into memory and return an io.ReadCloser that reads out of memory
-		storageVer.Zip = &zipReadCloser{zip, g.fs, goPathRoot}
-
-		return &storageVer, nil
-	})
+	// setup the GOPATH
+	goPathRoot, err := afero.TempDir(g.fs, g.gogetDir, "athens")
 	if err != nil {
-		return nil, err
+		return nil, errors.E(op, err)
 	}
-	return resp.(*storage.Version), nil
+	sourcePath := filepath.Join(goPathRoot, "src")
+	modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
+	if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
+		_ = clearFiles(g.fs, goPathRoot)
+		return nil, errors.E(op, err)
+	}
+
+	m, err := downloadModule(
+		ctx,
+		g.goBinaryName,
+		g.envVars,
+		goPathRoot,
+		modPath,
+		mod,
+		ver,
+	)
+	if err != nil {
+		_ = clearFiles(g.fs, goPathRoot)
+		return nil, errors.E(op, err)
+	}
+
+	var storageVer storage.Version
+	storageVer.Semver = m.Version
+	info, err := afero.ReadFile(g.fs, m.Info)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	storageVer.Info = info
+
+	gomod, err := afero.ReadFile(g.fs, m.GoMod)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	storageVer.Mod = gomod
+
+	zip, err := g.fs.Open(m.Zip)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	// note: don't close zip here so that the caller can read directly from disk.
+	//
+	// if we close, then the caller will panic, and the alternative to make this work is
+	// that we read into memory and return an io.ReadCloser that reads out of memory
+	storageVer.Zip = &zipReadCloser{zip, g.fs, goPathRoot}
+
+	return &storageVer, nil
 }
 
 // given a filesystem, gopath, repository root, module and version, runs 'go mod download -json'


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

This issue addresses some cache corruption issue within Athens when there are multiple requests in-flight to a package that is not yet cached.

When multiple requests are sent to the same package, each request calls `stasher.Stash`, and each call `fetcher.Fetch`.

The implementation of `goGetFetcher.Fetch` uses [singleflight.Group](https://pkg.go.dev/golang.org/x/sync/singleflight#Group) to prevent fetching the same package multiple times. As such, it returns a shared `storage.Version` for each `stasher.Stash`, which goes on to call `storage.Save`.

The problem here, is that the `Zip io.ReadCloser` within `storage.Version` is shared between the 2 calls to `storage.Save`. When the storage implementation tries to use the `io.ReadCloser` through e.g. `io.Copy`, the buffer is being consumed by both `storage.Save` calls and results in corrupt cache.

## How is the fix applied?

Move the single-flight mechanism to `stasher.Stash`: it returns only the semver which is safe to share, and the files can be safely concurrently read from the storage provider.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

No such issues; we have encountered corrupted cache while running in production.

<!-- 
example: Fixes #123
-->
