### PR TITLE
Add a Cache-Control config option for module file endpoints

### DIFF
--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -122,7 +122,7 @@ func addProxyRoutes(
 
 	dp := download.New(dpOpts, addons.WithPool(c.ProtocolWorkers))
 
-	handlerOpts := &download.HandlerOpts{Protocol: dp, Logger: l, DownloadFile: df}
+	handlerOpts := &download.HandlerOpts{Protocol: dp, Logger: l, DownloadFile: df, CacheControl: c.CacheControl}
 	download.RegisterHandlers(r, handlerOpts)
 
 	return nil

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -302,6 +302,15 @@ NetworkMode = "strict"
 # Env override: ATHENS_DOWNLOAD_URL
 DownloadURL = ""
 
+# CacheControl sets the Cache-Control header that Athens returns on the
+# immutable module file endpoints (.info, .mod and .zip). Those responses
+# never change for a given module@version, so a value such as
+# "public, max-age=31536000, immutable" lets a caching proxy in front of
+# Athens serve them without hitting Athens again. When empty, no Cache-Control
+# header is set on these endpoints, which is the default behavior.
+# Env override: ATHENS_CACHE_CONTROL
+CacheControl = ""
+
 # SingleFlightType determines what mechanism Athens uses
 # to manage concurrency flowing into the Athens Backend.
 # This is important for the following scenario: if two concurrent requests

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	NoSumPatterns         []string  `envconfig:"ATHENS_GONOSUM_PATTERNS"`
 	DownloadMode          mode.Mode `envconfig:"ATHENS_DOWNLOAD_MODE"`
 	DownloadURL           string    `envconfig:"ATHENS_DOWNLOAD_URL"`
+	CacheControl          string    `envconfig:"ATHENS_CACHE_CONTROL"`
 	NetworkMode           string    `envconfig:"ATHENS_NETWORK_MODE"            validate:"oneof=strict offline fallback"`
 	SingleFlightType      string    `envconfig:"ATHENS_SINGLE_FLIGHT_TYPE"`
 	RobotsFile            string    `envconfig:"ATHENS_ROBOTS_FILE"`

--- a/pkg/config/testdata/config.dev.toml
+++ b/pkg/config/testdata/config.dev.toml
@@ -301,6 +301,15 @@ NetworkMode = "strict"
 # Env override: ATHENS_DOWNLOAD_URL
 DownloadURL = ""
 
+# CacheControl sets the Cache-Control header that Athens returns on the
+# immutable module file endpoints (.info, .mod and .zip). Those responses
+# never change for a given module@version, so a value such as
+# "public, max-age=31536000, immutable" lets a caching proxy in front of
+# Athens serve them without hitting Athens again. When empty, no Cache-Control
+# header is set on these endpoints, which is the default behavior.
+# Env override: ATHENS_CACHE_CONTROL
+CacheControl = ""
+
 # SingleFlightType determines what mechanism Athens uses
 # to manage concurrency flowing into the Athens Backend.
 # This is important for the following scenario: if two concurrent requests

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -20,6 +20,11 @@ type HandlerOpts struct {
 	Protocol     Protocol
 	Logger       *log.Logger
 	DownloadFile *mode.DownloadFile
+	// CacheControl, when non-empty, is sent as the Cache-Control header on the
+	// module file endpoints (.info, .mod and .zip). Those responses are immutable
+	// for a given module@version, so a value like "public, max-age=..." lets a
+	// caching proxy in front of Athens serve them without hitting Athens again.
+	CacheControl string
 }
 
 // LogEntryHandler pulls a log entry from the request context. Thanks to the
@@ -50,9 +55,16 @@ func RegisterHandlers(r *mux.Router, opts *HandlerOpts) {
 	latestHandler := LogEntryHandler(LatestHandler, opts)
 	r.Handle(PathLatest, noCacheMw(latestHandler)).Methods(http.MethodGet)
 
-	r.Handle(PathVersionInfo, LogEntryHandler(InfoHandler, opts)).Methods(http.MethodGet)
-	r.Handle(PathVersionModule, LogEntryHandler(ModuleHandler, opts)).Methods(http.MethodGet)
-	r.Handle(PathVersionZip, LogEntryHandler(ZipHandler, opts)).Methods(http.MethodGet, http.MethodHead)
+	// The .info, .mod and .zip files are immutable for a given module@version,
+	// so honor an operator supplied Cache-Control header on them if one is set.
+	fileMw := func(h http.Handler) http.Handler { return h }
+	if opts.CacheControl != "" {
+		fileMw = middleware.CacheControl(opts.CacheControl)
+	}
+
+	r.Handle(PathVersionInfo, fileMw(LogEntryHandler(InfoHandler, opts))).Methods(http.MethodGet)
+	r.Handle(PathVersionModule, fileMw(LogEntryHandler(ModuleHandler, opts))).Methods(http.MethodGet)
+	r.Handle(PathVersionZip, fileMw(LogEntryHandler(ZipHandler, opts))).Methods(http.MethodGet, http.MethodHead)
 }
 
 func getRedirectURL(base, downloadPath string) (string, error) {

--- a/pkg/download/handler_test.go
+++ b/pkg/download/handler_test.go
@@ -62,3 +62,47 @@ func (mp *mockProtocol) Zip(ctx context.Context, mod, ver string) (storage.SizeR
 	const op errors.Op = "mockProtocol.Zip"
 	return nil, errors.E(op, "not found", errors.KindRedirect)
 }
+
+func TestCacheControl(t *testing.T) {
+	filePaths := [...]string{
+		"/github.com/gomods/athens/@v/v0.4.0.info",
+		"/github.com/gomods/athens/@v/v0.4.0.mod",
+		"/github.com/gomods/athens/@v/v0.4.0.zip",
+	}
+
+	t.Run("sets the header on module files when configured", func(t *testing.T) {
+		const cacheControl = "public, max-age=31536000, immutable"
+		r := mux.NewRouter()
+		RegisterHandlers(r, &HandlerOpts{
+			Protocol:     &mockProtocol{},
+			Logger:       log.NoOpLogger(),
+			DownloadFile: &mode.DownloadFile{Mode: mode.Redirect, DownloadURL: "https://gomods.io"},
+			CacheControl: cacheControl,
+		})
+		for _, path := range filePaths {
+			req := httptest.NewRequest("GET", path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if got := w.Header().Get("Cache-Control"); got != cacheControl {
+				t.Fatalf("expected Cache-Control %q for %s but got %q", cacheControl, path, got)
+			}
+		}
+	})
+
+	t.Run("leaves the header unset by default", func(t *testing.T) {
+		r := mux.NewRouter()
+		RegisterHandlers(r, &HandlerOpts{
+			Protocol:     &mockProtocol{},
+			Logger:       log.NoOpLogger(),
+			DownloadFile: &mode.DownloadFile{Mode: mode.Redirect, DownloadURL: "https://gomods.io"},
+		})
+		for _, path := range filePaths {
+			req := httptest.NewRequest("GET", path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if got := w.Header().Get("Cache-Control"); got != "" {
+				t.Fatalf("expected no Cache-Control header for %s but got %q", path, got)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What is the problem I am trying to address?

The `.info`, `.mod` and `.zip` endpoints serve content that is immutable for a given module@version, so they are safe to cache more or less forever. Right now Athens does not send a Cache-Control header on them, which means a caching proxy in front of Athens cannot know that, and operators cannot tune it.

## How is the fix applied?

Added an optional `CacheControl` setting (`ATHENS_CACHE_CONTROL`). When it is set, its value is sent as the Cache-Control header on the `.info`, `.mod` and `.zip` handlers. It defaults to empty, which keeps the current behavior of not setting the header, so nothing changes unless you opt in. The `@v/list` and `@latest` endpoints keep their existing no-cache behavior since those are not immutable.

Documented it in config.dev.toml and added a handler test that covers both the configured and default cases.

## What GitHub issue(s) does this PR fix or close?

Fixes #1183