### PR TITLE
fix(config): default GoBinaryEnvVars to proxy.golang.org, not direct-only

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -43,7 +43,7 @@ GoEnv = "development"
 # ATHENS_GO_BINARY_ENV_VARS='GODEBUG=true'
 # Then the final value that the Go binary will receive is ["GODEBUG=true"] and NOT ["GOPROXY=direct", "GODEBUG=true"]
 # Therefore, whether you use the config file or the env var, make sure you have all the values you need there.
-GoBinaryEnvVars = ["GOPROXY=direct"]
+GoBinaryEnvVars = ["GOPROXY=https://proxy.golang.org,direct"]
 
 # GoGetWorkers specifies how many times you can concurrently
 # go mod download, this is so that low performance instances

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,7 +149,7 @@ func Load(configFile string) (*Config, error) {
 func defaultConfig() *Config {
 	return &Config{
 		GoBinary:              "go",
-		GoBinaryEnvVars:       EnvList{"GOPROXY=direct"},
+		GoBinaryEnvVars:       EnvList{"GOPROXY=https://proxy.golang.org,direct"},
 		GoEnv:                 "development",
 		GoGetWorkers:          10,
 		ProtocolWorkers:       30,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -303,7 +303,7 @@ func TestParseExampleConfig(t *testing.T) {
 		TraceSamplingFraction: 1.0,
 		StatsExporter:         "prometheus",
 		SingleFlightType:      "memory",
-		GoBinaryEnvVars:       []string{"GOPROXY=direct"},
+		GoBinaryEnvVars:       []string{"GOPROXY=https://proxy.golang.org,direct"},
 		SingleFlight:          expSingleFlight,
 		SumDBs:                []string{"https://sum.golang.org"},
 		NoSumPatterns:         []string{},

--- a/pkg/config/testdata/config.dev.toml
+++ b/pkg/config/testdata/config.dev.toml
@@ -43,7 +43,7 @@ GoEnv = "development"
 # ATHENS_GO_BINARY_ENV_VARS='GODEBUG=true'
 # Then the final value that the Go binary will receive is ["GODEBUG=true"] and NOT ["GOPROXY=direct", "GODEBUG=true"]
 # Therefore, whether you use the config file or the env var, make sure you have all the values you need there.
-GoBinaryEnvVars = ["GOPROXY=direct"]
+GoBinaryEnvVars = ["GOPROXY=https://proxy.golang.org,direct"]
 
 # GoGetWorkers specifies how many times you can concurrently
 # go mod download, this is so that low performance instances


### PR DESCRIPTION
## What

Change the default `GoBinaryEnvVars` from `["GOPROXY=direct"]` to `["GOPROXY=https://proxy.golang.org,direct"]`.

## Why

With the current default, Athens' internal `go` subprocess fetches each module from its origin VCS and **rebuilds the module zip locally**. When the Go toolchain bundled in the Athens image differs from the one that produced a module's notarized zip, the rebuilt zip hashes differently, and Athens rejects the **valid** module:

```
github.com/onsi/ginkgo/v2@v2.32.0: verifying module: checksum mismatch
	downloaded: h1:OPshXBha3Pavij2LzHWXX30meRBGIucLwh97bHLjLpk=
	sum.golang.org: h1:Hw7s2pVrQo/8Yz5N77qdnpHaoc+c6cC9WIV1Jce+J6E=
SECURITY ERROR
This download does NOT match the one reported by the checksum server.
```

The client just sees a `404`. This is a recurring, hard-to-diagnose failure for ordinary public modules — e.g. a module declaring a `go` directive newer than the image's bundled Go. Prior reports: #1881, #1080, #1470.

Concretely reproduced on `gomods/athens:v0.15.1` (bundles Go 1.20.14) fetching `github.com/onsi/ginkgo/v2@v2.32.0` (declares `go 1.25`). Cross-checked that `proxy.golang.org`, `sum.golang.org`, a clean direct-VCS fetch with a current Go, and the module's `go.sum` **all agree** on `h1:Hw7s2pVrQo...` — only Athens' local rebuild diverged. The module is not tampered; the rebuild is.

## The change

Defaulting to `GOPROXY=https://proxy.golang.org,direct` makes Athens fetch the **immutable, notarized** zip from the public proxy, whose hash matches `sum.golang.org`, so the checksum check passes. The `,direct` fallback still resolves modules the proxy doesn't mirror. This matches Go's own default `GOPROXY` and eliminates the whole class of toolchain-skew checksum failures.

Operators who specifically need origin-only fetches (air-gapped / compliance) can still opt back in explicitly:

```toml
GoBinaryEnvVars = ["GOPROXY=direct"]
```

## Testing

- Updated `config.dev.toml`, the `pkg/config/testdata/config.dev.toml` fixture, and the `TestParseExampleConfig` assertion in lockstep so the `defaultConfig()` ⇄ example-config consistency test still holds.
- `go test ./pkg/config/... ./pkg/middleware/... ./pkg/module/... ./pkg/download/...` all pass.