### PR TITLE
fix: enable dependabot for Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
       include: scope
     open-pull-requests-limit: 2
     target-branch: main
+  - package-ecosystem: docker
+    directory: /cmd/proxy
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     open-pull-requests-limit: 2
     target-branch: main
   - package-ecosystem: docker
-    directory: /cmd/proxy
+    directories:
+      - /
+      - /cmd/proxy
     schedule:
       interval: weekly


### PR DESCRIPTION
## What is the problem I am trying to address?

resolve and prevent issues like #2055 that may be caused from outdated docker base image.

## How is the fix applied?

Enable dependabot for the Dockerfile to keep the base image up to date.

## What GitHub issue(s) does this PR fix or close?

May fix #2055, a scan with `trivy` does not show vulnerabilities from alpine base image 3.22.
