### PR TITLE
Add Checksum to Saver (+ GCP implementation)

### DIFF
--- a/pkg/download/list_merge_test.go
+++ b/pkg/download/list_merge_test.go
@@ -127,7 +127,7 @@ func TestListMerge(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, v := range tc.strVersions {
-				s.Save(ctx, testModName, v, bts, io.NopCloser(bytes.NewReader(bts)), bts)
+				s.Save(ctx, testModName, v, bts, io.NopCloser(bytes.NewReader(bts)), nil, bts)
 			}
 			defer clearStorage(s, testModName, tc.strVersions)
 			dp := New(&Opts{s, nil, &listerMock{versions: tc.goVersions, err: tc.goErr}, nil, Strict})

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -165,7 +165,7 @@ func TestListMode(t *testing.T) {
 			networkMode: tc.networkmode,
 		}
 		for _, tag := range tc.storageTags {
-			err := strg.Save(ctx, tc.path, tag, []byte("mod"), bytes.NewReader([]byte("zip")), []byte("info"))
+			err := strg.Save(ctx, tc.path, tag, []byte("mod"), bytes.NewReader([]byte("zip")), nil, []byte("info"))
 			require.NoError(t, err)
 		}
 		t.Run(tc.name, func(t *testing.T) {
@@ -429,7 +429,7 @@ func TestDownloadProtocolWhenFetchFails(t *testing.T) {
 	}
 	fakeMod := testMod{"github.com/athens-artifacts/samplelib", "v1.0.0"}
 	bts := []byte(fakeMod.mod + "@" + fakeMod.ver)
-	err = s.Save(context.Background(), fakeMod.mod, fakeMod.ver, bts, io.NopCloser(bytes.NewReader(bts)), bts)
+	err = s.Save(context.Background(), fakeMod.mod, fakeMod.ver, bts, io.NopCloser(bytes.NewReader(bts)), nil, bts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ type mockStasher struct {
 }
 
 func (ms *mockStasher) Stash(ctx context.Context, mod string, ver string) (string, error) {
-	err := ms.s.Save(ctx, mod, ver, []byte("mod"), strings.NewReader("zip"), []byte("info"))
+	err := ms.s.Save(ctx, mod, ver, []byte("mod"), strings.NewReader("zip"), nil, []byte("info"))
 	ms.ch <- true // signal async stashing is done
 	return ver, err
 }

--- a/pkg/stash/stasher.go
+++ b/pkg/stash/stasher.go
@@ -71,7 +71,7 @@ func (s *stasher) Stash(ctx context.Context, mod, ver string) (string, error) {
 				return v.Semver, nil
 			}
 		}
-		err = s.storage.Save(ctx, mod, v.Semver, v.Mod, v.Zip, v.Info)
+		err = s.storage.Save(ctx, mod, v.Semver, v.Mod, v.Zip, v.ZipMD5, v.Info)
 		if err != nil {
 			return "", errors.E(op, err)
 		}

--- a/pkg/stash/stasher_test.go
+++ b/pkg/stash/stasher_test.go
@@ -84,7 +84,7 @@ type mockStorage struct {
 	existsResponse bool
 }
 
-func (ms *mockStorage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (ms *mockStorage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5 []byte, info []byte) error {
 	ms.saveCalled = true
 	ms.givenVersion = version
 	return nil

--- a/pkg/stash/with_azureblob_test.go
+++ b/pkg/stash/with_azureblob_test.go
@@ -73,6 +73,7 @@ func (ms *mockAzureBlobStasher) Stash(ctx context.Context, mod, ver string) (str
 			ver,
 			[]byte("mod file"),
 			strings.NewReader("zip file"),
+			nil,
 			[]byte("info file"),
 		)
 		if err != nil {

--- a/pkg/stash/with_gcs_test.go
+++ b/pkg/stash/with_gcs_test.go
@@ -119,7 +119,7 @@ func TestWithGCSPartialFailure(t *testing.T) {
 	}
 	s := gs(ms)
 	// We simulate a failure by manually passing an io.Reader that will fail.
-	err = ms.strg.Save(ctx, "stashmod", "v1.0.0", []byte(ms.content), fr, []byte(ms.content))
+	err = ms.strg.Save(ctx, "stashmod", "v1.0.0", []byte(ms.content), fr, nil, []byte(ms.content))
 	if err == nil {
 		// We *want* to fail.
 		t.Fatal(err)
@@ -172,6 +172,7 @@ func (ms *mockGCPStasher) Stash(ctx context.Context, mod, ver string) (string, e
 		ver,
 		[]byte(ms.content),
 		strings.NewReader(ms.content),
+		nil,
 		[]byte(ms.content),
 	)
 	return "", err

--- a/pkg/stash/with_redis_test.go
+++ b/pkg/stash/with_redis_test.go
@@ -210,6 +210,7 @@ func (ms *mockRedisStasher) Stash(ctx context.Context, mod, ver string) (string,
 			ver,
 			[]byte("mod file"),
 			strings.NewReader("zip file"),
+			nil,
 			[]byte("info file"),
 		)
 		if err != nil {

--- a/pkg/storage/azureblob/saver.go
+++ b/pkg/storage/azureblob/saver.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Save implements the (./pkg/storage).Saver interface.
-func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "azureblob.Save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/compliance/benchmarks.go
+++ b/pkg/storage/compliance/benchmarks.go
@@ -33,6 +33,7 @@ func benchList(b *testing.B, s storage.Backend, reset func() error) {
 		version,
 		mock.Mod,
 		mock.Zip,
+		mock.ZipMD5,
 		mock.Info,
 	)
 	require.NoError(b, err, "save for storage failed")
@@ -65,6 +66,7 @@ func benchSave(b *testing.B, s storage.Backend, reset func() error) {
 				version,
 				mock.Mod,
 				bytes.NewReader(zipBts),
+				mock.ZipMD5,
 				mock.Info,
 			)
 			require.NoError(b, err)
@@ -87,7 +89,7 @@ func benchDelete(b *testing.B, s storage.Backend, reset func() error) {
 	b.Run("delete", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := fmt.Sprintf("del-%s-%d", module, i)
-			err := s.Save(ctx, name, version, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+			err := s.Save(ctx, name, version, mock.Mod, bytes.NewReader(zipBts), mock.ZipMD5, mock.Info)
 			require.NoError(b, err, "saving %s for storage failed", name)
 			err = s.Delete(ctx, name, version)
 			require.NoError(b, err, "delete failed: %s", name)
@@ -104,7 +106,7 @@ func benchExists(b *testing.B, s storage.Backend, reset func() error) {
 	mock := getMockModule()
 
 	ctx := context.Background()
-	err := s.Save(ctx, module, version, mock.Mod, mock.Zip, mock.Info)
+	err := s.Save(ctx, module, version, mock.Mod, mock.Zip, mock.ZipMD5, mock.Info)
 	require.NoError(b, err)
 
 	b.Run("exists", func(b *testing.B) {

--- a/pkg/storage/external/client.go
+++ b/pkg/storage/external/client.go
@@ -81,7 +81,7 @@ func (s *service) Zip(ctx context.Context, mod, ver string) (storage.SizeReadClo
 	return storage.NewSizer(body, size), nil
 }
 
-func (s *service) Save(ctx context.Context, mod, ver string, modFile []byte, zip io.Reader, info []byte) error {
+func (s *service) Save(ctx context.Context, mod, ver string, modFile []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "external.Save"
 	var err error
 	mod, err = module.EscapePath(mod)

--- a/pkg/storage/external/server.go
+++ b/pkg/storage/external/server.go
@@ -109,7 +109,7 @@ func NewServer(strg storage.Backend) http.Handler {
 			return
 		}
 		defer func() { _ = modZ.Close() }()
-		err = strg.Save(r.Context(), params.Module, params.Version, modFile, modZ, info)
+		err = strg.Save(r.Context(), params.Module, params.Version, modFile, modZ, nil, info)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/storage/fs/saver.go
+++ b/pkg/storage/fs/saver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (s *storageImpl) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *storageImpl) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "fs.Save"
 	_, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/minio/saver.go
+++ b/pkg/storage/minio/saver.go
@@ -13,7 +13,7 @@ import (
 	minio "github.com/minio/minio-go/v6"
 )
 
-func (s *storageImpl) Save(ctx context.Context, module, vsn string, mod []byte, zip io.Reader, info []byte) error {
+func (s *storageImpl) Save(ctx context.Context, module, vsn string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "storage.minio.Save"
 	_, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -59,7 +59,7 @@ func TestQueryModuleVersionExists(t *testing.T) {
 	backend := getStorage(t)
 
 	zipBts, _ := io.ReadAll(mock.Zip)
-	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.ZipMD5, mock.Info)
 	defer backend.Delete(ctx, modname, ver)
 
 	info, err := query(ctx, backend, modname, ver)
@@ -80,7 +80,7 @@ func TestQueryKindNotFoundErrorCases(t *testing.T) {
 	backend := getStorage(t)
 
 	zipBts, _ := io.ReadAll(mock.Zip)
-	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), nil, mock.Info)
 	defer backend.Delete(ctx, modname, ver)
 
 	testCases := []struct {

--- a/pkg/storage/mongo/saver.go
+++ b/pkg/storage/mongo/saver.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Save stores a module in mongo storage.
-func (s *ModuleStore) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *ModuleStore) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "mongo.Save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/s3/saver.go
+++ b/pkg/storage/s3/saver.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Save implements the (github.com/gomods/athens/pkg/storage).Saver interface.
-func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "s3.Save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/saver.go
+++ b/pkg/storage/saver.go
@@ -7,5 +7,9 @@ import (
 
 // Saver saves module metadata and its source to underlying storage.
 type Saver interface {
-	Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error
+	// Save saves the module metadata and its source to the storage.
+	//
+	// The caller MAY call zipMD5 with a nil value if the checksum is not available.
+	// The storage implementation MAY use the zipMD5 to verify the integrity of the zip file.
+	Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error
 }

--- a/pkg/storage/version.go
+++ b/pkg/storage/version.go
@@ -6,6 +6,7 @@ import "io"
 type Version struct {
 	Mod    []byte
 	Zip    io.ReadCloser
+	ZipMD5 []byte
 	Info   []byte
 	Semver string
 }


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Continuing the GCP storage backend lock removal, this PR aims to prevent regressions in future changes by precomputing the MD5 checksum and passing the checksum when uploading the file.

The computed checksum can be used for any storage provider; however, it is currently only implemented for GCP backend.

## How is the fix applied?

* Further protect against corrupt cache by precomputing the MD5 sum for the ZIP file.
* Modify the `Saver` interface to accept the MD5 sum, and clarify the contract between the Saver implementation and the Saver user regarding the MD5 sum.
* Implement checksum in upload for **GCP** backend only.
    * Other backends have checksum passed to the implementation, but we did not implement passing the checksum to the upload to prevent breaking existing users since we have no way to test those implementations.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

We are facing cache corruption in production.

<!-- 
example: Fixes #123
-->
