### PR TITLE
Make Cache-Control on the info, mod and zip endpoints configurable

### DIFF
--- a/cmd/proxy/actions/app_proxy.go
+++ b/cmd/proxy/actions/app_proxy.go
@@ -122,7 +122,7 @@ func addProxyRoutes(
 
 	dp := download.New(dpOpts, addons.WithPool(c.ProtocolWorkers))
 
-	handlerOpts := &download.HandlerOpts{Protocol: dp, Logger: l, DownloadFile: df}
+	handlerOpts := &download.HandlerOpts{Protocol: dp, Logger: l, DownloadFile: df, ContentCacheControl: c.ContentCacheControl}
 	download.RegisterHandlers(r, handlerOpts)
 
 	return nil

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -341,6 +341,14 @@ IndexType = "none"
 # Env override: ATHENS_SHUTDOWN_TIMEOUT
 ShutdownTimeout = 60
 
+# ContentCacheControl is the Cache-Control header sent on the info, mod and zip
+# endpoints. These serve immutable module content, so a caching proxy in front of
+# Athens can be told to cache and periodically refresh them by setting a value such
+# as "public, max-age=300". When empty (the default) no Cache-Control header is sent
+# on these endpoints, which keeps the previous behavior.
+# Env override: ATHENS_CONTENT_CACHE_CONTROL
+ContentCacheControl = ""
+
 [SingleFlight]
     [SingleFlight.Etcd]
         # Endpoints are comma separated URLs that determine all distributed etcd servers.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	IndexType             string    `envconfig:"ATHENS_INDEX_TYPE"`
 	ShutdownTimeout       int       `envconfig:"ATHENS_SHUTDOWN_TIMEOUT"        validate:"min=0"`
 	StashTimeout          int       `envconfig:"ATHENS_STASH_TIMEOUT"`
+	ContentCacheControl   string    `envconfig:"ATHENS_CONTENT_CACHE_CONTROL"`
 	SingleFlight          *SingleFlight
 	Storage               *Storage
 	Index                 *Index
@@ -176,6 +177,7 @@ func defaultConfig() *Config {
 		IndexType:             "none",
 		ShutdownTimeout:       60,
 		StashTimeout:          600,
+		ContentCacheControl:   "",
 		SingleFlight: &SingleFlight{
 			Etcd:  &Etcd{"localhost:2379,localhost:22379,localhost:32379"},
 			Redis: &Redis{Endpoint: "127.0.0.1:6379", LockConfig: DefaultRedisLockConfig()},

--- a/pkg/config/testdata/config.dev.toml
+++ b/pkg/config/testdata/config.dev.toml
@@ -340,6 +340,14 @@ IndexType = "none"
 # Env override: ATHENS_SHUTDOWN_TIMEOUT
 ShutdownTimeout = 60
 
+# ContentCacheControl is the Cache-Control header sent on the info, mod and zip
+# endpoints. These serve immutable module content, so a caching proxy in front of
+# Athens can be told to cache and periodically refresh them by setting a value such
+# as "public, max-age=300". When empty (the default) no Cache-Control header is sent
+# on these endpoints, which keeps the previous behavior.
+# Env override: ATHENS_CONTENT_CACHE_CONTROL
+ContentCacheControl = ""
+
 [SingleFlight]
     [SingleFlight.Etcd]
         # Endpoints are comma separated URLs that determine all distributed etcd servers.

--- a/pkg/download/handler.go
+++ b/pkg/download/handler.go
@@ -20,6 +20,11 @@ type HandlerOpts struct {
 	Protocol     Protocol
 	Logger       *log.Logger
 	DownloadFile *mode.DownloadFile
+	// ContentCacheControl is the Cache-Control header value sent on the info,
+	// mod and zip endpoints. Those endpoints serve immutable module content, so
+	// a caching proxy in front of Athens can safely cache them. When empty (the
+	// default) no Cache-Control header is set on them.
+	ContentCacheControl string
 }
 
 // LogEntryHandler pulls a log entry from the request context. Thanks to the
@@ -50,9 +55,19 @@ func RegisterHandlers(r *mux.Router, opts *HandlerOpts) {
 	latestHandler := LogEntryHandler(LatestHandler, opts)
 	r.Handle(PathLatest, noCacheMw(latestHandler)).Methods(http.MethodGet)
 
-	r.Handle(PathVersionInfo, LogEntryHandler(InfoHandler, opts)).Methods(http.MethodGet)
-	r.Handle(PathVersionModule, LogEntryHandler(ModuleHandler, opts)).Methods(http.MethodGet)
-	r.Handle(PathVersionZip, LogEntryHandler(ZipHandler, opts)).Methods(http.MethodGet, http.MethodHead)
+	infoHandler := LogEntryHandler(InfoHandler, opts)
+	moduleHandler := LogEntryHandler(ModuleHandler, opts)
+	zipHandler := LogEntryHandler(ZipHandler, opts)
+	if opts.ContentCacheControl != "" {
+		cacheMw := middleware.CacheControl(opts.ContentCacheControl)
+		infoHandler = cacheMw(infoHandler)
+		moduleHandler = cacheMw(moduleHandler)
+		zipHandler = cacheMw(zipHandler)
+	}
+
+	r.Handle(PathVersionInfo, infoHandler).Methods(http.MethodGet)
+	r.Handle(PathVersionModule, moduleHandler).Methods(http.MethodGet)
+	r.Handle(PathVersionZip, zipHandler).Methods(http.MethodGet, http.MethodHead)
 }
 
 func getRedirectURL(base, downloadPath string) (string, error) {

--- a/pkg/download/handler_test.go
+++ b/pkg/download/handler_test.go
@@ -44,6 +44,50 @@ func TestRedirect(t *testing.T) {
 	}
 }
 
+func TestContentCacheControl(t *testing.T) {
+	contentPaths := [...]string{
+		"/github.com/gomods/athens/@v/v0.4.0.info",
+		"/github.com/gomods/athens/@v/v0.4.0.mod",
+		"/github.com/gomods/athens/@v/v0.4.0.zip",
+	}
+
+	t.Run("sets the header when configured", func(t *testing.T) {
+		const cacheControl = "public, max-age=300"
+		r := mux.NewRouter()
+		RegisterHandlers(r, &HandlerOpts{
+			Protocol:            &mockProtocol{},
+			Logger:              log.NoOpLogger(),
+			DownloadFile:        &mode.DownloadFile{Mode: mode.Redirect, DownloadURL: "https://gomods.io"},
+			ContentCacheControl: cacheControl,
+		})
+		for _, path := range contentPaths {
+			req := httptest.NewRequest("GET", path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if got := w.Header().Get("Cache-Control"); got != cacheControl {
+				t.Fatalf("expected Cache-Control %q on %s but got %q", cacheControl, path, got)
+			}
+		}
+	})
+
+	t.Run("leaves the header off by default", func(t *testing.T) {
+		r := mux.NewRouter()
+		RegisterHandlers(r, &HandlerOpts{
+			Protocol:     &mockProtocol{},
+			Logger:       log.NoOpLogger(),
+			DownloadFile: &mode.DownloadFile{Mode: mode.Redirect, DownloadURL: "https://gomods.io"},
+		})
+		for _, path := range contentPaths {
+			req := httptest.NewRequest("GET", path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if got := w.Header().Get("Cache-Control"); got != "" {
+				t.Fatalf("expected no Cache-Control on %s but got %q", path, got)
+			}
+		}
+	})
+}
+
 type mockProtocol struct {
 	Protocol
 }


### PR DESCRIPTION
Fixes #1183.

The info, mod and zip endpoints serve immutable module content but Athens sends no Cache-Control header on them today, so a caching proxy out front either caches them forever or not at all. As #1183 describes, caching forever means a broken or stale zip can get pinned in the proxy until it's manually purged, and purging causes a load spike.

This adds a `ContentCacheControl` config option (env `ATHENS_CONTENT_CACHE_CONTROL`) that sets the Cache-Control header on those three endpoints. Setting something like `public, max-age=300` lets the proxy cache them and refresh periodically instead. It's off by default (empty value, no header) so existing setups don't change.

I reused the existing `middleware.CacheControl` that already powers the no-cache header on the list/latest endpoints, so it takes a raw header value. Added a test that checks the header shows up on info/mod/zip when configured and stays off when it isn't, plus the config wiring and docs in config.dev.toml.
