### PR TITLE
Update git-credential-github-app to version 0.3.4

### DIFF
--- a/cmd/proxy/Dockerfile
+++ b/cmd/proxy/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --update git git-lfs mercurial openssh-client subversion procps foss
 
 # Add git-credential-github-app for native integration with GitHub Apps
 RUN if [ "${TARGETARCH}" = "arm64" ]; then ARCH="arm64"; else ARCH="x86_64"; fi \
-  && wget -O git-credential-github-app.tar.gz https://github.com/bdellegrazie/git-credential-github-app/releases/download/v0.3.0/git-credential-github-app_v0.3.0_Linux_${ARCH}.tar.gz \
+  && wget -O git-credential-github-app.tar.gz https://github.com/bdellegrazie/git-credential-github-app/releases/download/v0.3.4/git-credential-github-app_v0.3.4_Linux_${ARCH}.tar.gz \
   && tar xvzf 'git-credential-github-app.tar.gz' git-credential-github-app -C /usr/local/bin \
   && rm git-credential-github-app.tar.gz || true;
 


### PR DESCRIPTION
## What is the problem I am trying to address?

CVE [GHSA-mh63-6h87-95cp](https://github.com/advisories/GHSA-mh63-6h87-95cp) from github.com/golang-jwt/jwt/v4 ([Go](https://github.com/advisories?query=ecosystem%3Ago)) < 4.5.2 in binary [git-credential-github-app](https://github.com/bdellegrazie/git-credential-github-app) used in [cmd/proxy/Dockerfile](https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile)

## How is the fix applied?

According to [commit 41a5848431cb0d004c0aed2c3352b0e8cfc0d490](https://github.com/bdellegrazie/git-credential-github-app/commit/41a5848431cb0d004c0aed2c3352b0e8cfc0d490) from repository [bdellegrazie/git-credential-github-app](https://github.com/bdellegrazie/git-credential-github-app), version tag `v0.3.4` started to ship with this patch

## What GitHub issue(s) does this PR fix or close?

N/A

Fixes #

N/A
