### PR TITLE
fix: return 410 Gone with descriptive semver error message

### DIFF
--- a/pkg/download/handler_test.go
+++ b/pkg/download/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gomods/athens/pkg/download/mode"
@@ -44,6 +45,30 @@ func TestRedirect(t *testing.T) {
 	}
 }
 
+
+func TestInfoHandlerGoneIncludesErrorMessage(t *testing.T) {
+	r := mux.NewRouter()
+	RegisterHandlers(r, &HandlerOpts{
+		Protocol: &mockGoneInfoProtocol{},
+		Logger:   log.NoOpLogger(),
+		DownloadFile: &mode.DownloadFile{
+			Mode: mode.Sync,
+		},
+	})
+
+	req := httptest.NewRequest("GET", "/github.com/uber/h3-go/@v/v3.0.2.info", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected status %d but got %d", http.StatusGone, w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "major version must be compatible") {
+		t.Fatalf("expected descriptive semver error in body, got %q", body)
+	}
+}
 type mockProtocol struct {
 	Protocol
 }
@@ -61,4 +86,13 @@ func (mp *mockProtocol) GoMod(ctx context.Context, mod, ver string) ([]byte, err
 func (mp *mockProtocol) Zip(ctx context.Context, mod, ver string) (storage.SizeReadCloser, error) {
 	const op errors.Op = "mockProtocol.Zip"
 	return nil, errors.E(op, "not found", errors.KindRedirect)
+}
+
+type mockGoneInfoProtocol struct {
+	Protocol
+}
+
+func (mp *mockGoneInfoProtocol) Info(ctx context.Context, mod, ver string) ([]byte, error) {
+	const op errors.Op = "mockGoneInfoProtocol.Info"
+	return nil, errors.E(op, "invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3", errors.KindGone)
 }

--- a/pkg/download/version_info.go
+++ b/pkg/download/version_info.go
@@ -24,7 +24,7 @@ func InfoHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handle
 		}
 		info, err := dp.Info(r.Context(), mod, ver)
 		if err != nil {
-			severityLevel := errors.Expect(err, errors.KindNotFound, errors.KindRedirect)
+			severityLevel := errors.Expect(err, errors.KindNotFound, errors.KindRedirect, errors.KindGone)
 			lggr.SystemErr(errors.E(op, err, errors.M(mod), errors.V(ver), severityLevel))
 			if errors.Kind(err) == errors.KindRedirect {
 				url, err := getRedirectURL(df.URL(mod), r.URL.Path)
@@ -37,6 +37,11 @@ func InfoHandler(dp Protocol, lggr log.Entry, df *mode.DownloadFile) http.Handle
 				return
 			}
 			w.WriteHeader(errors.Kind(err))
+			// For 410 Gone errors, include the descriptive error message in the response body
+			// to help users understand what went wrong (e.g., semver mismatch)
+			if errors.Kind(err) == errors.KindGone {
+				_, _ = w.Write([]byte(err.Error()))
+			}
 		}
 
 		_, _ = w.Write(info)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -20,6 +20,7 @@ const (
 	KindNotImplemented = http.StatusNotImplemented
 	KindRedirect       = http.StatusMovedPermanently
 	KindGatewayTimeout = http.StatusGatewayTimeout
+	KindGone           = http.StatusGone
 )
 
 // Error is an Athens system error.

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -168,6 +168,10 @@ func downloadModule(
 		if isLimitHit(m.Error) {
 			return goModule{}, errors.E(op, m.Error, errors.KindRateLimit)
 		}
+		// semver/major version compatibility error - return 410 Gone with descriptive message
+		if isSemverError(m.Error) {
+			return goModule{}, errors.E(op, m.Error, errors.KindGone)
+		}
 		return goModule{}, errors.E(op, m.Error, errors.KindNotFound)
 	}
 
@@ -184,6 +188,16 @@ func downloadModule(
 
 func isLimitHit(o string) bool {
 	return strings.Contains(o, "403 response from api.github.com")
+}
+
+// isSemverError detects if the error message indicates a semver/major version
+// compatibility issue. Go modules requires that v2+ modules have a major version
+// suffix in their import path (e.g., /v2, /v3). When this requirement is violated,
+// the error should be returned as 410 Gone with a descriptive message rather than
+// 404 Not Found.
+func isSemverError(errMsg string) bool {
+	return strings.Contains(errMsg, "invalid version") &&
+		strings.Contains(errMsg, "major version must be compatible")
 }
 
 // getRepoDirName takes a raw repository URI and a version and creates a directory name that the

--- a/pkg/module/go_get_fetcher_test.go
+++ b/pkg/module/go_get_fetcher_test.go
@@ -135,3 +135,48 @@ func (m *mockProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Write(resp)
 }
+
+func (s *ModuleSuite) TestIsSemverError() {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected bool
+	}{
+		{
+			name:     "major version mismatch error",
+			errMsg:   "invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3",
+			expected: true,
+		},
+		{
+			name:     "invalid version without major version message",
+			errMsg:   "invalid version: unknown revision",
+			expected: false,
+		},
+		{
+			name:     "unrelated error",
+			errMsg:   "repository not found",
+			expected: false,
+		},
+		{
+			name:     "empty error",
+			errMsg:   "",
+			expected: false,
+		},
+		{
+			name:     "partial match - only invalid version",
+			errMsg:   "invalid version: something else",
+			expected: false,
+		},
+		{
+			name:     "partial match - only major version",
+			errMsg:   "major version must be compatible",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			result := isSemverError(tt.errMsg)
+			assert.Equal(s.T(), tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## What is the problem I am trying to address?
Athens currently returns `404 Not Found` for certain non-conforming module import/version requests where the real failure is Go module major-version compatibility (for example `github.com/uber/h3-go@v3.0.2` when the module path/version combination is invalid for `go.mod` rules).

This differs from `proxy.golang.org`, which returns a more accurate `410 Gone` with a descriptive error. The current behavior makes debugging difficult because it looks like the module/version does not exist, while the real problem is semver compatibility.

## How is the fix applied?
The fix updates error classification and response handling in three places:

1. Added `KindGone` (`410`) in `pkg/errors/errors.go`.
2. Updated `pkg/module/go_get_fetcher.go`:
   - Added semver compatibility detection (`isSemverError`) for Go toolchain errors containing both:
     - `invalid version`
     - `major version must be compatible`
   - When this pattern is detected during `go mod download -json`, Athens now returns `errors.KindGone` instead of `errors.KindNotFound`.
3. Updated `pkg/download/version_info.go`:
   - For `.info` requests returning `410`, Athens now includes the descriptive error text in the response body so users see actionable guidance.

Test coverage:
- `pkg/module/go_get_fetcher_test.go`: unit tests for semver-error detection logic.
- `pkg/download/handler_test.go`: regression test verifying `.info` returns `410` and includes semver guidance in the response body.

## How to reproduce and verify locally
### Reproduce (before fix behavior)
1. Start Athens proxy locally.
2. Request:
   - `GET /github.com/uber/h3-go/@v/v3.0.2.info`
3. Observe previous behavior:
   - HTTP `404 Not Found`

### Verify (after fix behavior)
1. Run targeted tests:
   - `go test ./pkg/download ./pkg/module`
2. Re-run request:
   - `GET /github.com/uber/h3-go/@v/v3.0.2.info`
3. Confirm new behavior:
   - HTTP `410 Gone`
   - response body contains descriptive semver message including `major version must be compatible`

## What GitHub issue(s) does this PR fix or close?
Fixes #1697