### PR TITLE
docs: updating config.dev.toml to state NetworkMode env override

### DIFF
--- a/config.dev.toml
+++ b/config.dev.toml
@@ -294,6 +294,7 @@ DownloadMode = "sync"
 # 3. fallback: only return storage versions, if VCS fails. Note this means that you may
 # see inconsistent results since fallback mode does a best effort of giving you what's
 # available at the time of requesting versions.
+# Env override: ATHENS_NETWORK_MODE
 NetworkMode = "strict"
 
 # DownloadURL is the URL that will be used if


### PR DESCRIPTION
## What is the problem I am trying to address?

Add the env override variable name to the documentation.

## How is the fix applied?

The variable stated following the same conventions as the other env override comments.

## What GitHub issue(s) does this PR fix or close?

Fixes #2149

