### PR TITLE
stash/redis: add cluster-mode client support for singleflight

### DIFF
--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -155,6 +155,7 @@ func getSingleFlight(l *log.Logger, c *config.Config, s storage.Backend, checker
 			&athensLoggerForRedis{logger: l},
 			c.SingleFlight.Redis.Endpoint,
 			c.SingleFlight.Redis.Password,
+			c.SingleFlight.Redis.Cluster,
 			checker,
 			c.SingleFlight.Redis.LockConfig)
 	case "redis-sentinel":

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -344,12 +344,23 @@ ShutdownTimeout = 60
         # Endpoint is the redis endpoint for a SingleFlight lock. Should be either a host:port
         # pair or redis url such as:
         #    redis[s]://user:password@127.0.0.1:6379/0?protocol=3
-        # TODO(marwan): enable multiple endpoints for redis clusters.
+        # When Cluster = true below, Endpoint may also be a comma-separated list of
+        # host:port (or redis[s]://) seeds; the cluster client discovers the rest of
+        # the topology automatically.
         # Env override: ATHENS_REDIS_ENDPOINT
         Endpoint = "127.0.0.1:6379"
         # Password is the password for a redis SingleFlight lock.
         # Env override: ATHENS_REDIS_PASSWORD
         Password = ""
+        # Cluster selects a Redis Cluster Mode client (redis.NewClusterClient)
+        # instead of the default single-node client. Set this to true when Endpoint
+        # points at a Cluster Mode Enabled Redis (e.g. AWS ElastiCache's
+        # `clustercfg.*` configuration endpoint), so MOVED/ASK redirects are
+        # followed transparently. Required even for single-shard cluster-mode
+        # deployments — Cluster Mode replies MOVED any time the connected node
+        # doesn't own the slot for the key.
+        # Env override: ATHENS_REDIS_CLUSTER
+        Cluster = false
 
         [SingleFlight.Redis.LockConfig]
             # TTL for the lock in seconds. Defaults to 900 seconds (15 minutes).

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -345,8 +345,7 @@ ShutdownTimeout = 60
         # pair or redis url such as:
         #    redis[s]://user:password@127.0.0.1:6379/0?protocol=3
         # When Cluster = true below, Endpoint may also be a comma-separated list of
-        # host:port (or redis[s]://) seeds; the cluster client discovers the rest of
-        # the topology automatically.
+        # host:port (or redis[s]://) seeds
         # Env override: ATHENS_REDIS_ENDPOINT
         Endpoint = "127.0.0.1:6379"
         # Password is the password for a redis SingleFlight lock.
@@ -354,11 +353,7 @@ ShutdownTimeout = 60
         Password = ""
         # Cluster selects a Redis Cluster Mode client (redis.NewClusterClient)
         # instead of the default single-node client. Set this to true when Endpoint
-        # points at a Cluster Mode Enabled Redis (e.g. AWS ElastiCache's
-        # `clustercfg.*` configuration endpoint), so MOVED/ASK redirects are
-        # followed transparently. Required even for single-shard cluster-mode
-        # deployments — Cluster Mode replies MOVED any time the connected node
-        # doesn't own the slot for the key.
+        # points at a Cluster Mode Enabled Redis 
         # Env override: ATHENS_REDIS_CLUSTER
         Cluster = false
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,7 +176,7 @@ func defaultConfig() *Config {
 		StashTimeout:     600,
 		SingleFlight: &SingleFlight{
 			Etcd:  &Etcd{"localhost:2379,localhost:22379,localhost:32379"},
-			Redis: &Redis{"127.0.0.1:6379", "", DefaultRedisLockConfig()},
+			Redis: &Redis{Endpoint: "127.0.0.1:6379", LockConfig: DefaultRedisLockConfig()},
 			RedisSentinel: &RedisSentinel{
 				Endpoints:        []string{"127.0.0.1:26379"},
 				MasterName:       "redis-1",

--- a/pkg/config/singleflight.go
+++ b/pkg/config/singleflight.go
@@ -20,13 +20,9 @@ type Etcd struct {
 // Redis holds the client side configuration
 // to connect to redis as a SingleFlight implementation.
 type Redis struct {
-	Endpoint string `envconfig:"ATHENS_REDIS_ENDPOINT"`
-	Password string `envconfig:"ATHENS_REDIS_PASSWORD"`
-	// Cluster selects a Redis Cluster Mode client (redis.NewClusterClient)
-	// instead of the default single-node client. When true, Endpoint is
-	// treated as one or more cluster seed addresses (comma-separated host:port
-	// or a single redis[s]:// URL) and the client follows MOVED/ASK redirects.
-	Cluster    bool `envconfig:"ATHENS_REDIS_CLUSTER"`
+	Endpoint   string `envconfig:"ATHENS_REDIS_ENDPOINT"`
+	Password   string `envconfig:"ATHENS_REDIS_PASSWORD"`
+	Cluster    bool   `envconfig:"ATHENS_REDIS_CLUSTER"`
 	LockConfig *RedisLockConfig
 }
 

--- a/pkg/config/singleflight.go
+++ b/pkg/config/singleflight.go
@@ -20,8 +20,13 @@ type Etcd struct {
 // Redis holds the client side configuration
 // to connect to redis as a SingleFlight implementation.
 type Redis struct {
-	Endpoint   string `envconfig:"ATHENS_REDIS_ENDPOINT"`
-	Password   string `envconfig:"ATHENS_REDIS_PASSWORD"`
+	Endpoint string `envconfig:"ATHENS_REDIS_ENDPOINT"`
+	Password string `envconfig:"ATHENS_REDIS_PASSWORD"`
+	// Cluster selects a Redis Cluster Mode client (redis.NewClusterClient)
+	// instead of the default single-node client. When true, Endpoint is
+	// treated as one or more cluster seed addresses (comma-separated host:port
+	// or a single redis[s]:// URL) and the client follows MOVED/ASK redirects.
+	Cluster    bool `envconfig:"ATHENS_REDIS_CLUSTER"`
 	LockConfig *RedisLockConfig
 }
 

--- a/pkg/config/testdata/config.dev.toml
+++ b/pkg/config/testdata/config.dev.toml
@@ -344,12 +344,23 @@ ShutdownTimeout = 60
         # Endpoint is the redis endpoint for a SingleFlight lock. Should be either a host:port
         # pair or redis url such as:
         #    redis[s]://user:password@127.0.0.1:6379/0?protocol=3
-        # TODO(marwan): enable multiple endpoints for redis clusters.
+        # When Cluster = true below, Endpoint may also be a comma-separated list of
+        # host:port (or redis[s]://) seeds; the cluster client discovers the rest of
+        # the topology automatically.
         # Env override: ATHENS_REDIS_ENDPOINT
         Endpoint = "127.0.0.1:6379"
         # Password is the password for a redis SingleFlight lock.
         # Env override: ATHENS_REDIS_PASSWORD
         Password = ""
+        # Cluster selects a Redis Cluster Mode client (redis.NewClusterClient)
+        # instead of the default single-node client. Set this to true when Endpoint
+        # points at a Cluster Mode Enabled Redis (e.g. AWS ElastiCache's
+        # `clustercfg.*` configuration endpoint), so MOVED/ASK redirects are
+        # followed transparently. Required even for single-shard cluster-mode
+        # deployments — Cluster Mode replies MOVED any time the connected node
+        # doesn't own the slot for the key.
+        # Env override: ATHENS_REDIS_CLUSTER
+        Cluster = false
 
         [SingleFlight.Redis.LockConfig]
             # TTL for the lock in seconds. Defaults to 900 seconds (15 minutes).

--- a/pkg/config/testdata/config.dev.toml
+++ b/pkg/config/testdata/config.dev.toml
@@ -345,8 +345,7 @@ ShutdownTimeout = 60
         # pair or redis url such as:
         #    redis[s]://user:password@127.0.0.1:6379/0?protocol=3
         # When Cluster = true below, Endpoint may also be a comma-separated list of
-        # host:port (or redis[s]://) seeds; the cluster client discovers the rest of
-        # the topology automatically.
+        # host:port (or redis[s]://) seeds
         # Env override: ATHENS_REDIS_ENDPOINT
         Endpoint = "127.0.0.1:6379"
         # Password is the password for a redis SingleFlight lock.
@@ -354,11 +353,7 @@ ShutdownTimeout = 60
         Password = ""
         # Cluster selects a Redis Cluster Mode client (redis.NewClusterClient)
         # instead of the default single-node client. Set this to true when Endpoint
-        # points at a Cluster Mode Enabled Redis (e.g. AWS ElastiCache's
-        # `clustercfg.*` configuration endpoint), so MOVED/ASK redirects are
-        # followed transparently. Required even for single-shard cluster-mode
-        # deployments — Cluster Mode replies MOVED any time the connected node
-        # doesn't own the slot for the key.
+        # points at a Cluster Mode Enabled Redis 
         # Env override: ATHENS_REDIS_CLUSTER
         Cluster = false
 

--- a/pkg/stash/with_redis.go
+++ b/pkg/stash/with_redis.go
@@ -116,12 +116,6 @@ func getRedisClusterClientOptions(endpoint, password string) (*redis.ClusterOpti
 
 // WithRedisLock returns a distributed singleflight
 // using a redis cluster. If it cannot connect, it will return an error.
-//
-// When cluster is true, a redis.NewClusterClient is used so MOVED/ASK redirects
-// are followed transparently. This is required when pointing at a Cluster Mode
-// Enabled Redis (e.g. AWS ElastiCache's `clustercfg.*` configuration endpoint),
-// even if the cluster is single-shard — Cluster Mode replies MOVED any time the
-// connected node doesn't own the slot for the key.
 func WithRedisLock(l RedisLogger, endpoint, password string, cluster bool, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
 	redis.SetLogger(l)
 

--- a/pkg/stash/with_redis.go
+++ b/pkg/stash/with_redis.go
@@ -3,6 +3,7 @@ package stash
 import (
 	"context"
 	goerrors "errors"
+	"strings"
 	"time"
 
 	"github.com/bsm/redislock"
@@ -55,19 +56,91 @@ func getRedisClientOptions(endpoint, password string) (*redis.Options, error) {
 	return options, nil
 }
 
+// getRedisClusterClientOptions takes a (possibly comma-separated) endpoint and
+// a password and returns *redis.ClusterOptions suitable for redis.NewClusterClient.
+// Each comma-separated entry is treated as a host:port pair or a redis[s]:// URL.
+// URL-embedded passwords are validated against the explicit password the same
+// way getRedisClientOptions does.
+func getRedisClusterClientOptions(endpoint, password string) (*redis.ClusterOptions, error) {
+	rawAddrs := strings.Split(endpoint, ",")
+	addrs := make([]string, 0, len(rawAddrs))
+	clusterOpts := &redis.ClusterOptions{
+		Password: password,
+	}
+	var (
+		username string
+		urlPwd   string
+	)
+
+	for _, raw := range rawAddrs {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		// Try parsing as a redis[s]:// URL so TLS and credentials are honored.
+		// Fall back to host:port if it doesn't parse as a URL.
+		opts, err := redis.ParseURL(raw)
+		if err != nil {
+			addrs = append(addrs, raw)
+			continue
+		}
+		addrs = append(addrs, opts.Addr)
+		// First URL contributes TLS/username/embedded-password; subsequent URLs
+		// are expected to be homogeneous (same auth/TLS), which is the normal
+		// AWS ElastiCache / Redis Cluster setup.
+		if clusterOpts.TLSConfig == nil {
+			clusterOpts.TLSConfig = opts.TLSConfig
+		}
+		if username == "" {
+			username = opts.Username
+		}
+		if urlPwd == "" {
+			urlPwd = opts.Password
+		}
+	}
+
+	if username != "" {
+		clusterOpts.Username = username
+	}
+	// Apply the same password-consistency rule as the single-node path.
+	if urlPwd != "" && password != "" && urlPwd != password {
+		return nil, errPasswordsDoNotMatch
+	}
+	if urlPwd != "" && password == "" {
+		clusterOpts.Password = urlPwd
+	}
+
+	clusterOpts.Addrs = addrs
+	return clusterOpts, nil
+}
+
 // WithRedisLock returns a distributed singleflight
 // using a redis cluster. If it cannot connect, it will return an error.
-func WithRedisLock(l RedisLogger, endpoint, password string, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
+//
+// When cluster is true, a redis.NewClusterClient is used so MOVED/ASK redirects
+// are followed transparently. This is required when pointing at a Cluster Mode
+// Enabled Redis (e.g. AWS ElastiCache's `clustercfg.*` configuration endpoint),
+// even if the cluster is single-shard — Cluster Mode replies MOVED any time the
+// connected node doesn't own the slot for the key.
+func WithRedisLock(l RedisLogger, endpoint, password string, cluster bool, checker storage.Checker, lockConfig *config.RedisLockConfig) (Wrapper, error) {
 	redis.SetLogger(l)
 
 	const op errors.Op = "stash.WithRedisLock"
 
-	options, err := getRedisClientOptions(endpoint, password)
-	if err != nil {
-		return nil, errors.E(op, err)
+	var client redis.UniversalClient
+	if cluster {
+		clusterOpts, err := getRedisClusterClientOptions(endpoint, password)
+		if err != nil {
+			return nil, errors.E(op, err)
+		}
+		client = redis.NewClusterClient(clusterOpts)
+	} else {
+		options, err := getRedisClientOptions(endpoint, password)
+		if err != nil {
+			return nil, errors.E(op, err)
+		}
+		client = redis.NewClient(options)
 	}
-
-	client := redis.NewClient(options)
 	if _, err := client.Ping(context.Background()).Result(); err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -100,7 +173,7 @@ type redisLockOptions struct {
 }
 
 type redisLock struct {
-	client  *redis.Client
+	client  redis.UniversalClient
 	stasher Stasher
 	checker storage.Checker
 	options redisLockOptions

--- a/pkg/stash/with_redis_test.go
+++ b/pkg/stash/with_redis_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/gomods/athens/pkg/config"
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/gomods/athens/pkg/storage/mem"
+	"github.com/redis/go-redis/v9"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -41,7 +41,7 @@ func TestWithRedisLock(t *testing.T) {
 	}
 	ms := &mockRedisStasher{strg: strg}
 	l := &testingRedisLogger{t: t}
-	wrapper, err := WithRedisLock(l, endpoint, password, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	wrapper, err := WithRedisLock(l, endpoint, password, false, storage.WithChecker(strg), config.DefaultRedisLockConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestWithRedisLockWithPassword(t *testing.T) {
 	}
 	ms := &mockRedisStasher{strg: strg}
 	l := &testingRedisLogger{t: t}
-	wrapper, err := WithRedisLock(l, endpoint, password, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	wrapper, err := WithRedisLock(l, endpoint, password, false, storage.WithChecker(strg), config.DefaultRedisLockConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,13 +112,130 @@ func TestWithRedisLockWithWrongPassword(t *testing.T) {
 		t.Fatal(err)
 	}
 	l := &testingRedisLogger{t: t}
-	_, err = WithRedisLock(l, endpoint, password, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	_, err = WithRedisLock(l, endpoint, password, false, storage.WithChecker(strg), config.DefaultRedisLockConfig())
 	if err == nil {
 		t.Fatal("Expected Connection Error")
 	}
 
 	if !strings.Contains(err.Error(), "NOAUTH Authentication required.") {
 		t.Fatalf("Wrong error was thrown %q\n", err.Error())
+	}
+}
+
+// TestWithRedisClusterLock verifies that the cluster-mode client also produces
+// a working singleflight wrapper. Skipped unless REDIS_CLUSTER_TEST_ENDPOINT is
+// set (comma-separated seed addresses, or a single redis[s]:// URL).
+func TestWithRedisClusterLock(t *testing.T) {
+	endpoint := os.Getenv("REDIS_CLUSTER_TEST_ENDPOINT")
+	password := os.Getenv("ATHENS_REDIS_PASSWORD")
+	if len(endpoint) == 0 {
+		t.SkipNow()
+	}
+	strg, err := mem.NewStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms := &mockRedisStasher{strg: strg}
+	l := &testingRedisLogger{t: t}
+	wrapper, err := WithRedisLock(l, endpoint, password, true, storage.WithChecker(strg), config.DefaultRedisLockConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := wrapper(ms)
+
+	var eg errgroup.Group
+	for range 5 {
+		eg.Go(func() error {
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
+			defer cancel()
+			_, err := s.Stash(ctx, "mod", "ver")
+			return err
+		})
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type getRedisClusterClientOptionsFacet struct {
+	endpoint      string
+	password      string
+	wantAddrs     []string
+	wantPassword  string
+	wantUsername  string
+	wantTLS       bool
+	expectErrText string
+}
+
+func Test_getRedisClusterClientOptions(t *testing.T) {
+	facets := []*getRedisClusterClientOptionsFacet{
+		{
+			endpoint:  "127.0.0.1:6379",
+			wantAddrs: []string{"127.0.0.1:6379"},
+		},
+		{
+			endpoint:     "127.0.0.1:6379",
+			password:     "1234",
+			wantAddrs:    []string{"127.0.0.1:6379"},
+			wantPassword: "1234",
+		},
+		{
+			endpoint:  "127.0.0.1:6379,127.0.0.1:6380,127.0.0.1:6381",
+			wantAddrs: []string{"127.0.0.1:6379", "127.0.0.1:6380", "127.0.0.1:6381"},
+		},
+		{
+			// rediss:// URL — TLS configured, embedded password applied.
+			endpoint:     "rediss://127.0.0.1:6379",
+			password:     "1234",
+			wantAddrs:    []string{"127.0.0.1:6379"},
+			wantPassword: "1234",
+			wantTLS:      true,
+		},
+		{
+			// URL-embedded password equal to explicit password is fine.
+			endpoint:     "redis://:1234@127.0.0.1:6379",
+			password:     "1234",
+			wantAddrs:    []string{"127.0.0.1:6379"},
+			wantPassword: "1234",
+		},
+		{
+			// URL-embedded password mismatched with explicit password fails.
+			endpoint:      "redis://:url-pw@127.0.0.1:6379",
+			password:      "config-pw",
+			expectErrText: errPasswordsDoNotMatch.Error(),
+		},
+	}
+
+	for i, facet := range facets {
+		opts, err := getRedisClusterClientOptions(facet.endpoint, facet.password)
+		if facet.expectErrText != "" {
+			if err == nil {
+				t.Errorf("Facet %d: expected error %q, got nil", i, facet.expectErrText)
+				continue
+			}
+			if !strings.Contains(err.Error(), facet.expectErrText) {
+				t.Errorf("Facet %d: expected error containing %q, got %q", i, facet.expectErrText, err.Error())
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Facet %d: unexpected error %q", i, err.Error())
+			continue
+		}
+		if got, want := strings.Join(opts.Addrs, ","), strings.Join(facet.wantAddrs, ","); got != want {
+			t.Errorf("Facet %d: Addrs = %q, want %q", i, got, want)
+		}
+		if opts.Password != facet.wantPassword {
+			t.Errorf("Facet %d: Password = %q, want %q", i, opts.Password, facet.wantPassword)
+		}
+		if opts.Username != facet.wantUsername {
+			t.Errorf("Facet %d: Username = %q, want %q", i, opts.Username, facet.wantUsername)
+		}
+		if (opts.TLSConfig != nil) != facet.wantTLS {
+			t.Errorf("Facet %d: TLSConfig present = %v, want %v", i, opts.TLSConfig != nil, facet.wantTLS)
+		}
 	}
 }
 


### PR DESCRIPTION

<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Athens v0.17.0 singleflight uses redis.NewClient, which can't follow MOVED/ASK redirects. When the configured endpoint points at a Cluster Mode Enabled Redis (e.g. AWS ElastiCache's `clustercfg.*` configuration endpoint), every Stash op that happens to land on a non-slot-owning node returns MOVED, which the client surfaces as 500 to the caller — even when the cluster has only one shard, because Cluster Mode replies MOVED any time the connected node doesn't own the slot for the key.

## How is the fix applied?

Add a `Cluster` bool to the SingleFlight.Redis config (env override: ATHENS_REDIS_CLUSTER). When set, WithRedisLock constructs a redis.NewClusterClient and stores it in the redisLock as a redis.UniversalClient — both go-redis client types satisfy the bsm/redislock RedisClient interface, so the Stash/Release call sites need no further change. The endpoint may be a single host:port, redis[s]:// URL, or a comma-separated list of seed addresses; TLS, username, and embedded passwords are honored the same way the single-node path honors them.

Backwards compatible: existing configs default to Cluster = false and keep using redis.NewClient.

Tests:
- new env-gated TestWithRedisClusterLock (REDIS_CLUSTER_TEST_ENDPOINT) exercising the cluster-client code path against a real cluster
- new Test_getRedisClusterClientOptions table-test covering host:port, multi-seed, rediss://, URL-embedded password validation
- existing single-node tests pass through `false` for the new arg

Stood up grokzen/redis-cluster:6.2.0 locally (6 nodes, ports 7000-7005), confirmed cluster formation with cluster_state:ok and slots 16384/16384 ok

```
docker run -d --name redis-cluster  -e IP=0.0.0.0  -p 7000-7005:7000-7005 grokzen/redis-cluster:6.2.0  
docker exec redis-cluster redis-cli -p 7000 cluster info | head -3
# expect: cluster_state:ok

REDIS_CLUSTER_TEST_ENDPOINT=localhost:7000 go test -v -run TestWithRedisClusterLock ./pkg/stash/...
REDIS_CLUSTER_TEST_ENDPOINT=localhost:7000 go test -v -run TestWithRedisLock ./pkg/stash/...

```

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

Fixes #

#2121


<!-- 
example: Fixes #123
-->
