### PR TITLE
fix: explicit alpine version, so dependabot detects it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
       - /cmd/proxy
     schedule:
       interval: weekly
+    commit-message:
+      prefix: update-docker-image
+      include: scope
+    open-pull-requests-limit: 2
+    target-branch: main

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
     target-branch: main
   - package-ecosystem: docker
     directories:
-      - /
       - /cmd/proxy
     schedule:
       interval: weekly

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -6,7 +6,6 @@
 # See project Makefile if using make.
 # See docker --build-arg if building directly.
 ARG GOLANG_VERSION=1.23.5
-ARG ALPINE_VERSION=3.20
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -27,7 +26,7 @@ RUN DATE="$(date -u +%Y-%m-%d-%H:%M:%S-%Z)" && \
     -ldflags "-X github.com/gomods/athens/pkg/build.version=$VERSION -X github.com/gomods/athens/pkg/build.buildDate=$DATE -s -w" \
     -o /bin/athens-proxy ./cmd/proxy
 
-FROM alpine:${ALPINE_VERSION}
+FROM alpine:3.20
 ARG TARGETARCH
 
 ENV GOROOT="/usr/local/go" \


### PR DESCRIPTION
## What is the problem I am trying to address?

Dependabot does not detect docker image version/tag, if we use a variable.

## How is the fix applied?

Explicitly set the tag/version of the Alpine image, then Dependabot detects it and creates PRs.

Tested with dependabot locally: `dependabot update docker drpsychick/athens --local ./ -d /cmd/proxy`

## What GitHub issue(s) does this PR fix or close?

Fixes #2055 (previous attempt #2060)