### PR TITLE
Replace logrus with log/slog

### DIFF
--- a/cmd/proxy/actions/app.go
+++ b/cmd/proxy/actions/app.go
@@ -82,7 +82,7 @@ func App(logger *log.Logger, conf *config.Config) (http.Handler, func(), error) 
 		conf.GoEnv,
 	)
 	if err != nil {
-		logger.Info(err)
+		logger.Infof("%v", err)
 	} else {
 		cleanupTraces = flushTraces
 	}
@@ -93,7 +93,7 @@ func App(logger *log.Logger, conf *config.Config) (http.Handler, func(), error) 
 	cleanupStats := noop
 	flushStats, err := observ.RegisterStatsExporter(r, conf.StatsExporter, Service)
 	if err != nil {
-		logger.Info(err)
+		logger.Infof("%v", err)
 	} else {
 		cleanupStats = flushStats
 	}

--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -133,8 +133,8 @@ type athensLoggerForRedis struct {
 	logger *log.Logger
 }
 
-func (l *athensLoggerForRedis) Printf(ctx context.Context, format string, v ...any) {
-	l.logger.WithContext(ctx).Printf(format, v...)
+func (l *athensLoggerForRedis) Printf(_ context.Context, format string, v ...any) {
+	l.logger.Infof(format, v...)
 }
 
 func getSingleFlight(l *log.Logger, c *config.Config, s storage.Backend, checker storage.Checker) (stash.Wrapper, error) {

--- a/cmd/proxy/actions/basicauth_test.go
+++ b/cmd/proxy/actions/basicauth_test.go
@@ -2,13 +2,13 @@ package actions
 
 import (
 	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/gomods/athens/pkg/log"
-	"github.com/sirupsen/logrus"
 )
 
 var basicAuthTests = [...]struct {
@@ -69,9 +69,8 @@ func TestBasicAuth(t *testing.T) {
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			r.SetBasicAuth(tc.user, tc.pass)
-			lggr := log.New("none", logrus.DebugLevel, "")
 			buf := &bytes.Buffer{}
-			lggr.Out = buf
+			lggr := log.NewWithOutput(buf, "none", slog.LevelDebug, "")
 			ctx := log.SetEntryInContext(t.Context(), lggr)
 			r = r.WithContext(ctx)
 			handler.ServeHTTP(w, r)

--- a/cmd/proxy/actions/index.go
+++ b/cmd/proxy/actions/index.go
@@ -7,10 +7,11 @@ import (
 	"strconv"
 	"time"
 
+	"log/slog"
+
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/index"
 	"github.com/gomods/athens/pkg/log"
-	"github.com/sirupsen/logrus"
 )
 
 // indexHandler implements GET baseURL/index.
@@ -46,13 +47,13 @@ func getIndexLines(r *http.Request, index index.Indexer) ([]*index.Line, error) 
 	if limitStr := r.FormValue("limit"); limitStr != "" {
 		limit, err = strconv.Atoi(limitStr)
 		if err != nil || limit <= 0 {
-			return nil, errors.E(op, err, errors.KindBadRequest, logrus.InfoLevel)
+			return nil, errors.E(op, err, errors.KindBadRequest, slog.LevelInfo)
 		}
 	}
 	if sinceStr := r.FormValue("since"); sinceStr != "" {
 		since, err = time.Parse(time.RFC3339, sinceStr)
 		if err != nil {
-			return nil, errors.E(op, err, errors.KindBadRequest, logrus.InfoLevel)
+			return nil, errors.E(op, err, errors.KindBadRequest, slog.LevelInfo)
 		}
 	}
 	list, err := index.Lines(r.Context(), since, limit)

--- a/cmd/proxy/actions/index.go
+++ b/cmd/proxy/actions/index.go
@@ -3,11 +3,10 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
-
-	"log/slog"
 
 	"github.com/gomods/athens/pkg/errors"
 	"github.com/gomods/athens/pkg/index"

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -74,24 +74,20 @@ func main() {
 	var ln net.Listener
 
 	if conf.UnixSocket != "" {
-		socketLogger := logger.WithFields(map[string]any{"unixSocket": conf.UnixSocket})
-		socketLogger.Infof("Starting application")
+		logger.WithFields(map[string]any{"unixSocket": conf.UnixSocket}).Infof("Starting application")
 
 		//nolint:noctx
 		ln, err = net.Listen("unix", conf.UnixSocket)
 		if err != nil {
-			socketLogger.Errorf("Could not listen on Unix domain socket: %v", err)
-			os.Exit(1)
+			logger.Fatalf("Could not listen on Unix domain socket %q: %v", conf.UnixSocket, err)
 		}
 	} else {
-		portLogger := logger.WithFields(map[string]any{"tcpPort": conf.Port})
-		portLogger.Infof("Starting application")
+		logger.WithFields(map[string]any{"tcpPort": conf.Port}).Infof("Starting application")
 
 		//nolint:noctx
 		ln, err = net.Listen("tcp", conf.Port)
 		if err != nil {
-			portLogger.Errorf("Could not listen on TCP port: %v", err)
-			os.Exit(1)
+			logger.Fatalf("Could not listen on TCP port %q: %v", conf.Port, err)
 		}
 	}
 

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	stdlog "log"
+	"log/slog"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -18,7 +19,6 @@ import (
 	"github.com/gomods/athens/pkg/build"
 	"github.com/gomods/athens/pkg/config"
 	athenslog "github.com/gomods/athens/pkg/log"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -37,26 +37,21 @@ func main() {
 		stdlog.Fatalf("Could not load config file: %v", err)
 	}
 
-	logLvl, err := logrus.ParseLevel(conf.LogLevel)
+	logLvl, err := athenslog.ParseLevel(conf.LogLevel)
 	if err != nil {
 		stdlog.Fatalf("Could not parse log level %q: %v", conf.LogLevel, err)
 	}
 
 	logger := athenslog.New(conf.CloudRuntime, logLvl, conf.LogFormat)
 
-	// Turn standard logger output into logrus Errors.
-	logrusErrorWriter := logger.WriterLevel(logrus.ErrorLevel)
-	defer func() {
-		if err := logrusErrorWriter.Close(); err != nil {
-			logger.WithError(err).Warn("Could not close logrus writer pipe")
-		}
-	}()
-	stdlog.SetOutput(logrusErrorWriter)
+	// Route the standard library logger's output through our logger at the
+	// error level.
+	stdlog.SetOutput(logger.StdLogger(slog.LevelError).Writer())
 	stdlog.SetFlags(stdlog.Flags() &^ (stdlog.Ldate | stdlog.Ltime))
 
 	handler, cleanup, err := actions.App(logger, conf)
 	if err != nil {
-		logger.WithError(err).Fatal("Could not create App")
+		logger.Fatalf("Could not create App: %v", err)
 	}
 	defer cleanup()
 
@@ -70,8 +65,8 @@ func main() {
 			// pprof to be exposed on a different port than the application for security matters,
 			// not to expose profiling data and avoid DoS attacks (profiling slows down the service)
 			// https://www.farsightsecurity.com/txt-record/2016/10/28/cmikk-go-remote-profiling/
-			logger.WithField("port", conf.PprofPort).Infof("starting pprof")
-			logger.Fatal(http.ListenAndServe(conf.PprofPort, nil)) //nolint:gosec // This should not be exposed to the world.
+			logger.WithFields(map[string]any{"port": conf.PprofPort}).Infof("starting pprof")
+			logger.Fatalf("pprof server failed: %v", http.ListenAndServe(conf.PprofPort, nil)) //nolint:gosec // This should not be exposed to the world.
 		}()
 	}
 
@@ -79,27 +74,29 @@ func main() {
 	var ln net.Listener
 
 	if conf.UnixSocket != "" {
-		logger := logger.WithField("unixSocket", conf.UnixSocket)
-		logger.Info("Starting application")
+		socketLogger := logger.WithFields(map[string]any{"unixSocket": conf.UnixSocket})
+		socketLogger.Infof("Starting application")
 
 		//nolint:noctx
 		ln, err = net.Listen("unix", conf.UnixSocket)
 		if err != nil {
-			logger.WithError(err).Fatal("Could not listen on Unix domain socket")
+			socketLogger.Errorf("Could not listen on Unix domain socket: %v", err)
+			os.Exit(1)
 		}
 	} else {
-		logger := logger.WithField("tcpPort", conf.Port)
-		logger.Info("Starting application")
+		portLogger := logger.WithFields(map[string]any{"tcpPort": conf.Port})
+		portLogger.Infof("Starting application")
 
 		//nolint:noctx
 		ln, err = net.Listen("tcp", conf.Port)
 		if err != nil {
-			logger.WithError(err).Fatal("Could not listen on TCP port")
+			portLogger.Errorf("Could not listen on TCP port: %v", err)
+			os.Exit(1)
 		}
 	}
 
 	signalCtx, signalStop := signal.NotifyContext(context.Background(), shutdown.GetSignals()...)
-	reaper := shutdown.ChildProcReaper(signalCtx, logger.Logger)
+	reaper := shutdown.ChildProcReaper(signalCtx, logger)
 
 	go func() {
 		defer signalStop()
@@ -110,7 +107,7 @@ func main() {
 		}
 
 		if !errors.Is(err, http.ErrServerClosed) {
-			logger.WithError(err).Fatal("Could not start server")
+			logger.Fatalf("Could not start server: %v", err)
 		}
 	}()
 
@@ -122,7 +119,7 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(conf.ShutdownTimeout))
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
-		logger.WithError(err).Fatal("Could not shut down server")
+		logger.Fatalf("Could not shut down server: %v", err)
 	}
 	<-reaper.Done()
 }

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/minio/minio-go/v6 v6.0.57
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/redis/go-redis/v9 v9.18.0
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/afero v1.15.0
 	github.com/stretchr/testify v1.11.1
 	github.com/technosophos/moniker v0.0.0-20210218184952-3ea787d3943b
@@ -146,6 +145,7 @@ require (
 	github.com/prometheus/prometheus v0.311.2 // indirect
 	github.com/prometheus/statsd_exporter v0.29.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect

--- a/internal/shutdown/signals.go
+++ b/internal/shutdown/signals.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/sirupsen/logrus"
+	"github.com/gomods/athens/pkg/log"
 )
 
 // GetSignals returns the appropriate signals to catch for a clean shutdown, dependent on the OS.
@@ -25,7 +25,7 @@ func GetSignals() []os.Signal {
 //
 // This only applies to Unix platforms, and returns an already canceled context
 // on Windows.
-func ChildProcReaper(ctx context.Context, logger logrus.FieldLogger) context.Context {
+func ChildProcReaper(ctx context.Context, logger log.Entry) context.Context {
 	sigChld := make(chan os.Signal, 1)
 	signal.Notify(sigChld, syscall.SIGCHLD)
 	done, cancel := context.WithCancel(context.WithoutCancel(ctx))
@@ -44,7 +44,7 @@ func ChildProcReaper(ctx context.Context, logger logrus.FieldLogger) context.Con
 	return done
 }
 
-func reap(logger logrus.FieldLogger) {
+func reap(logger log.Entry) {
 	for {
 		var wstatus syscall.WaitStatus
 		pid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)

--- a/internal/shutdown/signals_notunix.go
+++ b/internal/shutdown/signals_notunix.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/gomods/athens/pkg/log"
 )
 
 // GetSignals returns the appropriate signals to catch for a clean shutdown, dependent on the OS.
@@ -20,7 +20,7 @@ func GetSignals() []os.Signal {
 //
 // This only applies to Unix platforms, and returns an already canceled context
 // on Windows.
-func ChildProcReaper(ctx context.Context, logger logrus.FieldLogger) context.Context {
+func ChildProcReaper(ctx context.Context, logger log.Entry) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	return ctx

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -3,12 +3,17 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"math"
 	"net/http"
 	"runtime"
 	"slices"
-
-	"github.com/sirupsen/logrus"
 )
+
+// severityUnset is a sentinel meaning "no severity was set on this error".
+// We need an explicit value because slog's zero level is LevelInfo (a real
+// level), unlike logrus whose zero level was an unused one.
+const severityUnset = slog.Level(math.MinInt32)
 
 // Kind enums.
 const (
@@ -38,7 +43,7 @@ type Error struct {
 	Module   M
 	Version  V
 	Err      error
-	Severity logrus.Level
+	Severity slog.Level
 }
 
 // Error returns the underlying error's
@@ -90,10 +95,10 @@ type V string
 // Operation always comes first, module path and version
 // come second, they are optional. Args must have at least
 // an error or a string to describe what exactly went wrong.
-// You can optionally pass a Logrus severity to indicate
+// You can optionally pass a slog severity to indicate
 // the log level of an error based on the context it was constructed in.
 func E(op Op, args ...any) error {
-	e := Error{Op: op}
+	e := Error{Op: op, Severity: severityUnset}
 	if len(args) == 0 {
 		msg := "errors.E called with 0 args"
 		_, file, line, ok := runtime.Caller(1)
@@ -112,7 +117,7 @@ func E(op Op, args ...any) error {
 			e.Module = a
 		case V:
 			e.Version = a
-		case logrus.Level:
+		case slog.Level:
 			e.Severity = a
 		case int:
 			e.Kind = a
@@ -127,17 +132,15 @@ func E(op Op, args ...any) error {
 // Severity returns the log level of an error
 // if none exists, then the level is Error because
 // it is an unexpected.
-func Severity(err error) logrus.Level {
+func Severity(err error) slog.Level {
 	var e Error
 	if !errors.As(err, &e) {
-		return logrus.ErrorLevel
+		return slog.LevelError
 	}
 
-	// if there's no severity (0 is Panic level in logrus
-	// which we should not use since cloud providers only have
-	// debug, info, warn, and error) then look for the
-	// child's severity.
-	if e.Severity < logrus.ErrorLevel {
+	// If no severity was set on this error, look for the
+	// child's severity. We only ever use debug/info/warn/error.
+	if e.Severity == severityUnset {
 		return Severity(e.Err)
 	}
 
@@ -147,11 +150,11 @@ func Severity(err error) logrus.Level {
 // Expect is a helper that returns an Info level
 // if the error has the expected kind, otherwise
 // it returns an Error level.
-func Expect(err error, kinds ...int) logrus.Level {
+func Expect(err error, kinds ...int) slog.Level {
 	if slices.Contains(kinds, Kind(err)) {
-		return logrus.InfoLevel
+		return slog.LevelInfo
 	}
-	return logrus.ErrorLevel
+	return slog.LevelError
 }
 
 // Kind recursively searches for the

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -2,10 +2,10 @@ package errors
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -35,16 +35,16 @@ func TestSeverity(t *testing.T) {
 	msg := "test error"
 
 	err := E(op, msg)
-	require.Equal(t, logrus.ErrorLevel, Severity(err))
+	require.Equal(t, slog.LevelError, Severity(err))
 
-	err = E(op, msg, logrus.WarnLevel)
-	require.Equal(t, logrus.WarnLevel, Severity(err))
+	err = E(op, msg, slog.LevelWarn)
+	require.Equal(t, slog.LevelWarn, Severity(err))
 
 	err = E(op, err)
-	require.Equal(t, logrus.WarnLevel, Severity(err))
+	require.Equal(t, slog.LevelWarn, Severity(err))
 
-	err = E(op, err, logrus.InfoLevel)
-	require.Equal(t, logrus.InfoLevel, Severity(err))
+	err = E(op, err, slog.LevelInfo)
+	require.Equal(t, slog.LevelInfo, Severity(err))
 }
 
 func TestKind(t *testing.T) {
@@ -85,14 +85,14 @@ func TestExpect(t *testing.T) {
 	err := E("TestExpect", "error message", KindBadRequest)
 
 	severity := Expect(err, KindBadRequest)
-	require.Equalf(t, severity, logrus.InfoLevel, "expected an info level log but got %v", severity)
+	require.Equalf(t, severity, slog.LevelInfo, "expected an info level log but got %v", severity)
 
 	severity = Expect(err, KindAlreadyExists)
-	require.Equalf(t, severity, logrus.ErrorLevel, "expected an error level but got %v", severity)
+	require.Equalf(t, severity, slog.LevelError, "expected an error level but got %v", severity)
 
 	severity = Expect(err, KindAlreadyExists, KindBadRequest)
-	require.Equalf(t, severity, logrus.InfoLevel, "expected an info level log but got %v", severity)
+	require.Equalf(t, severity, slog.LevelInfo, "expected an info level log but got %v", severity)
 
 	severity = Expect(err, KindAlreadyExists, KindNotImplemented)
-	require.Equalf(t, severity, logrus.ErrorLevel, "expected an error level but got %v", severity)
+	require.Equalf(t, severity, slog.LevelError, "expected an error level but got %v", severity)
 }

--- a/pkg/log/entry.go
+++ b/pkg/log/entry.go
@@ -1,12 +1,7 @@
 package log
 
-import (
-	"github.com/gomods/athens/pkg/errors"
-	"github.com/sirupsen/logrus"
-)
-
 // Entry is an abstraction to the
-// Logger and the logrus.Entry
+// Logger and the underlying slog logger
 // so that *Logger always creates
 // an Entry copy which ensures no
 // Fields are being overwritten.
@@ -23,44 +18,4 @@ type Entry interface {
 	// SystemErr is a method that disects the error
 	// and logs the appropriate level and fields for it.
 	SystemErr(err error)
-}
-
-type entry struct {
-	*logrus.Entry
-}
-
-func (e *entry) WithFields(fields map[string]any) Entry {
-	ent := e.Entry.WithFields(fields)
-	return &entry{ent}
-}
-
-func (e *entry) SystemErr(err error) {
-	var athensErr errors.Error
-	if !errors.AsErr(err, &athensErr) {
-		e.Error(err)
-		return
-	}
-
-	ent := e.WithFields(errFields(athensErr))
-	switch errors.Severity(err) {
-	case logrus.WarnLevel:
-		ent.Warnf("%v", err)
-	case logrus.InfoLevel:
-		ent.Infof("%v", err)
-	case logrus.DebugLevel:
-		ent.Debugf("%v", err)
-	default:
-		ent.Errorf("%v", err)
-	}
-}
-
-func errFields(err errors.Error) logrus.Fields {
-	f := logrus.Fields{}
-	f["operation"] = err.Op
-	f["kind"] = errors.KindText(err)
-	f["module"] = err.Module
-	f["version"] = err.Version
-	f["ops"] = errors.Ops(err)
-
-	return f
 }

--- a/pkg/log/entry_slog.go
+++ b/pkg/log/entry_slog.go
@@ -1,0 +1,70 @@
+package log
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/gomods/athens/pkg/errors"
+)
+
+// entry implements Entry on top of a *slog.Logger. The printf-style methods
+// preserve the original logrus-based API so importers of pkg/log do not change.
+type entry struct {
+	sl *slog.Logger
+}
+
+func (e *entry) Debugf(format string, args ...any) { e.sl.Debug(fmt.Sprintf(format, args...)) }
+func (e *entry) Infof(format string, args ...any)  { e.sl.Info(fmt.Sprintf(format, args...)) }
+func (e *entry) Warnf(format string, args ...any)  { e.sl.Warn(fmt.Sprintf(format, args...)) }
+func (e *entry) Errorf(format string, args ...any) { e.sl.Error(fmt.Sprintf(format, args...)) }
+
+func (e *entry) WithFields(fields map[string]any) Entry {
+	return &entry{sl: e.sl.With(attrsFromFields(fields)...)}
+}
+
+func (e *entry) SystemErr(err error) {
+	var athensErr errors.Error
+	if !errors.AsErr(err, &athensErr) {
+		e.Errorf("%v", err)
+		return
+	}
+
+	ent := e.WithFields(errFields(athensErr))
+	switch errors.Severity(err) {
+	case slog.LevelWarn:
+		ent.Warnf("%v", err)
+	case slog.LevelInfo:
+		ent.Infof("%v", err)
+	case slog.LevelDebug:
+		ent.Debugf("%v", err)
+	default:
+		ent.Errorf("%v", err)
+	}
+}
+
+func errFields(err errors.Error) map[string]any {
+	return map[string]any{
+		"operation": err.Op,
+		"kind":      errors.KindText(err),
+		"module":    err.Module,
+		"version":   err.Version,
+		"ops":       errors.Ops(err),
+	}
+}
+
+// attrsFromFields converts a field map into a key-sorted slice of slog attrs so
+// that log output is deterministic (logrus previously sorted keys for us).
+func attrsFromFields(fields map[string]any) []any {
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	attrs := make([]any, 0, len(keys))
+	for _, k := range keys {
+		attrs = append(attrs, slog.Any(k, fields[k]))
+	}
+	return attrs
+}

--- a/pkg/log/format.go
+++ b/pkg/log/format.go
@@ -2,72 +2,156 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/sirupsen/logrus"
 )
 
-func getGCPFormatter() logrus.Formatter {
-	return &logrus.JSONFormatter{
-		FieldMap: logrus.FieldMap{
-			logrus.FieldKeyLevel: "severity",
-			logrus.FieldKeyMsg:   "message",
-			logrus.FieldKeyTime:  "timestamp",
-		},
+// newHandler builds the slog.Handler for the given cloud provider and format.
+// GCP gets a JSON handler whose keys/severity are remapped so Cloud Logging
+// respects them; everything else uses the configured format.
+func newHandler(w io.Writer, cloudProvider, format string, level slog.Level) slog.Handler {
+	switch cloudProvider {
+	case "GCP":
+		return slog.NewJSONHandler(w, &slog.HandlerOptions{
+			Level:       level,
+			ReplaceAttr: gcpReplaceAttr,
+		})
+	default:
+		return parseFormat(w, format, level)
 	}
 }
 
-func getDevFormatter() logrus.Formatter {
-	return devFormatter{}
+func parseFormat(w io.Writer, format string, level slog.Level) slog.Handler {
+	if format == "json" {
+		return slog.NewJSONHandler(w, &slog.HandlerOptions{
+			Level:       level,
+			ReplaceAttr: jsonReplaceAttr,
+		})
+	}
+	return newDevHandler(w, level)
 }
 
-type devFormatter struct{}
+// gcpReplaceAttr renames slog's built-in keys to the ones Cloud Logging expects
+// (timestamp/severity/message) and maps the level to a GCP LogSeverity string.
+func gcpReplaceAttr(_ []string, a slog.Attr) slog.Attr {
+	switch a.Key {
+	case slog.TimeKey:
+		return slog.String("timestamp", a.Value.Time().Format(time.RFC3339))
+	case slog.LevelKey:
+		return slog.String("severity", gcpSeverity(a.Value.Any().(slog.Level)))
+	case slog.MessageKey:
+		a.Key = "message"
+		return a
+	}
+	return a
+}
+
+// jsonReplaceAttr keeps slog's native keys but normalizes the timestamp to
+// RFC3339 to match what operators previously parsed.
+func jsonReplaceAttr(_ []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey {
+		return slog.String(slog.TimeKey, a.Value.Time().Format(time.RFC3339))
+	}
+	return a
+}
+
+// GCP Cloud Logging severity strings. These must match the LogSeverity enum
+// exactly or Cloud Logging silently falls back to DEFAULT severity, breaking
+// severity-based routing and alerting.
+// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+const (
+	gcpSeverityDebug   = "DEBUG"
+	gcpSeverityInfo    = "INFO"
+	gcpSeverityWarning = "WARNING"
+	gcpSeverityError   = "ERROR"
+)
+
+// gcpSeverity maps an slog.Level onto a canonical GCP LogSeverity string.
+func gcpSeverity(l slog.Level) string {
+	switch {
+	case l <= slog.LevelDebug:
+		return gcpSeverityDebug
+	case l < slog.LevelWarn:
+		return gcpSeverityInfo
+	case l < slog.LevelError:
+		return gcpSeverityWarning
+	default:
+		return gcpSeverityError
+	}
+}
 
 const lightGrey = 0xffccc
 
-func (devFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	var buf bytes.Buffer
+// devHandler is a human-friendly, colored slog.Handler used for local
+// development. It renders "LEVEL[3:04PM]: message\tkey=value " lines with
+// fields sorted for deterministic output.
+type devHandler struct {
+	mu    *sync.Mutex
+	w     io.Writer
+	level slog.Level
+	attrs []slog.Attr
+}
+
+func newDevHandler(w io.Writer, level slog.Level) *devHandler {
+	return &devHandler{mu: &sync.Mutex{}, w: w, level: level}
+}
+
+func (h *devHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level
+}
+
+func (h *devHandler) Handle(_ context.Context, r slog.Record) error {
 	var sprintf func(format string, a ...any) string
-	switch e.Level {
-	case logrus.DebugLevel:
+	switch {
+	case r.Level <= slog.LevelDebug:
 		sprintf = color.New(lightGrey).Sprintf
-	case logrus.WarnLevel:
+	case r.Level == slog.LevelWarn:
 		sprintf = color.YellowString
-	case logrus.ErrorLevel:
+	case r.Level >= slog.LevelError:
 		sprintf = color.RedString
 	default:
 		sprintf = color.CyanString
 	}
-	lvl := strings.ToUpper(e.Level.String())
-	buf.WriteString(sprintf(lvl))
-	buf.WriteString("[" + e.Time.Format(time.Kitchen) + "]")
+
+	var buf bytes.Buffer
+	buf.WriteString(sprintf(strings.ToUpper(r.Level.String())))
+	buf.WriteString("[" + r.Time.Format(time.Kitchen) + "]")
 	buf.WriteString(": ")
-	buf.WriteString(e.Message)
+	buf.WriteString(r.Message)
 	buf.WriteByte('\t')
-	for _, k := range sortFields(e.Data) {
-		fmt.Fprintf(&buf, "%s=%s ", color.MagentaString(k), e.Data[k])
+
+	attrs := make([]slog.Attr, 0, len(h.attrs)+r.NumAttrs())
+	attrs = append(attrs, h.attrs...)
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a)
+		return true
+	})
+	sort.Slice(attrs, func(i, j int) bool { return attrs[i].Key < attrs[j].Key })
+	for _, a := range attrs {
+		fmt.Fprintf(&buf, "%s=%s ", color.MagentaString(a.Key), a.Value)
 	}
 	buf.WriteByte('\n')
-	return buf.Bytes(), nil
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := h.w.Write(buf.Bytes())
+	return err
 }
 
-func sortFields(data logrus.Fields) []string {
-	keys := make([]string, 0, len(data))
-	for k := range data {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+func (h *devHandler) WithAttrs(as []slog.Attr) slog.Handler {
+	nh := *h
+	nh.attrs = make([]slog.Attr, 0, len(h.attrs)+len(as))
+	nh.attrs = append(nh.attrs, h.attrs...)
+	nh.attrs = append(nh.attrs, as...)
+	return &nh
 }
 
-func parseFormat(format string) logrus.Formatter {
-	if format == "json" {
-		return &logrus.JSONFormatter{}
-	}
-
-	return getDevFormatter()
-}
+func (h *devHandler) WithGroup(string) slog.Handler { return h }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -13,6 +13,7 @@ import (
 // internal service should use to communicate things.
 type Logger struct {
 	*entry
+
 	handler slog.Handler
 	level   slog.Level
 }
@@ -50,10 +51,9 @@ func (l *Logger) StdLogger(level slog.Level) *stdlog.Logger {
 
 // NoOpLogger provides a Logger that does nothing.
 func NoOpLogger() *Logger {
-	h := slog.NewTextHandler(io.Discard, nil)
 	return &Logger{
-		entry:   &entry{sl: slog.New(h)},
-		handler: h,
+		entry:   &entry{sl: slog.New(slog.DiscardHandler)},
+		handler: slog.DiscardHandler,
 	}
 }
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,47 +1,76 @@
 package log
 
 import (
-	"github.com/sirupsen/logrus"
+	"fmt"
+	"io"
+	stdlog "log"
+	"log/slog"
+	"os"
+	"strings"
 )
 
 // Logger is the main struct that any athens
 // internal service should use to communicate things.
 type Logger struct {
-	*logrus.Logger
+	*entry
+	handler slog.Handler
+	level   slog.Level
 }
 
 // New constructs a new logger based on the
 // environment and the cloud platform it is
-// running on. TODO: take cloud arg and env
-// to construct the correct JSON formatter.
-func New(cloudProvider string, level logrus.Level, format string) *Logger {
-	l := logrus.New()
-	switch cloudProvider {
-	case "GCP":
-		l.Formatter = getGCPFormatter()
-	default:
-		l.Formatter = parseFormat(format)
+// running on.
+func New(cloudProvider string, level slog.Level, format string) *Logger {
+	return NewWithOutput(os.Stdout, cloudProvider, level, format)
+}
+
+// NewWithOutput is New but writes to the given io.Writer instead of stdout.
+// It is primarily useful for tests that need to capture log output.
+func NewWithOutput(w io.Writer, cloudProvider string, level slog.Level, format string) *Logger {
+	h := newHandler(w, cloudProvider, format, level)
+	return &Logger{
+		entry:   &entry{sl: slog.New(h)},
+		handler: h,
+		level:   level,
 	}
-	l.Level = level
-	return &Logger{Logger: l}
 }
 
-// SystemErr Entry implementation.
-func (l *Logger) SystemErr(err error) {
-	e := &entry{Entry: logrus.NewEntry(l.Logger)}
-	e.SystemErr(err)
+// Fatalf logs at the error level and then exits the process. slog has no
+// fatal level, so this preserves logrus.Fatal's exit-after-logging behavior.
+func (l *Logger) Fatalf(format string, args ...any) {
+	l.Errorf(format, args...)
+	os.Exit(1)
 }
 
-// WithFields Entry implementation.
-func (l *Logger) WithFields(fields map[string]any) Entry {
-	e := l.Logger.WithFields(fields)
-
-	return &entry{e}
+// StdLogger returns a *log.Logger that routes through this logger's handler at
+// the given level. Used to redirect output from the standard library logger.
+func (l *Logger) StdLogger(level slog.Level) *stdlog.Logger {
+	return slog.NewLogLogger(l.handler, level)
 }
 
 // NoOpLogger provides a Logger that does nothing.
 func NoOpLogger() *Logger {
+	h := slog.NewTextHandler(io.Discard, nil)
 	return &Logger{
-		Logger: &logrus.Logger{},
+		entry:   &entry{sl: slog.New(h)},
+		handler: h,
+	}
+}
+
+// ParseLevel converts a configured log-level string into an slog.Level. It
+// accepts the legacy logrus level names so existing operator configuration
+// keeps working: trace maps to debug, warning to warn, and fatal/panic to error.
+func ParseLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "trace", "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error", "fatal", "panic":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("not a valid log level: %q", s)
 	}
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -3,11 +3,11 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,8 +15,8 @@ type input struct {
 	name          string
 	cloudProvider string
 	format        string
-	level         logrus.Level
-	fields        logrus.Fields
+	level         slog.Level
+	fields        map[string]any
 	logFunc       func(e Entry) time.Time
 	output        string
 }
@@ -25,32 +25,32 @@ var testCases = []input{
 	{
 		name:          "gcp_debug",
 		cloudProvider: "GCP",
-		level:         logrus.DebugLevel,
-		fields:        logrus.Fields{},
+		level:         slog.LevelDebug,
+		fields:        map[string]any{},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Infof("info message")
 			return t
 		},
-		output: `{"message":"info message","severity":"info","timestamp":"%v"}` + "\n",
+		output: `{"timestamp":"%v","severity":"INFO","message":"info message"}` + "\n",
 	},
 	{
 		name:          "gcp_error",
 		cloudProvider: "GCP",
-		level:         logrus.DebugLevel,
-		fields:        logrus.Fields{},
+		level:         slog.LevelDebug,
+		fields:        map[string]any{},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Errorf("err message")
 			return t
 		},
-		output: `{"message":"err message","severity":"error","timestamp":"%v"}` + "\n",
+		output: `{"timestamp":"%v","severity":"ERROR","message":"err message"}` + "\n",
 	},
 	{
 		name:          "gcp_empty",
 		cloudProvider: "GCP",
-		level:         logrus.ErrorLevel,
-		fields:        logrus.Fields{},
+		level:         slog.LevelError,
+		fields:        map[string]any{},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Infof("info message")
@@ -61,73 +61,72 @@ var testCases = []input{
 	{
 		name:          "gcp_fields",
 		cloudProvider: "GCP",
-		level:         logrus.DebugLevel,
-		fields:        logrus.Fields{"field1": "value1", "field2": 2},
+		level:         slog.LevelDebug,
+		fields:        map[string]any{"field1": "value1", "field2": 2},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Debugf("debug message")
 			return t
 		},
-		output: `{"field1":"value1","field2":2,"message":"debug message","severity":"debug","timestamp":"%v"}` + "\n",
+		output: `{"timestamp":"%v","severity":"DEBUG","message":"debug message","field1":"value1","field2":2}` + "\n",
 	},
 	{
 		name:          "gcp_logs",
 		cloudProvider: "GCP",
-		level:         logrus.DebugLevel,
-		fields:        logrus.Fields{},
+		level:         slog.LevelDebug,
+		fields:        map[string]any{},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Warnf("warn message")
 			return t
 		},
-		output: `{"message":"warn message","severity":"warning","timestamp":"%v"}` + "\n",
+		output: `{"timestamp":"%v","severity":"WARNING","message":"warn message"}` + "\n",
 	},
 	{
 		name:          "default plain",
 		format:        "plain",
 		cloudProvider: "none",
-		level:         logrus.DebugLevel,
-		fields:        logrus.Fields{"xyz": "abc", "abc": "xyz"},
+		level:         slog.LevelDebug,
+		fields:        map[string]any{"xyz": "abc", "abc": "xyz"},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Warnf("warn message")
 			return t
 		},
-		output: `WARNING[%v]: warn message` + "\t" + `abc=xyz xyz=abc` + " \n",
+		output: `WARN[%v]: warn message` + "\t" + `abc=xyz xyz=abc` + " \n",
 	},
 	{
 		name:          "default",
 		cloudProvider: "none",
-		level:         logrus.DebugLevel,
-		fields:        logrus.Fields{"xyz": "abc", "abc": "xyz"},
+		level:         slog.LevelDebug,
+		fields:        map[string]any{"xyz": "abc", "abc": "xyz"},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Warnf("warn message")
 			return t
 		},
-		output: `WARNING[%v]: warn message` + "\t" + `abc=xyz xyz=abc` + " \n",
+		output: `WARN[%v]: warn message` + "\t" + `abc=xyz xyz=abc` + " \n",
 	},
 	{
 		name:          "default json",
 		format:        "json",
 		cloudProvider: "none",
-		level:         logrus.DebugLevel,
-		fields:        logrus.Fields{"xyz": "abc", "abc": "xyz"},
+		level:         slog.LevelDebug,
+		fields:        map[string]any{"xyz": "abc", "abc": "xyz"},
 		logFunc: func(e Entry) time.Time {
 			t := time.Now()
 			e.Warnf("warn message")
 			return t
 		},
-		output: `{"abc":"xyz","level":"warning","msg":"warn message","time":"%v","xyz":"abc"}` + "\n",
+		output: `{"time":"%v","level":"WARN","msg":"warn message","abc":"xyz","xyz":"abc"}` + "\n",
 	},
 }
 
 func TestCloudLogger(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			lggr := New(tc.cloudProvider, tc.level, tc.format)
 			var buf bytes.Buffer
-			lggr.Out = &buf
+			lggr := NewWithOutput(&buf, tc.cloudProvider, tc.level, tc.format)
 			e := lggr.WithFields(tc.fields)
 			entryTime := tc.logFunc(e)
 			out := buf.String()

--- a/pkg/middleware/log_entry.go
+++ b/pkg/middleware/log_entry.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gomods/athens/pkg/requestid"
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 )
 
 // LogEntryMiddleware builds a log.Entry, setting the request fields
@@ -15,7 +14,7 @@ func LogEntryMiddleware(lggr *log.Logger) mux.MiddlewareFunc {
 	return func(h http.Handler) http.Handler {
 		f := func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			ent := lggr.WithFields(logrus.Fields{
+			ent := lggr.WithFields(map[string]any{
 				"http-method": r.Method,
 				"http-path":   r.URL.Path,
 				"request-id":  requestid.FromContext(ctx),

--- a/pkg/middleware/log_entry_test.go
+++ b/pkg/middleware/log_entry_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/gomods/athens/pkg/log"
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,9 +24,7 @@ func TestLogContext(t *testing.T) {
 	r.HandleFunc("/test", h)
 
 	var buf bytes.Buffer
-	lggr := log.New("", logrus.DebugLevel, "")
-	lggr.Formatter = &logrus.JSONFormatter{DisableTimestamp: true}
-	lggr.Out = &buf
+	lggr := log.NewWithOutput(&buf, "", slog.LevelDebug, "json")
 
 	r.Use(LogEntryMiddleware(lggr))
 
@@ -34,6 +32,6 @@ func TestLogContext(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/test", nil)
 	r.ServeHTTP(w, req)
 
-	expected := `{"http-method":"GET","http-path":"/test","level":"info","msg":"test","request-id":""}`
+	expected := `"http-method":"GET","http-path":"/test","request-id":""`
 	assert.True(t, strings.Contains(buf.String(), expected), fmt.Sprintf("%s should contain: %s", buf.String(), expected))
 }

--- a/pkg/middleware/request.go
+++ b/pkg/middleware/request.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/gomods/athens/pkg/log"
-	logrus "github.com/sirupsen/logrus"
 )
 
 type responseWriter struct {
@@ -26,7 +25,7 @@ func RequestLogger(h http.Handler) http.Handler {
 	f := func(w http.ResponseWriter, r *http.Request) {
 		rw := &responseWriter{w, 0}
 		h.ServeHTTP(rw, r)
-		log.EntryFromContext(r.Context()).WithFields(logrus.Fields{
+		log.EntryFromContext(r.Context()).WithFields(map[string]any{
 			"http-status": fmtResponseCode(rw.statusCode),
 		}).Infof("incoming request")
 	}


### PR DESCRIPTION
## What is the problem I am trying to address?

#1890: replace logrus with the standard library's `log/slog`.

This picks up where #2010 left off. That PR tried to convert the whole repo at once and stalled on the level/severity mapping. Rather than revive it, I went with @marwan-at-work's suggestion from that review: only change `pkg/log` and keep the `Entry` interface identical, so importers don't have to change.

## How is the fix applied?

- `Entry` is unchanged. The slog implementation lives in a new `entry_slog.go`, and the printf methods just wrap slog with `fmt.Sprintf`, so the existing call sites compile as-is.
- `pkg/errors` `Severity` moves from `logrus.Level` to `slog.Level`. slog's zero value is `Info` (a real level), so instead of relying on the zero value the way the logrus code did, there's an explicit "unset" sentinel. This is the bit that tripped up #2010.
- The colored dev output is kept as a custom slog handler. GCP still emits `severity`/`message`/`timestamp`, so Cloud Logging routing is unaffected.
- `ParseLevel` maps the legacy logrus level names (`trace`, `warning`, `fatal`, `panic`) onto slog levels so existing config keeps working.
- logrus drops from a direct dependency to indirect. It's still pulled in transitively by etcd's embedded server, so it can't leave `go.mod` entirely without dropping etcd support.

The config knobs (`ATHENS_LOG_LEVEL`, `ATHENS_LOG_FORMAT`, `ATHENS_CLOUD_RUNTIME`) behave the same and GCP routing is intact. The non-GCP JSON keys now follow slog's native shape rather than logrus's.

## What GitHub issue(s) does this PR fix or close?

Fixes #1890
