### PR TITLE
fix: append Port to host for homepage, if it is missing

### DIFF
--- a/cmd/proxy/actions/home.go
+++ b/cmd/proxy/actions/home.go
@@ -109,6 +109,11 @@ func proxyHomeHandler(c *config.Config) http.HandlerFunc {
 		// This should be correct in most cases. If it is not, users can supply their own template
 		templateData["Host"] = r.Host
 
+		// make sure our port is part of the 'Host'
+		if !strings.HasSuffix(templateData["Host"], c.Port) {
+			templateData["Host"] += c.Port
+		}
+
 		// if the host does not have a scheme, add one based on the request
 		if !strings.HasPrefix(templateData["Host"], "http://") && !strings.HasPrefix(templateData["Host"], "https://") {
 			if r.TLS != nil {


### PR DESCRIPTION
## What is the problem I am trying to address?

Resolve issue #2066 

## How is the fix applied?

When request.Host is missing the port, we add it.

## What GitHub issue(s) does this PR fix or close?

Fixes #2066 
