### PR TITLE
chore: update container image to go 1.25.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           - 6379:6379
 
       redis-sentinel:
-        image: bitnami/redis-sentinel
+        image: bitnamilegacy/redis-sentinel
         env:
           REDIS_MASTER_HOST: redis
           REDIS_MASTER_SET: redis-1
@@ -86,7 +86,7 @@ jobs:
           - 26379:26379
 
       protectedredis:
-        image: bitnami/redis
+        image: bitnamilegacy/redis
         ports:
           - 6380:6380
         env:
@@ -94,7 +94,7 @@ jobs:
           REDIS_PASSWORD: AthensPass1
 
       redis-sentinel-protected-redis:
-        image: bitnami/redis-sentinel
+        image: bitnamilegacy/redis-sentinel
         env:
           REDIS_MASTER_HOST: protectedredis
           REDIS_MASTER_PORT_NUMBER: 6380

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 VERSION = "unset"
 DATE=$(shell date -u +%Y-%m-%d-%H:%M:%S-%Z)
 
-GOLANGCI_LINT_VERSION=v1.61.0
+GOLANGCI_LINT_VERSION=v2.1.6
 
 ifndef GOLANG_VERSION
-override GOLANG_VERSION = 1.23.5
+override GOLANG_VERSION = 1.25.1
 endif
 
 .PHONY: build
@@ -22,7 +22,7 @@ athens:
 # to perform some CI build steps, instead of relying on them being installed locally
 .PHONY: build-image
 build-image:
-	docker build -t athens-build ./scripts/build-image
+	docker build -t athens-build --build-arg GOLANG_VERSION=${GOLANG_VERSION} ./scripts/build-image
 
 .PHONY: run
 run: ## run the athens proxy with dev configs

--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -5,7 +5,7 @@
 # You can override the Go version used to build the image.
 # See project Makefile if using make.
 # See docker --build-arg if building directly.
-ARG GOLANG_VERSION=1.23.5
+ARG GOLANG_VERSION=1.25.1
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     ports:
       - 6379:6379
   redis-sentinel:
-    image: bitnami/redis-sentinel
+    image: bitnamilegacy/redis-sentinel
     environment:
       - REDIS_MASTER_HOST=redis
       - REDIS_MASTER_SET=redis-1

--- a/scripts/build-image/Dockerfile
+++ b/scripts/build-image/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.23.5-bookworm
+ARG GOLANG_VERSION=1.25.1
+FROM golang:${GOLANG_VERSION}-bookworm
 
 WORKDIR /tmp
 


### PR DESCRIPTION
## What is the problem I am trying to address?

Resolve issues with athens not being able to fetch modules with toolchain >= 1.25

## How is the fix applied?

Update image go version to 1.25.1

## What GitHub issue(s) does this PR fix or close?

Fixes #2054
