### PR TITLE
docfix: use `GONOSUMDB` on Athens' home page

### DIFF
--- a/cmd/proxy/actions/home.go
+++ b/cmd/proxy/actions/home.go
@@ -47,8 +47,8 @@ const homepage = `<!DOCTYPE html>
 	<pre>GOPROXY={{ .Host }},direct</pre>
 	{{ if .NoSumPatterns }}
 	<h3>Excluding checksum database</h3>
-	<p>Use the following GONOSUM environment variable to exclude checksum database:</p>
-	<pre>GONOSUM={{ .NoSumPatterns }}</pre>
+	<p>Use the following GONOSUMDB environment variable to exclude checksum database:</p>
+	<pre>GONOSUMDB={{ .NoSumPatterns }}</pre>
 	{{ end }}
 
 	<h2>How to use the Athens API</h2>

--- a/docs/content/configuration/home-template.md
+++ b/docs/content/configuration/home-template.md
@@ -61,8 +61,8 @@ For more advanced formatting read more about [Go HTML templates](https://pkg.go.
 	<pre>GOPROXY={{ .Host }},direct</pre>
 	{{ if .NoSumPatterns }}
 	<h3>Excluding checksum database</h3>
-	<p>Use the following GONOSUM environment variable to exclude checksum database:</p>
-	<pre>GONOSUM={{ .NoSumPatterns }}</pre>
+	<p>Use the following GONOSUMDB environment variable to exclude checksum database:</p>
+	<pre>GONOSUMDB={{ .NoSumPatterns }}</pre>
 	{{ end }}
 
 	<h2>How to use the Athens API</h2>


### PR DESCRIPTION
The home page was introduced in #1945 or commit 359c119441ec75baea05161932d66cc20822bae0. This commit fixes a typo; the correct Go environment variable is `GONOSUMDB` instead of `GONOSUM`.

## What is the problem I am trying to address?

When looking at the home page of Athens, it instructs the user to use `GONOSUM`, which isn't a recognized [Go environment variable](https://pkg.go.dev/cmd/go#hdr-Environment_variables). `GONOSUMDB` is the correct environment variable.

## How is the fix applied?

The built-in home page is automatically updated when building `cmd/proxy`. If a user customized this template (see `docs/content/configuration/home-template.md`), they may need to manually update their template if it contained `GONOSUM` instead of `GONOSUMDB`.

## What GitHub issue(s) does this PR fix or close?

None